### PR TITLE
test: per-item count-ordering and no-over-read contract tests (partial #46, #49)

### DIFF
--- a/src/Wolfgang.Etl.TestKit.Xunit/ExtractorBaseContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/ExtractorBaseContractTests.cs
@@ -177,6 +177,43 @@ public abstract class ExtractorBaseContractTests<TSut, TItem, TProgress>
 
 
 
+    /// <summary>
+    /// Verifies that <c>CurrentItemCount</c> reflects the exact number of items
+    /// yielded so far at every step of enumeration: it is <c>0</c> before the
+    /// first item is pulled and equals <c>k</c> immediately after the k-th item
+    /// is yielded.
+    /// </summary>
+    /// <remarks>
+    /// This is a stronger guarantee than
+    /// <see cref="ExtractAsync_increments_CurrentItemCount_for_each_item_Async"/>,
+    /// which only checks the final total. Enumerating one item at a time catches
+    /// implementations that increment the counter at the wrong point relative to
+    /// <c>yield return</c> (for example incrementing twice, or never updating the
+    /// count until the sequence is fully drained).
+    /// </remarks>
+    [Fact]
+    public async Task ExtractAsync_CurrentItemCount_tracks_each_yielded_item_Async()
+    {
+        var sut = CreateSut();
+        var expected = CreateExpectedItems();
+        Assert.True(expected.Count >= 1, "CreateExpectedItems() must return at least 1 item.");
+
+        await using var enumerator = sut.ExtractAsync().GetAsyncEnumerator();
+
+        Assert.Equal(0, sut.CurrentItemCount);
+
+        var count = 0;
+        while (await enumerator.MoveNextAsync().ConfigureAwait(false))
+        {
+            count++;
+            Assert.Equal(count, sut.CurrentItemCount);
+        }
+
+        Assert.Equal(expected.Count, sut.CurrentItemCount);
+    }
+
+
+
     // ------------------------------------------------------------------
     // ExtractAsync(CancellationToken) — cancellation
     // ------------------------------------------------------------------

--- a/src/Wolfgang.Etl.TestKit.Xunit/LoaderBaseContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/LoaderBaseContractTests.cs
@@ -722,6 +722,49 @@ public abstract class LoaderBaseContractTests<TSut, TItem, TProgress>
     }
 
     /// <summary>
+    /// Verifies that the loader stops pulling items from its source once
+    /// <c>MaximumItemCount</c> is reached, rather than draining the whole source
+    /// and discarding the surplus. A loader that over-reads holds upstream
+    /// resources (connections, cursors) far longer than necessary.
+    /// </summary>
+    /// <remarks>
+    /// The source is wrapped in a counter. Once the load completes with a limit
+    /// of <c>M</c>, the wrapper must have observed at most <c>M + 1</c> pulls —
+    /// the <c>+1</c> allows for the single read that discovers the limit has
+    /// been reached.
+    /// </remarks>
+    [Fact]
+    public async Task LoadAsync_stops_reading_source_at_MaximumItemCount_Async()
+    {
+        var sut = CreateSut();
+        var source = CreateSourceItems();
+        Assert.True(source.Count >= 3, "CreateSourceItems() must return at least 3 items.");
+
+        var pulled = 0;
+
+        async IAsyncEnumerable<TItem> CountingSourceAsync()
+        {
+            await Task.CompletedTask.ConfigureAwait(false);
+            foreach (var item in source)
+            {
+                pulled++;
+                yield return item;
+            }
+        }
+
+        sut.MaximumItemCount = source.Count - 2;
+
+        await sut.LoadAsync(CountingSourceAsync()).ConfigureAwait(false);
+
+        Assert.Equal(sut.MaximumItemCount, sut.CurrentItemCount);
+        Assert.True
+        (
+            pulled <= sut.MaximumItemCount + 1,
+            $"Expected at most {sut.MaximumItemCount + 1} source pulls but the source was read {pulled} times."
+        );
+    }
+
+    /// <summary>
     /// Verifies that when <c>MaximumItemCount</c> exceeds the sequence length, all items
     /// are still loaded.
     /// </summary>

--- a/src/Wolfgang.Etl.TestKit.Xunit/TransformerBaseContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/TransformerBaseContractTests.cs
@@ -186,6 +186,42 @@ public abstract class TransformerBaseContractTests<TSut, TItem, TProgress>
 
 
 
