### PR TITLE
build: add PublicApiAnalyzers baseline for both src packages (#96)

### DIFF
--- a/src/Wolfgang.Etl.TestKit.Xunit/PublicAPI.Shipped.txt
+++ b/src/Wolfgang.Etl.TestKit.Xunit/PublicAPI.Shipped.txt
@@ -1,0 +1,259 @@
+#nullable enable
+Wolfgang.Etl.TestKit.Xunit.ExtractAsyncContractTests<TSut, TItem>
+Wolfgang.Etl.TestKit.Xunit.ExtractAsyncContractTests<TSut, TItem>.ExtractAsyncContractTests() -> void
+Wolfgang.Etl.TestKit.Xunit.ExtractAsyncContractTests<TSut, TItem>.ExtractAsync_returns_non_null_sequence() -> void
+Wolfgang.Etl.TestKit.Xunit.ExtractAsyncContractTests<TSut, TItem>.ExtractAsync_yields_expected_items_in_order_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.ExtractWithCancellationAsyncContractTests<TSut, TItem>
+Wolfgang.Etl.TestKit.Xunit.ExtractWithCancellationAsyncContractTests<TSut, TItem>.ExtractAsync_with_already_cancelled_token_throws_OperationCanceledException_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.ExtractWithCancellationAsyncContractTests<TSut, TItem>.ExtractAsync_with_cancellation_token_stops_when_token_is_cancelled_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.ExtractWithCancellationAsyncContractTests<TSut, TItem>.ExtractAsync_with_cancellation_token_yields_expected_items_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.ExtractWithCancellationAsyncContractTests<TSut, TItem>.ExtractWithCancellationAsyncContractTests() -> void
+Wolfgang.Etl.TestKit.Xunit.ExtractWithProgressAndCancellationAsyncContractTests<TSut, TItem, TProgress>
+Wolfgang.Etl.TestKit.Xunit.ExtractWithProgressAndCancellationAsyncContractTests<TSut, TItem, TProgress>.ExtractAsync_returns_non_null_sequence() -> void
+Wolfgang.Etl.TestKit.Xunit.ExtractWithProgressAndCancellationAsyncContractTests<TSut, TItem, TProgress>.ExtractAsync_with_already_cancelled_token_throws_OperationCanceledException_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.ExtractWithProgressAndCancellationAsyncContractTests<TSut, TItem, TProgress>.ExtractAsync_with_cancellation_token_stops_when_token_is_cancelled_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.ExtractWithProgressAndCancellationAsyncContractTests<TSut, TItem, TProgress>.ExtractAsync_with_cancellation_token_yields_expected_items_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.ExtractWithProgressAndCancellationAsyncContractTests<TSut, TItem, TProgress>.ExtractAsync_with_null_progress_and_token_throws_ArgumentNullException() -> void
+Wolfgang.Etl.TestKit.Xunit.ExtractWithProgressAndCancellationAsyncContractTests<TSut, TItem, TProgress>.ExtractAsync_with_null_progress_throws_ArgumentNullException() -> void
+Wolfgang.Etl.TestKit.Xunit.ExtractWithProgressAndCancellationAsyncContractTests<TSut, TItem, TProgress>.ExtractAsync_with_progress_and_cancelled_token_stops_enumeration_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.ExtractWithProgressAndCancellationAsyncContractTests<TSut, TItem, TProgress>.ExtractAsync_with_progress_and_empty_source_invokes_callback_at_least_once_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.ExtractWithProgressAndCancellationAsyncContractTests<TSut, TItem, TProgress>.ExtractAsync_with_progress_and_token_and_empty_source_invokes_callback_at_least_once_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.ExtractWithProgressAndCancellationAsyncContractTests<TSut, TItem, TProgress>.ExtractAsync_with_progress_and_token_invokes_callback_at_least_once_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.ExtractWithProgressAndCancellationAsyncContractTests<TSut, TItem, TProgress>.ExtractAsync_with_progress_and_token_yields_expected_items_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.ExtractWithProgressAndCancellationAsyncContractTests<TSut, TItem, TProgress>.ExtractAsync_with_progress_invokes_callback_at_least_once_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.ExtractWithProgressAndCancellationAsyncContractTests<TSut, TItem, TProgress>.ExtractAsync_with_progress_yields_expected_items_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.ExtractWithProgressAndCancellationAsyncContractTests<TSut, TItem, TProgress>.ExtractAsync_yields_expected_items_in_order_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.ExtractWithProgressAndCancellationAsyncContractTests<TSut, TItem, TProgress>.ExtractWithProgressAndCancellationAsyncContractTests() -> void
+Wolfgang.Etl.TestKit.Xunit.ExtractWithProgressAsyncContractTests<TSut, TItem, TProgress>
+Wolfgang.Etl.TestKit.Xunit.ExtractWithProgressAsyncContractTests<TSut, TItem, TProgress>.ExtractAsync_with_null_progress_throws_ArgumentNullException() -> void
+Wolfgang.Etl.TestKit.Xunit.ExtractWithProgressAsyncContractTests<TSut, TItem, TProgress>.ExtractAsync_with_progress_and_empty_source_invokes_callback_at_least_once_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.ExtractWithProgressAsyncContractTests<TSut, TItem, TProgress>.ExtractAsync_with_progress_invokes_callback_at_least_once_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.ExtractWithProgressAsyncContractTests<TSut, TItem, TProgress>.ExtractAsync_with_progress_yields_expected_items_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.ExtractWithProgressAsyncContractTests<TSut, TItem, TProgress>.ExtractWithProgressAsyncContractTests() -> void
+Wolfgang.Etl.TestKit.Xunit.ExtractorBaseContractTests<TSut, TItem, TProgress>
+Wolfgang.Etl.TestKit.Xunit.ExtractorBaseContractTests<TSut, TItem, TProgress>.ExtractAsync_CurrentItemCount_tracks_each_yielded_item_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.ExtractorBaseContractTests<TSut, TItem, TProgress>.ExtractAsync_increments_CurrentItemCount_for_each_item_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.ExtractorBaseContractTests<TSut, TItem, TProgress>.ExtractAsync_returns_non_null_sequence() -> void
+Wolfgang.Etl.TestKit.Xunit.ExtractorBaseContractTests<TSut, TItem, TProgress>.ExtractAsync_skips_items_up_to_SkipItemCount_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.ExtractorBaseContractTests<TSut, TItem, TProgress>.ExtractAsync_stops_at_MaximumItemCount_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.ExtractorBaseContractTests<TSut, TItem, TProgress>.ExtractAsync_with_already_cancelled_token_throws_OperationCanceledException_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.ExtractorBaseContractTests<TSut, TItem, TProgress>.ExtractAsync_with_empty_source_yields_no_items_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.ExtractorBaseContractTests<TSut, TItem, TProgress>.ExtractAsync_with_null_progress_and_token_throws_ArgumentNullException() -> void
+Wolfgang.Etl.TestKit.Xunit.ExtractorBaseContractTests<TSut, TItem, TProgress>.ExtractAsync_with_null_progress_throws_ArgumentNullException() -> void
+Wolfgang.Etl.TestKit.Xunit.ExtractorBaseContractTests<TSut, TItem, TProgress>.ExtractAsync_with_progress_and_cancelled_token_stops_enumeration_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.ExtractorBaseContractTests<TSut, TItem, TProgress>.ExtractAsync_with_progress_and_empty_source_invokes_callback_at_least_once_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.ExtractorBaseContractTests<TSut, TItem, TProgress>.ExtractAsync_with_progress_and_empty_source_yields_no_items_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.ExtractorBaseContractTests<TSut, TItem, TProgress>.ExtractAsync_with_progress_and_token_and_empty_source_invokes_callback_at_least_once_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.ExtractorBaseContractTests<TSut, TItem, TProgress>.ExtractAsync_with_progress_and_token_and_empty_source_yields_no_items_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.ExtractorBaseContractTests<TSut, TItem, TProgress>.ExtractAsync_with_progress_and_token_invokes_callback_at_least_once_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.ExtractorBaseContractTests<TSut, TItem, TProgress>.ExtractAsync_with_progress_and_token_invokes_callback_when_timer_fires_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.ExtractorBaseContractTests<TSut, TItem, TProgress>.ExtractAsync_with_progress_and_token_yields_all_expected_items_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.ExtractorBaseContractTests<TSut, TItem, TProgress>.ExtractAsync_with_progress_invokes_callback_at_least_once_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.ExtractorBaseContractTests<TSut, TItem, TProgress>.ExtractAsync_with_progress_invokes_callback_when_timer_fires_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.ExtractorBaseContractTests<TSut, TItem, TProgress>.ExtractAsync_with_progress_yields_all_expected_items_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.ExtractorBaseContractTests<TSut, TItem, TProgress>.ExtractAsync_with_token_and_empty_source_yields_no_items_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.ExtractorBaseContractTests<TSut, TItem, TProgress>.ExtractAsync_with_token_stops_when_token_is_cancelled_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.ExtractorBaseContractTests<TSut, TItem, TProgress>.ExtractAsync_with_token_yields_all_expected_items_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.ExtractorBaseContractTests<TSut, TItem, TProgress>.ExtractAsync_yields_all_expected_items_in_order_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.ExtractorBaseContractTests<TSut, TItem, TProgress>.ExtractAsync_yields_all_items_when_MaximumItemCount_exceeds_sequence_length_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.ExtractorBaseContractTests<TSut, TItem, TProgress>.ExtractorBaseContractTests() -> void
+Wolfgang.Etl.TestKit.Xunit.ExtractorBaseContractTests<TSut, TItem, TProgress>.MaximumItemCount_can_be_set_to_positive_value() -> void
+Wolfgang.Etl.TestKit.Xunit.ExtractorBaseContractTests<TSut, TItem, TProgress>.MaximumItemCount_defaults_to_int_MaxValue() -> void
+Wolfgang.Etl.TestKit.Xunit.ExtractorBaseContractTests<TSut, TItem, TProgress>.MaximumItemCount_set_to_negative_throws_ArgumentOutOfRangeException() -> void
+Wolfgang.Etl.TestKit.Xunit.ExtractorBaseContractTests<TSut, TItem, TProgress>.MaximumItemCount_set_to_zero_throws_ArgumentOutOfRangeException() -> void
+Wolfgang.Etl.TestKit.Xunit.ExtractorBaseContractTests<TSut, TItem, TProgress>.ReportingInterval_can_be_set_to_positive_value() -> void
+Wolfgang.Etl.TestKit.Xunit.ExtractorBaseContractTests<TSut, TItem, TProgress>.ReportingInterval_defaults_to_1000() -> void
+Wolfgang.Etl.TestKit.Xunit.ExtractorBaseContractTests<TSut, TItem, TProgress>.ReportingInterval_set_to_negative_throws_ArgumentOutOfRangeException() -> void
+Wolfgang.Etl.TestKit.Xunit.ExtractorBaseContractTests<TSut, TItem, TProgress>.ReportingInterval_set_to_zero_throws_ArgumentOutOfRangeException() -> void
+Wolfgang.Etl.TestKit.Xunit.ExtractorBaseContractTests<TSut, TItem, TProgress>.SkipItemCount_can_be_set_to_positive_value() -> void
+Wolfgang.Etl.TestKit.Xunit.ExtractorBaseContractTests<TSut, TItem, TProgress>.SkipItemCount_defaults_to_zero() -> void
+Wolfgang.Etl.TestKit.Xunit.ExtractorBaseContractTests<TSut, TItem, TProgress>.SkipItemCount_set_to_negative_throws_ArgumentOutOfRangeException() -> void
+Wolfgang.Etl.TestKit.Xunit.LoadAsyncContractTests<TSut, TItem>
+Wolfgang.Etl.TestKit.Xunit.LoadAsyncContractTests<TSut, TItem>.LoadAsyncContractTests() -> void
+Wolfgang.Etl.TestKit.Xunit.LoadAsyncContractTests<TSut, TItem>.LoadAsync_completes_without_throwing_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.LoadAsyncContractTests<TSut, TItem>.LoadAsync_with_empty_sequence_completes_without_throwing_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.LoadWithCancellationAsyncContractTests<TSut, TItem>
+Wolfgang.Etl.TestKit.Xunit.LoadWithCancellationAsyncContractTests<TSut, TItem>.LoadAsync_with_already_cancelled_token_throws_OperationCanceledException_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.LoadWithCancellationAsyncContractTests<TSut, TItem>.LoadAsync_with_cancellation_token_completes_without_throwing_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.LoadWithCancellationAsyncContractTests<TSut, TItem>.LoadAsync_with_cancellation_token_stops_when_token_is_cancelled_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.LoadWithCancellationAsyncContractTests<TSut, TItem>.LoadWithCancellationAsyncContractTests() -> void
+Wolfgang.Etl.TestKit.Xunit.LoadWithProgressAndCancellationAsyncContractTests<TSut, TItem, TProgress>
+Wolfgang.Etl.TestKit.Xunit.LoadWithProgressAndCancellationAsyncContractTests<TSut, TItem, TProgress>.LoadAsync_completes_without_throwing_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.LoadWithProgressAndCancellationAsyncContractTests<TSut, TItem, TProgress>.LoadAsync_with_already_cancelled_token_throws_OperationCanceledException_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.LoadWithProgressAndCancellationAsyncContractTests<TSut, TItem, TProgress>.LoadAsync_with_cancellation_token_completes_without_throwing_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.LoadWithProgressAndCancellationAsyncContractTests<TSut, TItem, TProgress>.LoadAsync_with_cancellation_token_stops_when_token_is_cancelled_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.LoadWithProgressAndCancellationAsyncContractTests<TSut, TItem, TProgress>.LoadAsync_with_empty_sequence_completes_without_throwing_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.LoadWithProgressAndCancellationAsyncContractTests<TSut, TItem, TProgress>.LoadAsync_with_null_progress_and_token_throws_ArgumentNullException_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.LoadWithProgressAndCancellationAsyncContractTests<TSut, TItem, TProgress>.LoadAsync_with_null_progress_throws_ArgumentNullException_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.LoadWithProgressAndCancellationAsyncContractTests<TSut, TItem, TProgress>.LoadAsync_with_progress_and_cancelled_token_stops_loading_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.LoadWithProgressAndCancellationAsyncContractTests<TSut, TItem, TProgress>.LoadAsync_with_progress_and_empty_source_invokes_callback_at_least_once_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.LoadWithProgressAndCancellationAsyncContractTests<TSut, TItem, TProgress>.LoadAsync_with_progress_and_token_and_empty_source_invokes_callback_at_least_once_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.LoadWithProgressAndCancellationAsyncContractTests<TSut, TItem, TProgress>.LoadAsync_with_progress_and_token_completes_without_throwing_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.LoadWithProgressAndCancellationAsyncContractTests<TSut, TItem, TProgress>.LoadAsync_with_progress_and_token_invokes_callback_at_least_once_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.LoadWithProgressAndCancellationAsyncContractTests<TSut, TItem, TProgress>.LoadAsync_with_progress_completes_without_throwing_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.LoadWithProgressAndCancellationAsyncContractTests<TSut, TItem, TProgress>.LoadAsync_with_progress_invokes_callback_at_least_once_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.LoadWithProgressAndCancellationAsyncContractTests<TSut, TItem, TProgress>.LoadWithProgressAndCancellationAsyncContractTests() -> void
+Wolfgang.Etl.TestKit.Xunit.LoadWithProgressAsyncContractTests<TSut, TItem, TProgress>
+Wolfgang.Etl.TestKit.Xunit.LoadWithProgressAsyncContractTests<TSut, TItem, TProgress>.LoadAsync_with_null_progress_throws_ArgumentNullException_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.LoadWithProgressAsyncContractTests<TSut, TItem, TProgress>.LoadAsync_with_progress_and_empty_source_invokes_callback_at_least_once_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.LoadWithProgressAsyncContractTests<TSut, TItem, TProgress>.LoadAsync_with_progress_completes_without_throwing_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.LoadWithProgressAsyncContractTests<TSut, TItem, TProgress>.LoadAsync_with_progress_invokes_callback_at_least_once_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.LoadWithProgressAsyncContractTests<TSut, TItem, TProgress>.LoadWithProgressAsyncContractTests() -> void
+Wolfgang.Etl.TestKit.Xunit.LoaderBaseContractTests<TSut, TItem, TProgress>
+Wolfgang.Etl.TestKit.Xunit.LoaderBaseContractTests<TSut, TItem, TProgress>.LoadAsync_completes_successfully_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.LoaderBaseContractTests<TSut, TItem, TProgress>.LoadAsync_increments_CurrentItemCount_for_each_item_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.LoaderBaseContractTests<TSut, TItem, TProgress>.LoadAsync_loads_all_items_when_MaximumItemCount_exceeds_sequence_length_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.LoaderBaseContractTests<TSut, TItem, TProgress>.LoadAsync_skips_items_up_to_SkipItemCount_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.LoaderBaseContractTests<TSut, TItem, TProgress>.LoadAsync_stops_at_MaximumItemCount_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.LoaderBaseContractTests<TSut, TItem, TProgress>.LoadAsync_stops_reading_source_at_MaximumItemCount_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.LoaderBaseContractTests<TSut, TItem, TProgress>.LoadAsync_with_cancellation_token_stops_when_token_is_cancelled_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.LoaderBaseContractTests<TSut, TItem, TProgress>.LoadAsync_with_cancelled_token_throws_OperationCanceledException_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.LoaderBaseContractTests<TSut, TItem, TProgress>.LoadAsync_with_empty_source_completes_without_error_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.LoaderBaseContractTests<TSut, TItem, TProgress>.LoadAsync_with_null_items_throws_ArgumentNullException_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.LoaderBaseContractTests<TSut, TItem, TProgress>.LoadAsync_with_null_progress_throws_ArgumentNullException_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.LoaderBaseContractTests<TSut, TItem, TProgress>.LoadAsync_with_progress_and_cancelled_token_throws_OperationCanceledException_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.LoaderBaseContractTests<TSut, TItem, TProgress>.LoadAsync_with_progress_and_empty_source_completes_without_error_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.LoaderBaseContractTests<TSut, TItem, TProgress>.LoadAsync_with_progress_and_empty_source_invokes_callback_at_least_once_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.LoaderBaseContractTests<TSut, TItem, TProgress>.LoadAsync_with_progress_and_null_items_throws_ArgumentNullException_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.LoaderBaseContractTests<TSut, TItem, TProgress>.LoadAsync_with_progress_and_token_and_empty_source_completes_without_error_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.LoaderBaseContractTests<TSut, TItem, TProgress>.LoadAsync_with_progress_and_token_and_empty_source_invokes_callback_at_least_once_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.LoaderBaseContractTests<TSut, TItem, TProgress>.LoadAsync_with_progress_and_token_and_null_items_throws_ArgumentNullException_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.LoaderBaseContractTests<TSut, TItem, TProgress>.LoadAsync_with_progress_and_token_and_null_progress_throws_ArgumentNullException_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.LoaderBaseContractTests<TSut, TItem, TProgress>.LoadAsync_with_progress_and_token_completes_successfully_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.LoaderBaseContractTests<TSut, TItem, TProgress>.LoadAsync_with_progress_and_token_invokes_callback_at_least_once_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.LoaderBaseContractTests<TSut, TItem, TProgress>.LoadAsync_with_progress_and_token_invokes_callback_when_timer_fires_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.LoaderBaseContractTests<TSut, TItem, TProgress>.LoadAsync_with_progress_completes_successfully_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.LoaderBaseContractTests<TSut, TItem, TProgress>.LoadAsync_with_progress_invokes_callback_at_least_once_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.LoaderBaseContractTests<TSut, TItem, TProgress>.LoadAsync_with_progress_invokes_callback_when_timer_fires_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.LoaderBaseContractTests<TSut, TItem, TProgress>.LoadAsync_with_token_and_empty_source_completes_without_error_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.LoaderBaseContractTests<TSut, TItem, TProgress>.LoadAsync_with_token_and_null_items_throws_ArgumentNullException_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.LoaderBaseContractTests<TSut, TItem, TProgress>.LoadAsync_with_token_completes_successfully_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.LoaderBaseContractTests<TSut, TItem, TProgress>.LoaderBaseContractTests() -> void
+Wolfgang.Etl.TestKit.Xunit.LoaderBaseContractTests<TSut, TItem, TProgress>.MaximumItemCount_can_be_set_to_positive_value() -> void
+Wolfgang.Etl.TestKit.Xunit.LoaderBaseContractTests<TSut, TItem, TProgress>.MaximumItemCount_defaults_to_int_MaxValue() -> void
+Wolfgang.Etl.TestKit.Xunit.LoaderBaseContractTests<TSut, TItem, TProgress>.MaximumItemCount_set_to_negative_throws_ArgumentOutOfRangeException() -> void
+Wolfgang.Etl.TestKit.Xunit.LoaderBaseContractTests<TSut, TItem, TProgress>.MaximumItemCount_set_to_zero_throws_ArgumentOutOfRangeException() -> void
+Wolfgang.Etl.TestKit.Xunit.LoaderBaseContractTests<TSut, TItem, TProgress>.ReportingInterval_can_be_set_to_positive_value() -> void
+Wolfgang.Etl.TestKit.Xunit.LoaderBaseContractTests<TSut, TItem, TProgress>.ReportingInterval_defaults_to_1000() -> void
+Wolfgang.Etl.TestKit.Xunit.LoaderBaseContractTests<TSut, TItem, TProgress>.ReportingInterval_set_to_negative_throws_ArgumentOutOfRangeException() -> void
+Wolfgang.Etl.TestKit.Xunit.LoaderBaseContractTests<TSut, TItem, TProgress>.ReportingInterval_set_to_zero_throws_ArgumentOutOfRangeException() -> void
+Wolfgang.Etl.TestKit.Xunit.LoaderBaseContractTests<TSut, TItem, TProgress>.SkipItemCount_can_be_set_to_positive_value() -> void
+Wolfgang.Etl.TestKit.Xunit.LoaderBaseContractTests<TSut, TItem, TProgress>.SkipItemCount_defaults_to_zero() -> void
+Wolfgang.Etl.TestKit.Xunit.LoaderBaseContractTests<TSut, TItem, TProgress>.SkipItemCount_set_to_negative_throws_ArgumentOutOfRangeException() -> void
+Wolfgang.Etl.TestKit.Xunit.ManualProgressTimer
+Wolfgang.Etl.TestKit.Xunit.ManualProgressTimer.Dispose() -> void
+Wolfgang.Etl.TestKit.Xunit.ManualProgressTimer.Elapsed -> System.Action?
+Wolfgang.Etl.TestKit.Xunit.ManualProgressTimer.Fire() -> void
+Wolfgang.Etl.TestKit.Xunit.ManualProgressTimer.ManualProgressTimer() -> void
+Wolfgang.Etl.TestKit.Xunit.ManualProgressTimer.Start(int intervalMilliseconds) -> void
+Wolfgang.Etl.TestKit.Xunit.ManualProgressTimer.StopTimer() -> void
+Wolfgang.Etl.TestKit.Xunit.SynchronousProgress<T>
+Wolfgang.Etl.TestKit.Xunit.SynchronousProgress<T>.Report(T value) -> void
+Wolfgang.Etl.TestKit.Xunit.SynchronousProgress<T>.SynchronousProgress(System.Action<T> handler) -> void
+Wolfgang.Etl.TestKit.Xunit.TransformAsyncContractTests<TSut, TItem>
+Wolfgang.Etl.TestKit.Xunit.TransformAsyncContractTests<TSut, TItem>.TransformAsyncContractTests() -> void
+Wolfgang.Etl.TestKit.Xunit.TransformAsyncContractTests<TSut, TItem>.TransformAsync_returns_non_null_sequence() -> void
+Wolfgang.Etl.TestKit.Xunit.TransformAsyncContractTests<TSut, TItem>.TransformAsync_yields_expected_items_in_order_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.TransformWithCancellationAsyncContractTests<TSut, TItem>
+Wolfgang.Etl.TestKit.Xunit.TransformWithCancellationAsyncContractTests<TSut, TItem>.TransformAsync_with_already_cancelled_token_throws_OperationCanceledException_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.TransformWithCancellationAsyncContractTests<TSut, TItem>.TransformAsync_with_cancellation_token_stops_when_token_is_cancelled_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.TransformWithCancellationAsyncContractTests<TSut, TItem>.TransformAsync_with_cancellation_token_yields_expected_items_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.TransformWithCancellationAsyncContractTests<TSut, TItem>.TransformWithCancellationAsyncContractTests() -> void
+Wolfgang.Etl.TestKit.Xunit.TransformWithProgressAndCancellationAsyncContractTests<TSut, TItem, TProgress>
+Wolfgang.Etl.TestKit.Xunit.TransformWithProgressAndCancellationAsyncContractTests<TSut, TItem, TProgress>.TransformAsync_returns_non_null_sequence() -> void
+Wolfgang.Etl.TestKit.Xunit.TransformWithProgressAndCancellationAsyncContractTests<TSut, TItem, TProgress>.TransformAsync_with_already_cancelled_token_throws_OperationCanceledException_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.TransformWithProgressAndCancellationAsyncContractTests<TSut, TItem, TProgress>.TransformAsync_with_cancellation_token_stops_when_token_is_cancelled_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.TransformWithProgressAndCancellationAsyncContractTests<TSut, TItem, TProgress>.TransformAsync_with_cancellation_token_yields_expected_items_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.TransformWithProgressAndCancellationAsyncContractTests<TSut, TItem, TProgress>.TransformAsync_with_null_progress_and_token_throws_ArgumentNullException() -> void
+Wolfgang.Etl.TestKit.Xunit.TransformWithProgressAndCancellationAsyncContractTests<TSut, TItem, TProgress>.TransformAsync_with_null_progress_throws_ArgumentNullException() -> void
+Wolfgang.Etl.TestKit.Xunit.TransformWithProgressAndCancellationAsyncContractTests<TSut, TItem, TProgress>.TransformAsync_with_progress_and_cancelled_token_stops_enumeration_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.TransformWithProgressAndCancellationAsyncContractTests<TSut, TItem, TProgress>.TransformAsync_with_progress_and_empty_source_invokes_callback_at_least_once_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.TransformWithProgressAndCancellationAsyncContractTests<TSut, TItem, TProgress>.TransformAsync_with_progress_and_token_and_empty_source_invokes_callback_at_least_once_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.TransformWithProgressAndCancellationAsyncContractTests<TSut, TItem, TProgress>.TransformAsync_with_progress_and_token_invokes_callback_at_least_once_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.TransformWithProgressAndCancellationAsyncContractTests<TSut, TItem, TProgress>.TransformAsync_with_progress_and_token_yields_expected_items_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.TransformWithProgressAndCancellationAsyncContractTests<TSut, TItem, TProgress>.TransformAsync_with_progress_invokes_callback_at_least_once_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.TransformWithProgressAndCancellationAsyncContractTests<TSut, TItem, TProgress>.TransformAsync_with_progress_yields_expected_items_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.TransformWithProgressAndCancellationAsyncContractTests<TSut, TItem, TProgress>.TransformAsync_yields_expected_items_in_order_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.TransformWithProgressAndCancellationAsyncContractTests<TSut, TItem, TProgress>.TransformWithProgressAndCancellationAsyncContractTests() -> void
+Wolfgang.Etl.TestKit.Xunit.TransformWithProgressAsyncContractTests<TSut, TItem, TProgress>
+Wolfgang.Etl.TestKit.Xunit.TransformWithProgressAsyncContractTests<TSut, TItem, TProgress>.TransformAsync_with_null_progress_throws_ArgumentNullException() -> void
+Wolfgang.Etl.TestKit.Xunit.TransformWithProgressAsyncContractTests<TSut, TItem, TProgress>.TransformAsync_with_progress_and_empty_source_invokes_callback_at_least_once_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.TransformWithProgressAsyncContractTests<TSut, TItem, TProgress>.TransformAsync_with_progress_invokes_callback_at_least_once_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.TransformWithProgressAsyncContractTests<TSut, TItem, TProgress>.TransformAsync_with_progress_yields_expected_items_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.TransformWithProgressAsyncContractTests<TSut, TItem, TProgress>.TransformWithProgressAsyncContractTests() -> void
+Wolfgang.Etl.TestKit.Xunit.TransformerBaseContractTests<TSut, TItem, TProgress>
+Wolfgang.Etl.TestKit.Xunit.TransformerBaseContractTests<TSut, TItem, TProgress>.MaximumItemCount_can_be_set_to_positive_value() -> void
+Wolfgang.Etl.TestKit.Xunit.TransformerBaseContractTests<TSut, TItem, TProgress>.MaximumItemCount_defaults_to_int_MaxValue() -> void
+Wolfgang.Etl.TestKit.Xunit.TransformerBaseContractTests<TSut, TItem, TProgress>.MaximumItemCount_set_to_negative_throws_ArgumentOutOfRangeException() -> void
+Wolfgang.Etl.TestKit.Xunit.TransformerBaseContractTests<TSut, TItem, TProgress>.MaximumItemCount_set_to_zero_throws_ArgumentOutOfRangeException() -> void
+Wolfgang.Etl.TestKit.Xunit.TransformerBaseContractTests<TSut, TItem, TProgress>.ReportingInterval_can_be_set_to_positive_value() -> void
+Wolfgang.Etl.TestKit.Xunit.TransformerBaseContractTests<TSut, TItem, TProgress>.ReportingInterval_defaults_to_1000() -> void
+Wolfgang.Etl.TestKit.Xunit.TransformerBaseContractTests<TSut, TItem, TProgress>.ReportingInterval_set_to_negative_throws_ArgumentOutOfRangeException() -> void
+Wolfgang.Etl.TestKit.Xunit.TransformerBaseContractTests<TSut, TItem, TProgress>.ReportingInterval_set_to_zero_throws_ArgumentOutOfRangeException() -> void
+Wolfgang.Etl.TestKit.Xunit.TransformerBaseContractTests<TSut, TItem, TProgress>.SkipItemCount_can_be_set_to_positive_value() -> void
+Wolfgang.Etl.TestKit.Xunit.TransformerBaseContractTests<TSut, TItem, TProgress>.SkipItemCount_defaults_to_zero() -> void
+Wolfgang.Etl.TestKit.Xunit.TransformerBaseContractTests<TSut, TItem, TProgress>.SkipItemCount_set_to_negative_throws_ArgumentOutOfRangeException() -> void
+Wolfgang.Etl.TestKit.Xunit.TransformerBaseContractTests<TSut, TItem, TProgress>.TransformAsync_CurrentItemCount_tracks_each_yielded_item_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.TransformerBaseContractTests<TSut, TItem, TProgress>.TransformAsync_increments_CurrentItemCount_for_each_item_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.TransformerBaseContractTests<TSut, TItem, TProgress>.TransformAsync_returns_non_null_sequence() -> void
+Wolfgang.Etl.TestKit.Xunit.TransformerBaseContractTests<TSut, TItem, TProgress>.TransformAsync_skips_items_up_to_SkipItemCount_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.TransformerBaseContractTests<TSut, TItem, TProgress>.TransformAsync_stops_at_MaximumItemCount_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.TransformerBaseContractTests<TSut, TItem, TProgress>.TransformAsync_stops_reading_source_at_MaximumItemCount_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.TransformerBaseContractTests<TSut, TItem, TProgress>.TransformAsync_with_already_cancelled_token_throws_OperationCanceledException_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.TransformerBaseContractTests<TSut, TItem, TProgress>.TransformAsync_with_empty_source_yields_no_items_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.TransformerBaseContractTests<TSut, TItem, TProgress>.TransformAsync_with_null_items_throws_ArgumentNullException() -> void
+Wolfgang.Etl.TestKit.Xunit.TransformerBaseContractTests<TSut, TItem, TProgress>.TransformAsync_with_null_progress_throws_ArgumentNullException() -> void
+Wolfgang.Etl.TestKit.Xunit.TransformerBaseContractTests<TSut, TItem, TProgress>.TransformAsync_with_progress_and_cancelled_token_stops_enumeration_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.TransformerBaseContractTests<TSut, TItem, TProgress>.TransformAsync_with_progress_and_empty_source_invokes_callback_at_least_once_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.TransformerBaseContractTests<TSut, TItem, TProgress>.TransformAsync_with_progress_and_empty_source_yields_no_items_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.TransformerBaseContractTests<TSut, TItem, TProgress>.TransformAsync_with_progress_and_null_items_throws_ArgumentNullException() -> void
+Wolfgang.Etl.TestKit.Xunit.TransformerBaseContractTests<TSut, TItem, TProgress>.TransformAsync_with_progress_and_token_and_empty_source_invokes_callback_at_least_once_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.TransformerBaseContractTests<TSut, TItem, TProgress>.TransformAsync_with_progress_and_token_and_empty_source_yields_no_items_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.TransformerBaseContractTests<TSut, TItem, TProgress>.TransformAsync_with_progress_and_token_and_null_items_throws_ArgumentNullException() -> void
+Wolfgang.Etl.TestKit.Xunit.TransformerBaseContractTests<TSut, TItem, TProgress>.TransformAsync_with_progress_and_token_and_null_progress_throws_ArgumentNullException() -> void
+Wolfgang.Etl.TestKit.Xunit.TransformerBaseContractTests<TSut, TItem, TProgress>.TransformAsync_with_progress_and_token_invokes_callback_at_least_once_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.TransformerBaseContractTests<TSut, TItem, TProgress>.TransformAsync_with_progress_and_token_invokes_callback_when_timer_fires_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.TransformerBaseContractTests<TSut, TItem, TProgress>.TransformAsync_with_progress_and_token_yields_all_expected_items_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.TransformerBaseContractTests<TSut, TItem, TProgress>.TransformAsync_with_progress_invokes_callback_at_least_once_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.TransformerBaseContractTests<TSut, TItem, TProgress>.TransformAsync_with_progress_invokes_callback_when_timer_fires_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.TransformerBaseContractTests<TSut, TItem, TProgress>.TransformAsync_with_progress_yields_all_expected_items_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.TransformerBaseContractTests<TSut, TItem, TProgress>.TransformAsync_with_token_and_empty_source_yields_no_items_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.TransformerBaseContractTests<TSut, TItem, TProgress>.TransformAsync_with_token_and_null_items_throws_ArgumentNullException() -> void
+Wolfgang.Etl.TestKit.Xunit.TransformerBaseContractTests<TSut, TItem, TProgress>.TransformAsync_with_token_stops_when_token_is_cancelled_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.TransformerBaseContractTests<TSut, TItem, TProgress>.TransformAsync_with_token_yields_all_expected_items_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.TransformerBaseContractTests<TSut, TItem, TProgress>.TransformAsync_yields_all_expected_items_in_order_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.TransformerBaseContractTests<TSut, TItem, TProgress>.TransformAsync_yields_all_items_when_MaximumItemCount_exceeds_sequence_length_Async() -> System.Threading.Tasks.Task
+Wolfgang.Etl.TestKit.Xunit.TransformerBaseContractTests<TSut, TItem, TProgress>.TransformerBaseContractTests() -> void
+abstract Wolfgang.Etl.TestKit.Xunit.ExtractAsyncContractTests<TSut, TItem>.CreateExpectedItems() -> System.Collections.Generic.IReadOnlyList<TItem>
+abstract Wolfgang.Etl.TestKit.Xunit.ExtractAsyncContractTests<TSut, TItem>.CreateSut(int itemCount) -> TSut
+abstract Wolfgang.Etl.TestKit.Xunit.ExtractWithCancellationAsyncContractTests<TSut, TItem>.CreateExpectedItems() -> System.Collections.Generic.IReadOnlyList<TItem>
+abstract Wolfgang.Etl.TestKit.Xunit.ExtractWithCancellationAsyncContractTests<TSut, TItem>.CreateSut(int itemCount) -> TSut
+abstract Wolfgang.Etl.TestKit.Xunit.ExtractWithProgressAndCancellationAsyncContractTests<TSut, TItem, TProgress>.CreateExpectedItems() -> System.Collections.Generic.IReadOnlyList<TItem>
+abstract Wolfgang.Etl.TestKit.Xunit.ExtractWithProgressAndCancellationAsyncContractTests<TSut, TItem, TProgress>.CreateSut(int itemCount) -> TSut
+abstract Wolfgang.Etl.TestKit.Xunit.ExtractWithProgressAsyncContractTests<TSut, TItem, TProgress>.CreateExpectedItems() -> System.Collections.Generic.IReadOnlyList<TItem>
+abstract Wolfgang.Etl.TestKit.Xunit.ExtractWithProgressAsyncContractTests<TSut, TItem, TProgress>.CreateSut(int itemCount) -> TSut
+abstract Wolfgang.Etl.TestKit.Xunit.ExtractorBaseContractTests<TSut, TItem, TProgress>.CreateExpectedItems() -> System.Collections.Generic.IReadOnlyList<TItem>
+abstract Wolfgang.Etl.TestKit.Xunit.ExtractorBaseContractTests<TSut, TItem, TProgress>.CreateSut(int itemCount) -> TSut
+abstract Wolfgang.Etl.TestKit.Xunit.ExtractorBaseContractTests<TSut, TItem, TProgress>.CreateSutWithTimer(Wolfgang.Etl.Abstractions.IProgressTimer timer) -> TSut
+abstract Wolfgang.Etl.TestKit.Xunit.LoadAsyncContractTests<TSut, TItem>.CreateSourceItems() -> System.Collections.Generic.IReadOnlyList<TItem>
+abstract Wolfgang.Etl.TestKit.Xunit.LoadAsyncContractTests<TSut, TItem>.CreateSut(int itemCount) -> TSut
+abstract Wolfgang.Etl.TestKit.Xunit.LoadWithCancellationAsyncContractTests<TSut, TItem>.CreateSourceItems() -> System.Collections.Generic.IReadOnlyList<TItem>
+abstract Wolfgang.Etl.TestKit.Xunit.LoadWithCancellationAsyncContractTests<TSut, TItem>.CreateSut(int itemCount) -> TSut
+abstract Wolfgang.Etl.TestKit.Xunit.LoadWithProgressAndCancellationAsyncContractTests<TSut, TItem, TProgress>.CreateSourceItems() -> System.Collections.Generic.IReadOnlyList<TItem>
+abstract Wolfgang.Etl.TestKit.Xunit.LoadWithProgressAndCancellationAsyncContractTests<TSut, TItem, TProgress>.CreateSut(int itemCount) -> TSut
+abstract Wolfgang.Etl.TestKit.Xunit.LoadWithProgressAsyncContractTests<TSut, TItem, TProgress>.CreateSourceItems() -> System.Collections.Generic.IReadOnlyList<TItem>
+abstract Wolfgang.Etl.TestKit.Xunit.LoadWithProgressAsyncContractTests<TSut, TItem, TProgress>.CreateSut(int itemCount) -> TSut
+abstract Wolfgang.Etl.TestKit.Xunit.LoaderBaseContractTests<TSut, TItem, TProgress>.CreateSourceItems() -> System.Collections.Generic.IReadOnlyList<TItem>
+abstract Wolfgang.Etl.TestKit.Xunit.LoaderBaseContractTests<TSut, TItem, TProgress>.CreateSut(int itemCount) -> TSut
+abstract Wolfgang.Etl.TestKit.Xunit.LoaderBaseContractTests<TSut, TItem, TProgress>.CreateSutWithTimer(Wolfgang.Etl.Abstractions.IProgressTimer timer) -> TSut
+abstract Wolfgang.Etl.TestKit.Xunit.TransformAsyncContractTests<TSut, TItem>.CreateExpectedItems() -> System.Collections.Generic.IReadOnlyList<TItem>
+abstract Wolfgang.Etl.TestKit.Xunit.TransformAsyncContractTests<TSut, TItem>.CreateSut(int itemCount) -> TSut
+abstract Wolfgang.Etl.TestKit.Xunit.TransformWithCancellationAsyncContractTests<TSut, TItem>.CreateExpectedItems() -> System.Collections.Generic.IReadOnlyList<TItem>
+abstract Wolfgang.Etl.TestKit.Xunit.TransformWithCancellationAsyncContractTests<TSut, TItem>.CreateSut(int itemCount) -> TSut
+abstract Wolfgang.Etl.TestKit.Xunit.TransformWithProgressAndCancellationAsyncContractTests<TSut, TItem, TProgress>.CreateExpectedItems() -> System.Collections.Generic.IReadOnlyList<TItem>
+abstract Wolfgang.Etl.TestKit.Xunit.TransformWithProgressAndCancellationAsyncContractTests<TSut, TItem, TProgress>.CreateSut(int itemCount) -> TSut
+abstract Wolfgang.Etl.TestKit.Xunit.TransformWithProgressAsyncContractTests<TSut, TItem, TProgress>.CreateExpectedItems() -> System.Collections.Generic.IReadOnlyList<TItem>
+abstract Wolfgang.Etl.TestKit.Xunit.TransformWithProgressAsyncContractTests<TSut, TItem, TProgress>.CreateSut(int itemCount) -> TSut
+abstract Wolfgang.Etl.TestKit.Xunit.TransformerBaseContractTests<TSut, TItem, TProgress>.CreateExpectedItems() -> System.Collections.Generic.IReadOnlyList<TItem>
+abstract Wolfgang.Etl.TestKit.Xunit.TransformerBaseContractTests<TSut, TItem, TProgress>.CreateSut(int itemCount) -> TSut
+abstract Wolfgang.Etl.TestKit.Xunit.TransformerBaseContractTests<TSut, TItem, TProgress>.CreateSutWithTimer(Wolfgang.Etl.Abstractions.IProgressTimer timer) -> TSut

--- a/src/Wolfgang.Etl.TestKit.Xunit/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.TestKit.Xunit/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Wolfgang.Etl.TestKit.Xunit/Wolfgang.Etl.TestKit.Xunit.csproj
+++ b/src/Wolfgang.Etl.TestKit.Xunit/Wolfgang.Etl.TestKit.Xunit.csproj
@@ -27,6 +27,13 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <ApplicationIcon>..\..\assets\testkit_xunit_icon.ico</ApplicationIcon>
     <PackageIcon>testkit_xunit_icon_128.png</PackageIcon>
+    <!-- PublicApiAnalyzers (#96): promote the public-API tracking diagnostics to
+         errors so the PublicAPI.Shipped.txt baseline actually guards the public
+         surface against unintended additions (RS0016), removals / mismatches
+         (RS0017), and duplicate entries (RS0025). Scoped to this opted-in src
+         project; test / benchmark / example projects do not carry the .txt
+         files and so are unaffected. -->
+    <WarningsAsErrors>$(WarningsAsErrors);RS0016;RS0017;RS0025</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Wolfgang.Etl.TestKit/PublicAPI.Shipped.txt
+++ b/src/Wolfgang.Etl.TestKit/PublicAPI.Shipped.txt
@@ -1,0 +1,22 @@
+#nullable enable
+Wolfgang.Etl.TestKit.TestExtractor<T>
+Wolfgang.Etl.TestKit.TestExtractor<T>.TestExtractor(System.Collections.Generic.IEnumerable<T> items) -> void
+Wolfgang.Etl.TestKit.TestExtractor<T>.TestExtractor(System.Collections.Generic.IEnumerable<T> items, Wolfgang.Etl.Abstractions.IProgressTimer timer) -> void
+Wolfgang.Etl.TestKit.TestExtractor<T>.TestExtractor(System.Collections.Generic.IEnumerator<T> enumerator) -> void
+Wolfgang.Etl.TestKit.TestExtractor<T>.TestExtractor(System.Collections.Generic.IEnumerator<T> enumerator, Wolfgang.Etl.Abstractions.IProgressTimer timer) -> void
+Wolfgang.Etl.TestKit.TestLoader<T>
+Wolfgang.Etl.TestKit.TestLoader<T>.GetCollectedItems() -> System.Collections.Generic.IReadOnlyList<T>?
+Wolfgang.Etl.TestKit.TestLoader<T>.TestLoader(bool collectItems) -> void
+Wolfgang.Etl.TestKit.TestLoader<T>.TestLoader(bool collectItems, Wolfgang.Etl.Abstractions.IProgressTimer timer) -> void
+Wolfgang.Etl.TestKit.TestTransformer<T>
+Wolfgang.Etl.TestKit.TestTransformer<T>.TestTransformer() -> void
+Wolfgang.Etl.TestKit.TestTransformer<T>.TestTransformer(Wolfgang.Etl.Abstractions.IProgressTimer timer) -> void
+override Wolfgang.Etl.TestKit.TestExtractor<T>.CreateProgressReport() -> Wolfgang.Etl.Abstractions.Report
+override Wolfgang.Etl.TestKit.TestExtractor<T>.CreateProgressTimer(System.IProgress<Wolfgang.Etl.Abstractions.Report> progress) -> Wolfgang.Etl.Abstractions.IProgressTimer
+override Wolfgang.Etl.TestKit.TestExtractor<T>.ExtractWorkerAsync(System.Threading.CancellationToken token) -> System.Collections.Generic.IAsyncEnumerable<T>
+override Wolfgang.Etl.TestKit.TestLoader<T>.CreateProgressReport() -> Wolfgang.Etl.Abstractions.Report
+override Wolfgang.Etl.TestKit.TestLoader<T>.CreateProgressTimer(System.IProgress<Wolfgang.Etl.Abstractions.Report> progress) -> Wolfgang.Etl.Abstractions.IProgressTimer
+override Wolfgang.Etl.TestKit.TestLoader<T>.LoadWorkerAsync(System.Collections.Generic.IAsyncEnumerable<T> items, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task
+override Wolfgang.Etl.TestKit.TestTransformer<T>.CreateProgressReport() -> Wolfgang.Etl.Abstractions.Report
+override Wolfgang.Etl.TestKit.TestTransformer<T>.CreateProgressTimer(System.IProgress<Wolfgang.Etl.Abstractions.Report> progress) -> Wolfgang.Etl.Abstractions.IProgressTimer
+override Wolfgang.Etl.TestKit.TestTransformer<T>.TransformWorkerAsync(System.Collections.Generic.IAsyncEnumerable<T> items, System.Threading.CancellationToken token) -> System.Collections.Generic.IAsyncEnumerable<T>

--- a/src/Wolfgang.Etl.TestKit/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.TestKit/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Wolfgang.Etl.TestKit/Wolfgang.Etl.TestKit.csproj
+++ b/src/Wolfgang.Etl.TestKit/Wolfgang.Etl.TestKit.csproj
@@ -26,6 +26,13 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <ApplicationIcon>..\..\assets\testkit_icon.ico</ApplicationIcon>
     <PackageIcon>testkit_icon_128.png</PackageIcon>
+    <!-- PublicApiAnalyzers (#96): promote the public-API tracking diagnostics to
+         errors so the PublicAPI.Shipped.txt baseline actually guards the public
+         surface against unintended additions (RS0016), removals / mismatches
+         (RS0017), and duplicate entries (RS0025). Scoped to this opted-in src
+         project; test / benchmark / example projects do not carry the .txt
+         files and so are unaffected. -->
+    <WarningsAsErrors>$(WarningsAsErrors);RS0016;RS0017;RS0025</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Populates the `PublicAPI.Shipped.txt` / `PublicAPI.Unshipped.txt` baselines for the two shippable `src/` packages so the PublicApiAnalyzers (RS0016 / RS0017 / RS0025) now guard the public API surface against unintended breaking changes — the goal of #96.

The analyzer **infrastructure was already present** on `main`: `Directory.Build.props` references `Microsoft.CodeAnalysis.PublicApiAnalyzers` 3.3.4 and globs the two `.txt` files as `AdditionalFiles` (opt-in per project via `Exists()`). What was missing was the actual baseline files in the two library projects. This **supersedes the reverted A1 attempt** (commits 7d2fe3a / 9e42df7, reverted in 38470e4 during v0.8.1 release prep).

## What changed

- **`src/Wolfgang.Etl.TestKit/`** — `PublicAPI.Shipped.txt` (full current public surface) + `PublicAPI.Unshipped.txt` (`#nullable enable` only).
- **`src/Wolfgang.Etl.TestKit.Xunit/`** — `PublicAPI.Shipped.txt` (full current public surface) + `PublicAPI.Unshipped.txt` (`#nullable enable` only).
- Both `.csproj` files: `<WarningsAsErrors>$(WarningsAsErrors);RS0016;RS0017;RS0025</WarningsAsErrors>`.

### Why the csproj `WarningsAsErrors`

In this repo's current analyzer configuration RS0016 ("symbol not in declared API") was **not** being raised, so a baseline alone would silently fail to catch *additions* to the surface (only RS0017 removals fired). Promoting the three tracking diagnostics to errors — scoped to the two opted-in src projects only, no protected-file edits — makes the baseline genuinely enforce both additions and removals. Verified by a negative test: deleting a single baseline entry now fails the build with RS0016.

### Stale baseline corrected

The recoverable (reverted) baseline was generated without RS0016 active, so it omitted the recently-added contract-test methods (`ExtractAsync_/TransformAsync_CurrentItemCount_tracks_each_yielded_item_Async`, `LoadAsync_/TransformAsync_stops_reading_source_at_MaximumItemCount_Async`) **and** the implicit public constructors of all 16 contract base classes. Those entries were added so the baseline matches the real surface.

## Public surface across TFMs

A single shared baseline builds clean against **all 5 TFMs** (`net462;net481;netstandard2.0;net8.0;net10.0`) for both projects — the public surface does **not** differ per TFM.

## Build / test results

- `dotnet build -c Release` (all TFMs), both src projects: **0 warnings / 0 errors**.
- `dotnet test -c Release -f net8.0`:
  - `Wolfgang.Etl.TestKit.Tests.Unit`: **58 passed**
  - `Wolfgang.Etl.TestKit.Xunit.Tests.Unit`: **199 passed**

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)