### PR TITLE
build: add BenchmarkDotNet baseline project for test doubles (#80, #102)

### DIFF
--- a/ETL-Test-Kit.slnx
+++ b/ETL-Test-Kit.slnx
@@ -36,7 +36,9 @@
     <File Path="scripts/Setup-Labels.ps1" />
 
   </Folder>
-  <Folder Name="/benchmarks/" />
+  <Folder Name="/benchmarks/">
+    <Project Path="benchmarks/Wolfgang.Etl.TestKit.Benchmarks/Wolfgang.Etl.TestKit.Benchmarks.csproj" />
+  </Folder>
   <Folder Name="/examples/" />
   <Folder Name="/src/">
     <Project Path="src/Wolfgang.Etl.TestKit/Wolfgang.Etl.TestKit.csproj" />

--- a/benchmarks/.editorconfig
+++ b/benchmarks/.editorconfig
@@ -1,0 +1,15 @@
+# Analyzer rules relaxed for benchmark projects
+
+[*.cs]
+
+# AsyncFixer01: Remove async/await — benchmark methods use BenchmarkDotNet conventions
+dotnet_diagnostic.AsyncFixer01.severity = none
+
+# MA0004: Use ConfigureAwait(false) — not needed in benchmark harness
+dotnet_diagnostic.MA0004.severity = none
+
+# S1215: Remove use of GC.GetTotalMemory — required for memory benchmarks
+dotnet_diagnostic.S1215.severity = none
+
+# VSTHRD200: Use Async suffix — benchmark methods follow BenchmarkDotNet naming conventions
+dotnet_diagnostic.VSTHRD200.severity = none

--- a/benchmarks/Wolfgang.Etl.TestKit.Benchmarks/ExtractorBenchmarks.cs
+++ b/benchmarks/Wolfgang.Etl.TestKit.Benchmarks/ExtractorBenchmarks.cs
@@ -1,0 +1,48 @@
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using Wolfgang.Etl.TestKit;
+
+namespace Wolfgang.Etl.TestKit.Benchmarks;
+
+/// <summary>
+/// Benchmarks the primary <see cref="TestExtractor{T}"/> path: enumerating every
+/// item out of an in-memory source via <c>ExtractAsync</c>.
+/// </summary>
+[MemoryDiagnoser]
+public class ExtractorBenchmarks
+{
+    private int[] _items = System.Array.Empty<int>();
+
+
+
+    [Params(1_000, 10_000, 100_000)]
+    public int ItemCount { get; set; }
+
+
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _items = new int[ItemCount];
+        for (var i = 0; i < ItemCount; i++)
+        {
+            _items[i] = i;
+        }
+    }
+
+
+
+    [Benchmark(Baseline = true)]
+    public async Task<int> Extract()
+    {
+        var extractor = new TestExtractor<int>(_items);
+
+        var count = 0;
+        await foreach (var _ in extractor.ExtractAsync())
+        {
+            count++;
+        }
+
+        return count;
+    }
+}

--- a/benchmarks/Wolfgang.Etl.TestKit.Benchmarks/LoaderBenchmarks.cs
+++ b/benchmarks/Wolfgang.Etl.TestKit.Benchmarks/LoaderBenchmarks.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using Wolfgang.Etl.TestKit;
+
+namespace Wolfgang.Etl.TestKit.Benchmarks;
+
+/// <summary>
+/// Benchmarks the primary <see cref="TestLoader{T}"/> path: consuming an
+/// <see cref="IAsyncEnumerable{T}"/> source via <c>LoadAsync</c> without collecting
+/// items, so the measurement is dominated by the framework pipeline.
+/// </summary>
+[MemoryDiagnoser]
+public class LoaderBenchmarks
+{
+    private int[] _items = System.Array.Empty<int>();
+
+
+
+    [Params(1_000, 10_000, 100_000)]
+    public int ItemCount { get; set; }
+
+
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _items = new int[ItemCount];
+        for (var i = 0; i < ItemCount; i++)
+        {
+            _items[i] = i;
+        }
+    }
+
+
+
+    [Benchmark(Baseline = true)]
+    public async Task Load()
+    {
+        var loader = new TestLoader<int>(collectItems: false);
+
+        await loader.LoadAsync(ToAsyncEnumerable(_items));
+    }
+
+
+
+    private static async IAsyncEnumerable<int> ToAsyncEnumerable
+    (
+        int[] items,
+        [EnumeratorCancellation] System.Threading.CancellationToken token = default
+    )
+    {
+        foreach (var item in items)
+        {
+            token.ThrowIfCancellationRequested();
+            yield return item;
+        }
+
+        await Task.CompletedTask;
+    }
+}

--- a/benchmarks/Wolfgang.Etl.TestKit.Benchmarks/Program.cs
+++ b/benchmarks/Wolfgang.Etl.TestKit.Benchmarks/Program.cs
@@ -1,0 +1,5 @@
+using BenchmarkDotNet.Running;
+
+BenchmarkSwitcher
+    .FromAssembly(typeof(Program).Assembly)
+    .Run(args);