+    /// <summary>
+    /// Verifies that <c>CurrentItemCount</c> reflects the exact number of items
+    /// yielded so far at every step of enumeration: it is <c>0</c> before the
+    /// first item is pulled and equals <c>k</c> immediately after the k-th item
+    /// is yielded.
+    /// </summary>
+    /// <remarks>
+    /// This is a stronger guarantee than
+    /// <see cref="TransformAsync_increments_CurrentItemCount_for_each_item_Async"/>,
+    /// which only checks the final total. Enumerating one item at a time catches
+    /// implementations that increment the counter at the wrong point relative to
+    /// <c>yield return</c>.
+    /// </remarks>
+    [Fact]
+    public async Task TransformAsync_CurrentItemCount_tracks_each_yielded_item_Async()
+    {
+        var sut = CreateSut();
+        var expected = CreateExpectedItems();
+        Assert.True(expected.Count >= 1, "CreateExpectedItems() must return at least 1 item.");
+
+        await using var enumerator = sut.TransformAsync(CreateInputItemsAsync()).GetAsyncEnumerator();
+
+        Assert.Equal(0, sut.CurrentItemCount);
+
+        var count = 0;
+        while (await enumerator.MoveNextAsync().ConfigureAwait(false))
+        {
+            count++;
+            Assert.Equal(count, sut.CurrentItemCount);
+        }
+
+        Assert.Equal(expected.Count, sut.CurrentItemCount);
+    }
+
+
+
     // ------------------------------------------------------------------
     // TransformAsync(IAsyncEnumerable, CancellationToken) — cancellation
     // ------------------------------------------------------------------
@@ -705,6 +741,49 @@ public abstract class TransformerBaseContractTests<TSut, TItem, TProgress>
 
         Assert.Equal(1, actual.Count);
         Assert.Equal(expected[0], actual[0]);
+    }
+
+    /// <summary>
+    /// Verifies that the transformer stops pulling items from its source once
+    /// <c>MaximumItemCount</c> is reached, rather than draining the whole source
+    /// and discarding the surplus. A pull-based stage that over-reads holds
+    /// upstream resources (connections, cursors) far longer than necessary.
+    /// </summary>
+    /// <remarks>
+    /// The source is wrapped in a counter. Once enumeration completes with a
+    /// limit of <c>M</c>, the wrapper must have observed at most <c>M + 1</c>
+    /// pulls — the <c>+1</c> allows for the single read that discovers the limit
+    /// has been reached.
+    /// </remarks>
+    [Fact]
+    public async Task TransformAsync_stops_reading_source_at_MaximumItemCount_Async()
+    {
+        var sut = CreateSut();
+        var expected = CreateExpectedItems();
+        Assert.True(expected.Count >= 3, "CreateExpectedItems() must return at least 3 items.");
+
+        var pulled = 0;
+
+        async IAsyncEnumerable<TItem> CountingSourceAsync()
+        {
+            await Task.CompletedTask.ConfigureAwait(false);
+            foreach (var item in expected)
+            {
+                pulled++;
+                yield return item;
+            }
+        }
+
+        sut.MaximumItemCount = expected.Count - 2;
+
+        var actual = await sut.TransformAsync(CountingSourceAsync()).ToListAsync().ConfigureAwait(false);
+
+        Assert.Equal(sut.MaximumItemCount, actual.Count);
+        Assert.True
+        (
+            pulled <= sut.MaximumItemCount + 1,
+            $"Expected at most {sut.MaximumItemCount + 1} source pulls but the source was read {pulled} times."
+        );
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
Adds 4 contract tests to the `Wolfgang.Etl.TestKit.Xunit` base classes, strengthening two LSP guarantees. Build clean (0 warnings), **199 tests pass** (was 195).

### #46 — `CurrentItemCount` tracks each yielded item
`ExtractAsync_CurrentItemCount_tracks_each_yielded_item_Async` (ExtractorBase) and the TransformerBase equivalent enumerate **one item at a time** and assert `CurrentItemCount == k` immediately after the k-th yield, plus `== 0` before the first pull. This catches counter-increment-at-the-wrong-point bugs that the existing final-total test (`*_increments_CurrentItemCount_for_each_item_Async`) misses.

### #49 — components stop reading the source at `MaximumItemCount`
`LoadAsync_stops_reading_source_at_MaximumItemCount_Async` (LoaderBase) and the TransformerBase equivalent wrap the source in a pull counter and assert that hitting `MaximumItemCount = M` results in **at most M+1 source pulls** (the +1 being the read that discovers the limit). A stage that drains its whole source and discards the surplus now fails the contract.

Both behaviours pass against the TestKit's own doubles, which increment before `yield` and `break` once `CurrentItemCount >= MaximumItemCount`.

## Why these are *partial* (issues left open)
Two sub-cases genuinely can't be expressed through the current contract base without an API change, so this PR does **not** fully close #46/#49:

- **#46 / loaders** — a loader doesn't `yield`, so per-item count ordering isn't externally observable; only the final-total check is possible without a new hook.
- **#49 / extractors** — an extractor's upstream source is internal to the SUT, so 'pulls observed' can't be counted through the contract base. This would need a new abstract hook (e.g. `CreateSutWithCountingSource`), which is a **breaking change** to every downstream contract-test class — deferred for a deliberate decision.

> Note on #46 semantics: the issue's prose describes increment-*after*-yield, but its proposed assertion (`count == i+1` after each MoveNext) and the actual `TestExtractor`/`TestTransformer` code both increment *before* yield. These tests encode the **actual shipping convention** (increment-before-yield, mandated by CLAUDE.md). If the intended contract is different, say so and I'll flip them.

## Verification
- `dotnet build -c Release -f net8.0` — 0 warnings, 0 errors
- `dotnet test -c Release -f net8.0` (TestKit.Xunit consumer) — 199 passed, 0 failed

Addresses #46 and #49 (partial — see above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)