### PR TITLE
docs(README): document Wolfgang.Etl.TestKit.Xunit add-on package (D2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,35 @@ An Extractor, Transformer and Loader designed to be used in testing libraries bu
 
 ## 📦 Installation
 
+This repo ships two NuGet packages.
+
+**Core** — test doubles for building ETL test fixtures:
+
 ```bash
 dotnet add package Wolfgang.Etl.TestKit
 ```
 
-**NuGet Package:** [Wolfgang.Etl.TestKit](https://www.nuget.org/packages/Wolfgang.Etl.TestKit)
+**xUnit add-on** — abstract xUnit contract-test base classes for verifying custom extractors, transformers, and loaders built on `Wolfgang.Etl.Abstractions`:
 
+```bash
+dotnet add package Wolfgang.Etl.TestKit.Xunit
+```
+
+**NuGet packages:**
+
+- [Wolfgang.Etl.TestKit](https://www.nuget.org/packages/Wolfgang.Etl.TestKit) — test doubles
+- [Wolfgang.Etl.TestKit.Xunit](https://www.nuget.org/packages/Wolfgang.Etl.TestKit.Xunit) — xUnit contract tests
+
+Install `Wolfgang.Etl.TestKit.Xunit` whenever you author a custom `ExtractorBase` / `LoaderBase` / `TransformerBase` and want your test project to inherit the canonical xUnit contract coverage with zero boilerplate:
+
+```csharp
+public sealed class MyExtractorTests : ExtractorBaseContractTests<MyExtractor, MyItem, MyProgress>
+{
+    protected override MyExtractor CreateSut(int itemCount) => new MyExtractor(itemCount);
+    protected override IReadOnlyList<MyItem> CreateExpectedItems() => ...;
+    protected override MyExtractor CreateSutWithTimer(IProgressTimer timer) => ...;
+}
+```
 ---
 
 ## 📄 License


### PR DESCRIPTION
Closes #105.

## Summary

Adds the missing `Wolfgang.Etl.TestKit.Xunit` package to the README's Installation section. The README previously documented only `Wolfgang.Etl.TestKit` — readers had no way to discover the xUnit contract-test add-on that ships from the same repo.

## Change

`README.md` Installation section is expanded to:

- Describe both packages and when to use each
- Show install commands for both
- Add a one-line usage example for the xUnit base classes (`ExtractorBaseContractTests<TSut, TItem, TProgress>`) showing the three abstract members a downstream test author overrides

No prose, header, or other section changes.