--- a/benchmarks/Wolfgang.Etl.TestKit.Benchmarks/TransformerBenchmarks.cs
+++ b/benchmarks/Wolfgang.Etl.TestKit.Benchmarks/TransformerBenchmarks.cs
@@ -1,0 +1,68 @@
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using Wolfgang.Etl.TestKit;
+
+namespace Wolfgang.Etl.TestKit.Benchmarks;
+
+/// <summary>
+/// Benchmarks the primary <see cref="TestTransformer{T}"/> path: streaming an
+/// <see cref="IAsyncEnumerable{T}"/> source through <c>TransformAsync</c> and
+/// enumerating every yielded item.
+/// </summary>
+[MemoryDiagnoser]
+public class TransformerBenchmarks
+{
+    private int[] _items = System.Array.Empty<int>();
+
+
+
+    [Params(1_000, 10_000, 100_000)]
+    public int ItemCount { get; set; }
+
+
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _items = new int[ItemCount];
+        for (var i = 0; i < ItemCount; i++)
+        {
+            _items[i] = i;
+        }
+    }
+
+
+
+    [Benchmark(Baseline = true)]
+    public async Task<int> Transform()
+    {
+        var transformer = new TestTransformer<int>();
+
+        var count = 0;
+        await foreach (var _ in transformer.TransformAsync(ToAsyncEnumerable(_items)))
+        {
+            count++;
+        }
+
+        return count;
+    }
+
+
+
+    private static async IAsyncEnumerable<int> ToAsyncEnumerable
+    (
+        int[] items,
+        [EnumeratorCancellation] System.Threading.CancellationToken token = default
+    )
+    {
+        foreach (var item in items)
+        {
+            token.ThrowIfCancellationRequested();
+            yield return item;
+        }
+
+        await Task.CompletedTask;
+    }
+}

--- a/benchmarks/Wolfgang.Etl.TestKit.Benchmarks/Wolfgang.Etl.TestKit.Benchmarks.csproj
+++ b/benchmarks/Wolfgang.Etl.TestKit.Benchmarks/Wolfgang.Etl.TestKit.Benchmarks.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>disable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Etl.TestKit\Wolfgang.Etl.TestKit.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
+  </ItemGroup>
+
+  <!-- Analyzer PackageReferences are centralized in Directory.Build.props -->
+
+
+</Project>


### PR DESCRIPTION
## Summary
Stands up a BenchmarkDotNet baseline project for the ETL Test Kit's runtime test doubles, satisfying #80 (stand up a BDN baseline project) and #102 (hold benchmarks to `TreatWarningsAsErrors` via a curated `benchmarks/.editorconfig`, with **no** `benchmarks/Directory.Build.props` exemption).

## The project
`benchmarks/Wolfgang.Etl.TestKit.Benchmarks/` — an `Exe` targeting `net10.0`, `LangVersion=latest`, `ImplicitUsings=disable`, with a `ProjectReference` to `Wolfgang.Etl.TestKit` and a single `BenchmarkDotNet` 0.15.8 package reference. `Program.cs` uses the standard `BenchmarkSwitcher.FromAssembly(...).Run(args)` entry point. Analyzer package references are inherited from the root `Directory.Build.props` (comment noted in the csproj). Added to `ETL-Test-Kit.slnx` under the `/benchmarks/` folder.

## Three benchmark classes
Each is `[MemoryDiagnoser]`, with `[Params(1_000, 10_000, 100_000)] public int ItemCount` and a `[GlobalSetup]` that builds an in-memory `int[]`. `T = int` keeps allocations dominated by the framework path rather than record construction. One representative benchmark per class is `[Benchmark(Baseline = true)]`.

- `ExtractorBenchmarks.Extract` — `new TestExtractor<int>(int[])` then `await foreach` over `ExtractAsync()`.
- `LoaderBenchmarks.Load` — `new TestLoader<int>(collectItems: false)` then `await loader.LoadAsync(source)`.
- `TransformerBenchmarks.Transform` — `new TestTransformer<int>()` then `await foreach` over `TransformAsync(source)`.

## #102 — held to TreatWarningsAsErrors
There is **no** `benchmarks/Directory.Build.props`. The benchmark project inherits the root `Directory.Build.props`, so it IS held to `TreatWarningsAsErrors` in Release. The only relaxation is a curated `benchmarks/.editorconfig` silencing genuinely benchmark-inappropriate analyzer rules, each with a one-line justification:

- `AsyncFixer01` — remove async/await; benchmark methods follow BDN conventions.
- `MA0004` — `ConfigureAwait(false)` not needed in the benchmark harness.
- `S1215` — `GC.GetTotalMemory` is required by memory benchmarks.
- `VSTHRD200` — Async suffix; benchmark method names follow BDN naming conventions.

This matches the curated FixedWidth set exactly — no additional rule IDs were needed; the Release build is clean (0 warnings, 0 errors) against the full analyzer set.

## IAsyncEnumerable source
Rather than depend on `System.Linq.Async`'s `.ToAsyncEnumerable()` (a transitive dep), the loader and transformer benchmarks use a tiny local `async IAsyncEnumerable<int>` generator helper, keeping the source self-contained and the measured pipeline obvious.

## Verification
- `dotnet build benchmarks/Wolfgang.Etl.TestKit.Benchmarks/... -c Release` → **Build succeeded, 0 Warning(s), 0 Error(s)**.
- `dotnet run -c Release --project benchmarks/... -- --list flat` lists all three benchmarks.
- `dotnet run -c Release --project benchmarks/... -- --filter '*Extract*' --job dry` executes and emits a summary table with the MemoryDiagnoser `Allocated` column (e.g. ~520 B/op across all three ItemCount params), confirming the harness runs.

Closes #80
Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)
