### PR TITLE
fix: address AI code-review findings (#78)

### DIFF
--- a/src/Wolfgang.Etl.TestKit.Xunit/ExtractorBaseContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/ExtractorBaseContractTests.cs
@@ -29,7 +29,7 @@ namespace Wolfgang.Etl.TestKit.Xunit;
 ///   <item><description><c>CurrentItemCount</c> is incremented as items are yielded.</description></item>
 ///   <item><description><c>ReportingInterval</c> rejects values less than 1.</description></item>
 ///   <item><description><c>MaximumItemCount</c> stops extraction at the specified limit.</description></item>
-///   <item><description><c>MaximumItemCount</c> rejects values less than 0.</description></item>
+///   <item><description><c>MaximumItemCount</c> rejects values less than 1.</description></item>
 ///   <item><description><c>SkipItemCount</c> rejects values less than 0.</description></item>
 ///   <item><description>Progress callbacks fire at least once per extraction.</description></item>
 ///   <item><description><c>CreateProgressReport</c> reflects <c>CurrentItemCount</c>.</description></item>

--- a/src/Wolfgang.Etl.TestKit.Xunit/LoaderBaseContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/LoaderBaseContractTests.cs
@@ -30,7 +30,7 @@ namespace Wolfgang.Etl.TestKit.Xunit;
 ///   <item><description><c>CurrentItemCount</c> is incremented as items are loaded.</description></item>
 ///   <item><description><c>ReportingInterval</c> rejects values less than 1.</description></item>
 ///   <item><description><c>MaximumItemCount</c> stops loading at the specified limit.</description></item>
-///   <item><description><c>MaximumItemCount</c> rejects values less than 0.</description></item>
+///   <item><description><c>MaximumItemCount</c> rejects values less than 1.</description></item>
 ///   <item><description><c>SkipItemCount</c> skips the specified number of items.</description></item>
 ///   <item><description><c>SkipItemCount</c> rejects values less than 0.</description></item>
 ///   <item><description>Progress callbacks fire when the timer fires.</description></item>

--- a/src/Wolfgang.Etl.TestKit.Xunit/ManualProgressTimer.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/ManualProgressTimer.cs
@@ -31,9 +31,15 @@ namespace Wolfgang.Etl.TestKit.Xunit;
 /// TProgress? captured = null;
 /// var progress = new SynchronousProgress&lt;TProgress&gt;(r => captured = r);
 ///
-/// var task = sut.ExtractAsync(progress).ToListAsync().AsTask();
+/// // Begin enumeration and pull the first item so the pipeline is mid-flight,
+/// // then fire the timer deterministically before draining the rest. This
+/// // avoids the race where a fast synchronous source completes (and the
+/// // timer's Elapsed handler is unsubscribed in the worker's finally) before
+/// // Fire() is reached.
+/// await using var enumerator = sut.ExtractAsync(progress).GetAsyncEnumerator();
+/// await enumerator.MoveNextAsync();
 /// timer.Fire();
-/// await task;
+/// while (await enumerator.MoveNextAsync()) { }
 ///
 /// Assert.NotNull(captured);
 /// </code>

--- a/src/Wolfgang.Etl.TestKit.Xunit/TransformerBaseContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/TransformerBaseContractTests.cs
@@ -32,7 +32,7 @@ namespace Wolfgang.Etl.TestKit.Xunit;
 ///   <item><description><c>CurrentItemCount</c> is incremented as items are transformed.</description></item>
 ///   <item><description><c>ReportingInterval</c> rejects values less than 1.</description></item>
 ///   <item><description><c>MaximumItemCount</c> stops transformation at the specified limit.</description></item>
-///   <item><description><c>MaximumItemCount</c> rejects values less than 0.</description></item>
+///   <item><description><c>MaximumItemCount</c> rejects values less than 1.</description></item>
 ///   <item><description><c>SkipItemCount</c> skips the specified number of items.</description></item>
 ///   <item><description><c>SkipItemCount</c> rejects values less than 0.</description></item>
 ///   <item><description>Progress callbacks fire when the timer fires.</description></item>

--- a/src/Wolfgang.Etl.TestKit/TestExtractor.cs
+++ b/src/Wolfgang.Etl.TestKit/TestExtractor.cs
@@ -186,6 +186,14 @@ public class TestExtractor<T> : ExtractorBase<T, Report>
     {
         token.ThrowIfCancellationRequested();
 
+        // The wrapped source is synchronous, so this iterator would otherwise
+        // contain no await. Yield once up front to honour the async-iterator
+        // contract on every exit path (including the MaximumItemCount
+        // yield-break) and to give callers an asynchronous hop. Placing it here
+        // rather than after the loop keeps it reachable regardless of how the
+        // loop terminates.
+        await Task.Yield();
+
         var enumerator     = (_enumerator ?? _enumerable!.GetEnumerator())!;
         var ownsEnumerator = _enumerator == null;
 
@@ -218,7 +226,5 @@ public class TestExtractor<T> : ExtractorBase<T, Report>
                 enumerator.Dispose();
             }
         }
-
-        await Task.Yield(); // satisfies async method contract without causing extra allocations
     }
 }


### PR DESCRIPTION
## Summary
Resolves the findings from the #78 AI code-review pass directly (both low-severity). The review found no correctness, security, performance, or CLAUDE.md-compliance issues; these were the only two items above the noise bar, plus one doc-wording nit.

### Changes
1. **`TestExtractor.ExtractWorkerAsync`** — moved the artificial `await Task.Yield()` from after the try/finally to the top of the method, so it runs on **every** exit path (including the `MaximumItemCount` `yield break`), and corrected the misleading comment. Note: removing it outright (the reviewer's first suggestion) would trip **CS1998** under `TreatWarningsAsErrors` because the wrapped source is synchronous and this is the iterator's only `await`.
2. **`ManualProgressTimer` `<example>`** — replaced the race-prone `ToListAsync().AsTask()` + `Fire()` pattern with the enumerator-step pattern the kit's own contract tests use (get enumerator → one `MoveNextAsync()` → `Fire()` → drain). The old example could race a fast synchronous source to completion (with the timer's `Elapsed` already unsubscribed in the worker's `finally`) before `Fire()`.
3. **Contract base `<remarks>`** — `MaximumItemCount` "rejects values less than 0" → "less than 1" in all three base classes (it rejects 0). `SkipItemCount` wording left unchanged (it correctly rejects only negatives).

## Verification
- `dotnet build -c Release` both src projects, all TFMs — 0 warnings / 0 errors (confirms the relocated `Task.Yield()` doesn't trip CS1998).
- `dotnet test -c Release -f net8.0` — 58 pass (doubles) / 199 pass (contract consumer).

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)