### PR TITLE
Add protected-files guard to detect-projects job

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -72,6 +72,114 @@ jobs:
           ref: refs/pull/${{ github.event.pull_request.number }}/head
           persist-credentials: false
       
+      - name: Fetch trusted configuration files from main branch
+        # Skip for Dependabot — its package-version bumps to protected files (e.g.
+        # Directory.Build.props) are legitimate and should not be overwritten by main's
+        # older versions. Dependabot's identity is GitHub-controlled and not spoofable.
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
+        run: |
+          echo "Fetching configuration files from main branch to prevent malicious overrides..."
+          
+          # Fetch the main branch
+          git fetch origin main:main-branch
+          
+          # List of configuration files that should come from trusted main branch
+          config_files=(
+            ".editorconfig"
+            "Directory.Build.props"
+            "Directory.Build.targets"
+            "BannedSymbols.txt"
+            "*.globalconfig"
+            "*.ruleset"
+            ".github/workflows/*.yml"
+            ".github/workflows/*.yaml"
+          )
+          
+          # Copy each configuration file from main branch if it exists
+          for config_file in "${config_files[@]}"; do
+            # Handle glob patterns
+            if [[ "$config_file" == *"*"* ]]; then
+              # Find files matching the pattern in main branch
+              git ls-tree -r --name-only main-branch | grep -E "${config_file//\*/.*}" | while read -r file; do
+                if [ -n "$file" ]; then
+                  echo "  ✓ Copying $file from main branch"
+                  mkdir -p "$(dirname "$file")"
+                  git show "main-branch:$file" > "$file" || echo "  ⚠️  Failed to copy $file"
+                fi
+              done
+            else
+              # Check if file exists in main branch
+              if git cat-file -e "main-branch:$config_file" 2>/dev/null; then
+                echo "  ✓ Copying $config_file from main branch"
+                git show "main-branch:$config_file" > "$config_file"
+              else
+                echo "  ℹ️  $config_file not found in main branch, skipping"
+              fi
+            fi
+          done
+          
+          echo ""
+          echo "✅ Configuration files secured - using versions from main branch"
+      
+      - name: Detect protected configuration file changes
+        # Skip for Dependabot — its bumps to protected files (e.g. Directory.Build.props)
+        # are legitimate. The guard's threat model is human PR authors disabling analyzers
+        # in their own PRs; it does not apply to a trusted GitHub-controlled bot whose
+        # only action is package-version updates.
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
+        run: |
+          echo "Checking for changes to protected configuration files in this PR..."
+          
+          # Verify main-branch ref is available (it was fetched in the previous step)
+          if ! git cat-file -e main-branch 2>/dev/null; then
+            echo "❌ main-branch ref not found - cannot detect configuration file changes"
+            exit 1
+          fi
+          
+          changed_files=()
+          
+          # Check exact file matches against main branch git objects
+          # 2>/dev/null suppresses output when a file doesn't exist in one ref (new/deleted file),
+          # which git diff handles correctly via its exit code
+          exact_files=(
+            ".editorconfig"
+            "Directory.Build.props"
+            "Directory.Build.targets"
+            "BannedSymbols.txt"
+          )
+          
+          for config_file in "${exact_files[@]}"; do
+            if ! git diff --quiet main-branch HEAD -- "$config_file" 2>/dev/null; then
+              changed_files+=("$config_file")
+            fi
+          done
+          
+          # Check .globalconfig, .ruleset, and workflow files using the same git diff approach
+          # --diff-filter=AMRC: Added, Modified, Renamed, Copied (excludes Deleted)
+          while IFS= read -r file; do
+            changed_files+=("$file")
+          done < <(git diff --name-only --diff-filter=AMRC main-branch HEAD 2>/dev/null | grep -E '(\.(globalconfig|ruleset)|^\.github/workflows/.*\.ya?ml)$' || true)
+          
+          if [ ${#changed_files[@]} -gt 0 ]; then
+            echo ""
+            echo "⚠️  PROTECTED CONFIGURATION FILES CHANGED IN THIS PR:"
+            for file in "${changed_files[@]}"; do
+              echo "  - $file"
+            done
+            echo ""
+            echo "❌ CI uses the main branch version of these files to prevent security bypasses."
+            echo "   The PR's changes to these files were NOT tested by CI."
+            echo "   A maintainer must manually review and verify these changes before merging."
+            echo ""
+            echo "To proceed, a maintainer should:"
+            echo "  1. Review the configuration changes in this PR carefully"
+            echo "  2. Test the changes locally to confirm they work correctly"
+            echo "  3. Merge with awareness that CI did not validate these configuration changes"
+            exit 1
+          else
+            echo "✅ No protected configuration files changed - CI fully validates this PR"
+          fi
+      
       - name: Check for .NET project files
         id: check-projects
         run: |


### PR DESCRIPTION
## Summary
Adds the protected-files guard to the `detect-projects` job in `pr.yaml`:

1. **`Fetch trusted configuration files from main branch`** — copies workflow / `Directory.Build.props` / `.editorconfig` / etc. from `main` so subsequent CI steps run against the trusted versions, not the PR's.
2. **`Detect protected configuration file changes`** — fails the job if the PR modified any of those protected files, prompting a maintainer review.

Mirrors the existing pattern in `repo-template/pr.yaml` and the other extension repos that already have the guard.

## Why this repo was missing it
The "Add .github/workflows/* to protected file detection" rollout that propagated this guard hadn't reached this repo yet. The recent action-upgrade PR merged here without tripping the guard precisely because the guard wasn't installed.

## Behavior
- PRs that don't touch `.github/workflows/*`, `Directory.Build.props`, etc. are unaffected.
- PRs that DO touch them will fail this job with a clear maintainer-review prompt — the same ergonomics every other repo on this template has.
- Dependabot is exempted (its protected-file bumps are legitimate and trustworthy).

## Test plan
- [ ] CI passes on this PR (this PR itself touches `pr.yaml`, so the guard self-trips on first install — CI will fail on `Detect .NET Projects`. Maintainer reviews the diff and merges.)