### PR TITLE
Add .NET Core 3.1 to release workflow setup-dotnet

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,6 +27,7 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
+            3.1.x
             5.0.x
             6.0.x
             7.0.x
@@ -300,6 +301,7 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
+            3.1.x
             5.0.x
             6.0.x
             7.0.x
@@ -516,6 +518,7 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
+            3.1.x
             5.0.x
             6.0.x
             7.0.x


### PR DESCRIPTION
## Summary
Adds `3.1.x` to the `dotnet-version` list in `actions/setup-dotnet` at all 3 setup-dotnet locations in `release.yaml`.

Mirrors [ETL-Json#54](https://github.com/Chris-Wolfgang/ETL-Json/pull/54). The test projects in this repo target `netcoreapp3.1` and need the 3.1 SDK installed for restore/test to succeed in the release workflow.

## Test plan
- [ ] Next release run installs the .NET Core 3.1 SDK and tests pass on netcoreapp3.1