### PR TITLE
test: assert ParamName in null-argument contract tests (#50)

### DIFF
--- a/src/Wolfgang.Etl.TestKit.Xunit/ExtractWithProgressAndCancellationAsyncContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/ExtractWithProgressAndCancellationAsyncContractTests.cs
@@ -202,10 +202,12 @@ public abstract class ExtractWithProgressAndCancellationAsyncContractTests<TSut,
     {
         var sut = CreateSut();
 
-        Assert.Throws<ArgumentNullException>(() =>
+        var ex = Assert.Throws<ArgumentNullException>(() =>
         {
             _ = sut.ExtractAsync((IProgress<TProgress>)null!);
         });
+
+        Assert.Equal("progress", ex.ParamName);
     }
 
 
@@ -278,10 +280,12 @@ public abstract class ExtractWithProgressAndCancellationAsyncContractTests<TSut,
     {
         var sut = CreateSut();
 
-        Assert.Throws<ArgumentNullException>(() =>
+        var ex = Assert.Throws<ArgumentNullException>(() =>
         {
             _ = sut.ExtractAsync((IProgress<TProgress>)null!, CancellationToken.None);
         });
+
+        Assert.Equal("progress", ex.ParamName);
     }
 
     /// <summary>

--- a/src/Wolfgang.Etl.TestKit.Xunit/ExtractWithProgressAsyncContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/ExtractWithProgressAsyncContractTests.cs
@@ -88,11 +88,13 @@ public abstract class ExtractWithProgressAsyncContractTests<TSut, TItem, TProgre
     {
         var sut = CreateSut();
 
-        Assert.Throws<ArgumentNullException>(() =>
+        var ex = Assert.Throws<ArgumentNullException>(() =>
         {
             // The exception is thrown when the method is called, before enumeration starts.
             _ = sut.ExtractAsync((IProgress<TProgress>)null!);
         });
+
+        Assert.Equal("progress", ex.ParamName);
     }
 
     /// <summary>

--- a/src/Wolfgang.Etl.TestKit.Xunit/ExtractorBaseContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/ExtractorBaseContractTests.cs
@@ -291,10 +291,12 @@ public abstract class ExtractorBaseContractTests<TSut, TItem, TProgress>
     {
         var sut = CreateSut();
 
-        Assert.Throws<ArgumentNullException>(() =>
+        var ex = Assert.Throws<ArgumentNullException>(() =>
         {
             _ = sut.ExtractAsync((IProgress<TProgress>)null!);
         });
+
+        Assert.Equal("progress", ex.ParamName);
     }
 
     /// <summary>
@@ -403,10 +405,12 @@ public abstract class ExtractorBaseContractTests<TSut, TItem, TProgress>
     {
         var sut = CreateSut();
 
-        Assert.Throws<ArgumentNullException>(() =>
+        var ex = Assert.Throws<ArgumentNullException>(() =>
         {
             _ = sut.ExtractAsync((IProgress<TProgress>)null!, CancellationToken.None);
         });
+
+        Assert.Equal("progress", ex.ParamName);
     }
 
     /// <summary>

--- a/src/Wolfgang.Etl.TestKit.Xunit/LoadWithProgressAndCancellationAsyncContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/LoadWithProgressAndCancellationAsyncContractTests.cs
@@ -216,7 +216,7 @@ public abstract class LoadWithProgressAndCancellationAsyncContractTests<TSut, TI
             () => sut.LoadAsync(AsyncEnumerable.Empty<TItem>(), (IProgress<TProgress>)null!)
         ).ConfigureAwait(false);
 
-        Assert.NotNull(ex);
+        Assert.Equal("progress", ex.ParamName);
     }
 
 
@@ -295,7 +295,7 @@ public abstract class LoadWithProgressAndCancellationAsyncContractTests<TSut, TI
             () => sut.LoadAsync(AsyncEnumerable.Empty<TItem>(), (IProgress<TProgress>)null!, CancellationToken.None)
         ).ConfigureAwait(false);
 
-        Assert.NotNull(ex);
+        Assert.Equal("progress", ex.ParamName);
     }
 
 

--- a/src/Wolfgang.Etl.TestKit.Xunit/LoadWithProgressAsyncContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/LoadWithProgressAsyncContractTests.cs
@@ -79,7 +79,7 @@ public abstract class LoadWithProgressAsyncContractTests<TSut, TItem, TProgress>
             () => sut.LoadAsync(AsyncEnumerable.Empty<TItem>(), (IProgress<TProgress>)null!)
         ).ConfigureAwait(false);
 
-        Assert.NotNull(ex);
+        Assert.Equal("progress", ex.ParamName);
     }
 
 

