### PR TITLE
fix: restore <AssemblyVersion>1.0.0.0</AssemblyVersion> across all src csprojs (C4 post-mortem)

### DIFF
--- a/src/Wolfgang.Etl.TestKit.Xunit/Wolfgang.Etl.TestKit.Xunit.csproj
+++ b/src/Wolfgang.Etl.TestKit.Xunit/Wolfgang.Etl.TestKit.Xunit.csproj
@@ -6,7 +6,13 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <Version>0.8.0</Version>
-    <FileVersion>1.0.0</FileVersion>
+    <!-- Pin AssemblyVersion to a fixed binding-stability baseline so consumers
+         do not need to recompile / add binding redirects on every minor/patch
+         bump. Bump only on a deliberate breaking API change. FileVersion +
+         InformationalVersion (the latter auto-derived from <Version>) carry
+         the actual release version. -->
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <FileVersion>$([System.Text.RegularExpressions.Regex]::Replace("$(Version)", "[-+].*$", "")).0</FileVersion>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Title>Wolfgang.Etl.TestKit.Xunit</Title>
     <Authors>Chris Wolfgang</Authors>

--- a/src/Wolfgang.Etl.TestKit/Wolfgang.Etl.TestKit.csproj
+++ b/src/Wolfgang.Etl.TestKit/Wolfgang.Etl.TestKit.csproj
@@ -6,7 +6,13 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <Version>0.8.0</Version>
-    <FileVersion>1.0.0</FileVersion>
+    <!-- Pin AssemblyVersion to a fixed binding-stability baseline so consumers
+         do not need to recompile / add binding redirects on every minor/patch
+         bump. Bump only on a deliberate breaking API change. FileVersion +
+         InformationalVersion (the latter auto-derived from <Version>) carry
+         the actual release version. -->
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <FileVersion>$([System.Text.RegularExpressions.Regex]::Replace("$(Version)", "[-+].*$", "")).0</FileVersion>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Title>Wolfgang.Etl.TestKit</Title>
     <Authors>Chris Wolfgang</Authors>


### PR DESCRIPTION
Restores `<AssemblyVersion>1.0.0.0</AssemblyVersion>` + adds prerelease-safe `<FileVersion>` (via regex-strip property function) to **every src csproj** in this multi-project repo.

## Why

The original C4 fanout dropped `<AssemblyVersion>` on the rationale that the hardcoded `1.0.0` was "stale" relative to released package versions. But that staleness was the **correct** binding-stability behaviour for libraries that ship a `net462` TFM. With SDK-derived AssemblyVersion, every minor/patch release ships a different binding identity, breaking .NET Framework consumers without a binding redirect.

DateTime-Extensions v1.3.0 publicly shipped this regression. **This repo has not yet released the regression** (the C4 drop is on `canonical-unprotected` but hasn't reached `main`). Landing this fix neutralises the footgun across all src csprojs before any merge to main.

## Csproj changes (per src project)

```diff
  <Version>...</Version>
+ <!-- Pin AssemblyVersion to a fixed binding-stability baseline so consumers
+      do not need to recompile / add binding redirects on every minor/patch
+      bump. Bump only on a deliberate breaking API change. FileVersion +
+      InformationalVersion (the latter auto-derived from <Version>) carry
+      the actual release version. -->
+ <AssemblyVersion>1.0.0.0</AssemblyVersion>
+ <FileVersion>$([System.Text.RegularExpressions.Regex]::Replace("$(Version)", "[-+].*$", "")).0</FileVersion>
```

The regex-strip property function ensures prerelease `<Version>` values (e.g., `1.2.3-beta.1`) still produce a 4-part numeric `AssemblyFileVersion` (`1.2.3.0`) — verified locally on peer repos.

## Standard pattern (NodaTime / Newtonsoft / AutoMapper)

| Property | Bumps on | Example |
|---|---|---|
| `AssemblyVersion` | **breaking change only** | `1.0.0.0` |
| `AssemblyFileVersion` | every release | `<Version>.0` |
| `Version` (NuGet) | every release | `<Version>` |

Tracked in the per-repo-release-pilot skill as the corrected Phase 2 step 1.