### PR TITLE
Remove analyzer PackageReferences from Directory.Build.props

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,42 +15,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- Roslynator - Code quality and refactoring -->
-    <PackageReference Include="Roslynator.Analyzers" Version="4.15.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-
-    <!-- AsyncFixer - Async/await best practices -->
-    <PackageReference Include="AsyncFixer" Version="2.1.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-
-    <!-- Microsoft Threading Analyzers - Thread safety -->
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-
-    <!-- Meziantou - Comprehensive code quality -->
-    <PackageReference Include="Meziantou.Analyzer" Version="3.0.25">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-
-    <!-- SonarAnalyzer - Industry-standard analysis -->
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.22.0.136894">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-
-    <!-- Banned API Analyzers - Enforce async-first practices via BannedSymbols.txt -->
-    <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.4">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)BannedSymbols.txt" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- Removes the 6 analyzer `PackageReference` entries (Roslynator.Analyzers, AsyncFixer, Microsoft.VisualStudio.Threading.Analyzers, Meziantou.Analyzer, SonarAnalyzer.CSharp, Microsoft.CodeAnalysis.BannedApiAnalyzers) from `Directory.Build.props`
- Retains PropertyGroup settings (EnableNETAnalyzers, AnalysisLevel, etc.) and the BannedSymbols.txt AdditionalFiles entry
- Prepares for a follow-up PR that adds these analyzers to individual csproj files instead

## Test plan
- [ ] Verify build succeeds (analyzers will be absent until follow-up PR is merged)
- [ ] Confirm BannedSymbols.txt is still referenced via AdditionalFiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)