--- a/src/Wolfgang.Etl.TestKit.Xunit/LoaderBaseContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/LoaderBaseContractTests.cs
@@ -140,7 +140,7 @@ public abstract class LoaderBaseContractTests<TSut, TItem, TProgress>
         var ex = await Assert.ThrowsAsync<ArgumentNullException>(() =>
             sut.LoadAsync((IAsyncEnumerable<TItem>)null!)).ConfigureAwait(false);
 
-        Assert.NotNull(ex);
+        Assert.Equal("items", ex.ParamName);
     }
 
     /// <summary>
@@ -214,7 +214,7 @@ public abstract class LoaderBaseContractTests<TSut, TItem, TProgress>
         var ex = await Assert.ThrowsAsync<ArgumentNullException>(() =>
             sut.LoadAsync((IAsyncEnumerable<TItem>)null!, CancellationToken.None)).ConfigureAwait(false);
 
-        Assert.NotNull(ex);
+        Assert.Equal("items", ex.ParamName);
     }
 
     /// <summary>
@@ -335,7 +335,7 @@ public abstract class LoaderBaseContractTests<TSut, TItem, TProgress>
         var ex = await Assert.ThrowsAsync<ArgumentNullException>(() =>
             sut.LoadAsync((IAsyncEnumerable<TItem>)null!, progress)).ConfigureAwait(false);
 
-        Assert.NotNull(ex);
+        Assert.Equal("items", ex.ParamName);
     }
 
     /// <summary>
@@ -350,7 +350,7 @@ public abstract class LoaderBaseContractTests<TSut, TItem, TProgress>
         var ex = await Assert.ThrowsAsync<ArgumentNullException>(() =>
             sut.LoadAsync(CreateInputItemsAsync(), (IProgress<TProgress>)null!)).ConfigureAwait(false);
 
-        Assert.NotNull(ex);
+        Assert.Equal("progress", ex.ParamName);
     }
 
     /// <summary>
@@ -469,7 +469,7 @@ public abstract class LoaderBaseContractTests<TSut, TItem, TProgress>
         var ex = await Assert.ThrowsAsync<ArgumentNullException>(() =>
             sut.LoadAsync((IAsyncEnumerable<TItem>)null!, progress, CancellationToken.None)).ConfigureAwait(false);
 
-        Assert.NotNull(ex);
+        Assert.Equal("items", ex.ParamName);
     }
 
     /// <summary>
@@ -484,7 +484,7 @@ public abstract class LoaderBaseContractTests<TSut, TItem, TProgress>
         var ex = await Assert.ThrowsAsync<ArgumentNullException>(() =>
             sut.LoadAsync(CreateInputItemsAsync(), (IProgress<TProgress>)null!, CancellationToken.None)).ConfigureAwait(false);
 
-        Assert.NotNull(ex);
+        Assert.Equal("progress", ex.ParamName);
     }
 
     /// <summary>

--- a/src/Wolfgang.Etl.TestKit.Xunit/TransformWithProgressAndCancellationAsyncContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/TransformWithProgressAndCancellationAsyncContractTests.cs
@@ -203,10 +203,12 @@ public abstract class TransformWithProgressAndCancellationAsyncContractTests<TSu
     {
         var sut = CreateSut();
 
-        Assert.Throws<ArgumentNullException>(() =>
+        var ex = Assert.Throws<ArgumentNullException>(() =>
         {
             _ = sut.TransformAsync(AsyncEnumerable.Empty<TItem>(), (IProgress<TProgress>)null!);
         });
+
+        Assert.Equal("progress", ex.ParamName);
     }
 
 
@@ -278,10 +280,12 @@ public abstract class TransformWithProgressAndCancellationAsyncContractTests<TSu
     {
         var sut = CreateSut();
 
-        Assert.Throws<ArgumentNullException>(() =>
+        var ex = Assert.Throws<ArgumentNullException>(() =>
         {
             _ = sut.TransformAsync(AsyncEnumerable.Empty<TItem>(), (IProgress<TProgress>)null!, CancellationToken.None);
         });
+
+        Assert.Equal("progress", ex.ParamName);
     }
 
 

--- a/src/Wolfgang.Etl.TestKit.Xunit/TransformWithProgressAsyncContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/TransformWithProgressAsyncContractTests.cs
@@ -74,10 +74,12 @@ public abstract class TransformWithProgressAsyncContractTests<TSut, TItem, TProg
     {
         var sut = CreateSut();
 
-        Assert.Throws<ArgumentNullException>(() =>
+        var ex = Assert.Throws<ArgumentNullException>(() =>
         {
             _ = sut.TransformAsync(AsyncEnumerable.Empty<TItem>(), (IProgress<TProgress>)null!);
         });
+
+        Assert.Equal("progress", ex.ParamName);
     }
 
 

--- a/src/Wolfgang.Etl.TestKit.Xunit/TransformerBaseContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/TransformerBaseContractTests.cs
@@ -163,10 +163,12 @@ public abstract class TransformerBaseContractTests<TSut, TItem, TProgress>
     {
         var sut = CreateSut();
 
-        Assert.Throws<ArgumentNullException>(() =>
+        var ex = Assert.Throws<ArgumentNullException>(() =>
         {
             _ = sut.TransformAsync((IAsyncEnumerable<TItem>)null!);
         });
+
+        Assert.Equal("items", ex.ParamName);
     }
 
     /// <summary>
@@ -199,10 +201,12 @@ public abstract class TransformerBaseContractTests<TSut, TItem, TProgress>
     {
         var sut = CreateSut();
 
-        Assert.Throws<ArgumentNullException>(() =>
+        var ex = Assert.Throws<ArgumentNullException>(() =>
         {
             _ = sut.TransformAsync((IAsyncEnumerable<TItem>)null!, CancellationToken.None);
         });
+
+        Assert.Equal("items", ex.ParamName);
     }
 
     /// <summary>
@@ -316,10 +320,12 @@ public abstract class TransformerBaseContractTests<TSut, TItem, TProgress>
         var sut = CreateSut();
         var progress = new SynchronousProgress<TProgress>(_ => { });
 
-        Assert.Throws<ArgumentNullException>(() =>
+        var ex = Assert.Throws<ArgumentNullException>(() =>
         {
             _ = sut.TransformAsync((IAsyncEnumerable<TItem>)null!, progress);
         });
+
+        Assert.Equal("items", ex.ParamName);
     }
 
     /// <summary>
@@ -331,10 +337,12 @@ public abstract class TransformerBaseContractTests<TSut, TItem, TProgress>
     {
         var sut = CreateSut();
 
-        Assert.Throws<ArgumentNullException>(() =>
+        var ex = Assert.Throws<ArgumentNullException>(() =>
         {
             _ = sut.TransformAsync(CreateInputItemsAsync(), (IProgress<TProgress>)null!);
         });
+
+        Assert.Equal("progress", ex.ParamName);
     }
 
     /// <summary>
@@ -444,10 +452,12 @@ public abstract class TransformerBaseContractTests<TSut, TItem, TProgress>
         var sut = CreateSut();
         var progress = new SynchronousProgress<TProgress>(_ => { });
 
-        Assert.Throws<ArgumentNullException>(() =>
+        var ex = Assert.Throws<ArgumentNullException>(() =>
         {
             _ = sut.TransformAsync((IAsyncEnumerable<TItem>)null!, progress, CancellationToken.None);
         });
+
+        Assert.Equal("items", ex.ParamName);
     }
 
     /// <summary>
@@ -459,10 +469,12 @@ public abstract class TransformerBaseContractTests<TSut, TItem, TProgress>
     {
         var sut = CreateSut();
 
-        Assert.Throws<ArgumentNullException>(() =>
+        var ex = Assert.Throws<ArgumentNullException>(() =>
         {
             _ = sut.TransformAsync(CreateInputItemsAsync(), (IProgress<TProgress>)null!, CancellationToken.None);
         });
+
+        Assert.Equal("progress", ex.ParamName);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
Strengthens the `ArgumentNullException` contract tests in the `Wolfgang.Etl.TestKit.Xunit` base classes so they assert the exact `ParamName` (`"items"` / `"progress"`), not just the exception type. Implements issue #50.

22 assertion sites updated across 9 files (extractor / loader / transformer × base + WithProgress + WithProgressAndCancellation):
- **Sync** (extractor/transformer): now capture `var ex = Assert.Throws<…>(…)` and assert `ex.ParamName`.
- **Async** (loader): `Assert.NotNull(ex)` replaced with `Assert.Equal("…", ex.ParamName)`.

## Why it's safe (zero blast radius)
The null checks live in the **Abstractions** base classes, which throw `new ArgumentNullException(nameof(items))` / `nameof(progress)`. Every downstream component built on those bases inherits this behavior, so the tightened assertion is satisfied by all shipping extractors/loaders/transformers without any downstream change.

## Verification
- `dotnet build -c Release` — 0 warnings, 0 errors
- `dotnet test -c Release` (TestKit.Xunit consumer test project) — **195 passed, 0 failed**

## Scope note
This PR addresses **#50 only**. The companion contract-test issues #46 (CurrentItemCount increment ordering) and #49 (no upstream over-read) are **not** included — both need a maintainer decision first:
- **#46**: its prose says increment *after* yield is correct, but its proposed assertion (`count == i+1` after each MoveNext) and the actual `TestExtractor` implementation both use increment-*before*-yield. The spec is self-contradictory re: the intended ordering contract.
- **#49**: an extractor's upstream source isn't observable through the current contract base, so 'no over-read' can't be asserted without a new abstract hook (loader/transformer inputs are observable).

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)