### PR TITLE
feat: add factory-based constructors to TestExtractor<T> (#13)

### DIFF
--- a/src/Wolfgang.Etl.TestKit/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.TestKit/PublicAPI.Unshipped.txt
@@ -1,1 +1,9 @@
 #nullable enable
+Wolfgang.Etl.TestKit.TestExtractor<T>.TestExtractor(System.Func<int, T> factory) -> void
+Wolfgang.Etl.TestKit.TestExtractor<T>.TestExtractor(System.Func<int, T> factory, int count) -> void
+Wolfgang.Etl.TestKit.TestExtractor<T>.TestExtractor(System.Func<int, T> factory, int count, Wolfgang.Etl.Abstractions.IProgressTimer timer) -> void
+Wolfgang.Etl.TestKit.TestExtractor<T>.TestExtractor(System.Func<int, T> factory, Wolfgang.Etl.Abstractions.IProgressTimer timer) -> void
+Wolfgang.Etl.TestKit.TestExtractor<T>.TestExtractor(System.Func<T> factory) -> void
+Wolfgang.Etl.TestKit.TestExtractor<T>.TestExtractor(System.Func<T> factory, int count) -> void
+Wolfgang.Etl.TestKit.TestExtractor<T>.TestExtractor(System.Func<T> factory, int count, Wolfgang.Etl.Abstractions.IProgressTimer timer) -> void
+Wolfgang.Etl.TestKit.TestExtractor<T>.TestExtractor(System.Func<T> factory, Wolfgang.Etl.Abstractions.IProgressTimer timer) -> void

--- a/src/Wolfgang.Etl.TestKit/TestExtractor.cs
+++ b/src/Wolfgang.Etl.TestKit/TestExtractor.cs
@@ -9,8 +9,9 @@ namespace Wolfgang.Etl.TestKit;
 
 /// <summary>
 /// An in-memory extractor for use in tests, examples, and benchmarks.
-/// Yields items from either an <see cref="IEnumerable{T}"/> or an
-/// <see cref="IEnumerator{T}"/>, depending on which constructor is used.
+/// Yields items from an <see cref="IEnumerable{T}"/>, an
+/// <see cref="IEnumerator{T}"/>, or a factory delegate, depending on which
+/// constructor is used.
 /// </summary>
 /// <typeparam name="T">The type of item to extract.</typeparam>
 /// <remarks>
@@ -146,6 +147,322 @@ public class TestExtractor<T> : ExtractorBase<T, Report>
     {
         _enumerator    = enumerator ?? throw new ArgumentNullException(nameof(enumerator));
         _progressTimer = timer      ?? throw new ArgumentNullException(nameof(timer));
+    }
+
+
+
+    /// <summary>
+    /// Initializes a new <see cref="TestExtractor{T}"/> that yields items produced
+    /// by repeatedly invoking the specified factory delegate.
+    /// </summary>
+    /// <param name="factory">
+    /// A delegate invoked once per item to produce the next value to yield.
+    /// </param>
+    /// <remarks>
+    /// This constructor produces an <b>unbounded</b> sequence — the factory is invoked
+    /// indefinitely. The caller <b>must</b> bound the run by setting
+    /// <see cref="ExtractorBase{TSource,TProgress}.MaximumItemCount"/> or by cancelling
+    /// the extraction; otherwise extraction never completes.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="factory"/> is <see langword="null"/>.
+    /// </exception>
+    public TestExtractor(Func<T> factory)
+    {
+        if (factory is null)
+        {
+            throw new ArgumentNullException(nameof(factory));
+        }
+
+        _enumerable = Generate(factory);
+    }
+
+
+
+    /// <summary>
+    /// Initializes a new <see cref="TestExtractor{T}"/> that yields
+    /// <paramref name="count"/> items, each produced by invoking the specified
+    /// factory delegate.
+    /// </summary>
+    /// <param name="factory">
+    /// A delegate invoked once per item to produce the next value to yield.
+    /// </param>
+    /// <param name="count">The number of items to produce. Must be non-negative.</param>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="factory"/> is <see langword="null"/>.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="count"/> is less than zero.
+    /// </exception>
+    public TestExtractor(Func<T> factory, int count)
+    {
+        if (factory is null)
+        {
+            throw new ArgumentNullException(nameof(factory));
+        }
+
+        if (count < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(count));
+        }
+
+        _enumerable = Generate(factory, count);
+    }
+
+
+
+    /// <summary>
+    /// Initializes a new <see cref="TestExtractor{T}"/> that yields items produced
+    /// by repeatedly invoking the specified index-aware factory delegate. The
+    /// factory receives the zero-based index of the item being produced.
+    /// </summary>
+    /// <param name="factory">
+    /// A delegate invoked once per item, receiving the zero-based item index, to
+    /// produce the next value to yield.
+    /// </param>
+    /// <remarks>
+    /// This constructor produces an <b>unbounded</b> sequence — the factory is invoked
+    /// indefinitely. The caller <b>must</b> bound the run by setting
+    /// <see cref="ExtractorBase{TSource,TProgress}.MaximumItemCount"/> or by cancelling
+    /// the extraction; otherwise extraction never completes.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="factory"/> is <see langword="null"/>.
+    /// </exception>
+    public TestExtractor(Func<int, T> factory)
+    {
+        if (factory is null)
+        {
+            throw new ArgumentNullException(nameof(factory));
+        }
+
+        _enumerable = GenerateIndexed(factory);
+    }
+
+
+
+    /// <summary>
+    /// Initializes a new <see cref="TestExtractor{T}"/> that yields
+    /// <paramref name="count"/> items, each produced by invoking the specified
+    /// index-aware factory delegate. The factory receives the zero-based index of
+    /// the item being produced.
+    /// </summary>
+    /// <param name="factory">
+    /// A delegate invoked once per item, receiving the zero-based item index, to
+    /// produce the next value to yield.
+    /// </param>
+    /// <param name="count">The number of items to produce. Must be non-negative.</param>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="factory"/> is <see langword="null"/>.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="count"/> is less than zero.
+    /// </exception>
+    public TestExtractor(Func<int, T> factory, int count)
+    {
+        if (factory is null)
+        {
+            throw new ArgumentNullException(nameof(factory));
+        }
+
+        if (count < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(count));
+        }
+
+        _enumerable = GenerateIndexed(factory, count);
+    }
+
+
+
+    /// <summary>
+    /// Initializes a new <see cref="TestExtractor{T}"/> that yields items produced
+    /// by repeatedly invoking the specified factory delegate and uses the supplied
+    /// <see cref="IProgressTimer"/> to drive progress callbacks.
+    /// </summary>
+    /// <param name="factory">
+    /// A delegate invoked once per item to produce the next value to yield.
+    /// </param>
+    /// <param name="timer">
+    /// The timer used to drive progress callbacks. Inject a
+    /// <c>ManualProgressTimer</c> in tests to fire callbacks on demand.
+    /// </param>
+    /// <remarks>
+    /// This constructor produces an <b>unbounded</b> sequence — the factory is invoked
+    /// indefinitely. The caller <b>must</b> bound the run by setting
+    /// <see cref="ExtractorBase{TSource,TProgress}.MaximumItemCount"/> or by cancelling
+    /// the extraction; otherwise extraction never completes.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="factory"/> or <paramref name="timer"/> is <see langword="null"/>.
+    /// </exception>
+    protected TestExtractor(Func<T> factory, IProgressTimer timer)
+    {
+        if (factory is null)
+        {
+            throw new ArgumentNullException(nameof(factory));
+        }
+
+        _progressTimer = timer ?? throw new ArgumentNullException(nameof(timer));
+        _enumerable    = Generate(factory);
+    }
+
+
+
+    /// <summary>
+    /// Initializes a new <see cref="TestExtractor{T}"/> that yields
+    /// <paramref name="count"/> items, each produced by invoking the specified
+    /// factory delegate, and uses the supplied <see cref="IProgressTimer"/> to
+    /// drive progress callbacks.
+    /// </summary>
+    /// <param name="factory">
+    /// A delegate invoked once per item to produce the next value to yield.
+    /// </param>
+    /// <param name="count">The number of items to produce. Must be non-negative.</param>
+    /// <param name="timer">
+    /// The timer used to drive progress callbacks. Inject a
+    /// <c>ManualProgressTimer</c> in tests to fire callbacks on demand.
+    /// </param>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="factory"/> or <paramref name="timer"/> is <see langword="null"/>.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="count"/> is less than zero.
+    /// </exception>
+    protected TestExtractor(Func<T> factory, int count, IProgressTimer timer)
+    {
+        if (factory is null)
+        {
+            throw new ArgumentNullException(nameof(factory));
+        }
+
+        if (count < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(count));
+        }
+
+        _progressTimer = timer ?? throw new ArgumentNullException(nameof(timer));
+        _enumerable    = Generate(factory, count);
+    }
+
+
+
+    /// <summary>
+    /// Initializes a new <see cref="TestExtractor{T}"/> that yields items produced
+    /// by repeatedly invoking the specified index-aware factory delegate and uses
+    /// the supplied <see cref="IProgressTimer"/> to drive progress callbacks. The
+    /// factory receives the zero-based index of the item being produced.
+    /// </summary>
+    /// <param name="factory">
+    /// A delegate invoked once per item, receiving the zero-based item index, to
+    /// produce the next value to yield.
+    /// </param>
+    /// <param name="timer">
+    /// The timer used to drive progress callbacks. Inject a
+    /// <c>ManualProgressTimer</c> in tests to fire callbacks on demand.
+    /// </param>
+    /// <remarks>
+    /// This constructor produces an <b>unbounded</b> sequence — the factory is invoked
+    /// indefinitely. The caller <b>must</b> bound the run by setting
+    /// <see cref="ExtractorBase{TSource,TProgress}.MaximumItemCount"/> or by cancelling
+    /// the extraction; otherwise extraction never completes.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="factory"/> or <paramref name="timer"/> is <see langword="null"/>.
+    /// </exception>
+    protected TestExtractor(Func<int, T> factory, IProgressTimer timer)
+    {
+        if (factory is null)
+        {
+            throw new ArgumentNullException(nameof(factory));
+        }
+
+        _progressTimer = timer ?? throw new ArgumentNullException(nameof(timer));
+        _enumerable    = GenerateIndexed(factory);
+    }
+
+
+
+    /// <summary>
+    /// Initializes a new <see cref="TestExtractor{T}"/> that yields
+    /// <paramref name="count"/> items, each produced by invoking the specified
+    /// index-aware factory delegate, and uses the supplied
+    /// <see cref="IProgressTimer"/> to drive progress callbacks. The factory
+    /// receives the zero-based index of the item being produced.
+    /// </summary>
+    /// <param name="factory">
+    /// A delegate invoked once per item, receiving the zero-based item index, to
+    /// produce the next value to yield.
+    /// </param>
+    /// <param name="count">The number of items to produce. Must be non-negative.</param>
+    /// <param name="timer">
+    /// The timer used to drive progress callbacks. Inject a
+    /// <c>ManualProgressTimer</c> in tests to fire callbacks on demand.
+    /// </param>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="factory"/> or <paramref name="timer"/> is <see langword="null"/>.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="count"/> is less than zero.
+    /// </exception>
+    protected TestExtractor(Func<int, T> factory, int count, IProgressTimer timer)
+    {
+        if (factory is null)
+        {
+            throw new ArgumentNullException(nameof(factory));
+        }
+
+        if (count < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(count));
+        }
+
+        _progressTimer = timer ?? throw new ArgumentNullException(nameof(timer));
+        _enumerable    = GenerateIndexed(factory, count);
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // Factory generators
+    // ------------------------------------------------------------------
+
+    private static IEnumerable<T> Generate(Func<T> factory)
+    {
+        while (true)
+        {
+            yield return factory();
+        }
+    }
+
+
+
+    private static IEnumerable<T> Generate(Func<T> factory, int count)
+    {
+        for (var i = 0; i < count; i++)
+        {
+            yield return factory();
+        }
+    }
+
+
+
+    private static IEnumerable<T> GenerateIndexed(Func<int, T> factory)
+    {
+        for (var i = 0; ; i++)
+        {
+            yield return factory(i);
+        }
+    }
+
+
+
+    private static IEnumerable<T> GenerateIndexed(Func<int, T> factory, int count)
+    {
+        for (var i = 0; i < count; i++)
+        {
+            yield return factory(i);
+        }
     }
 
 

--- a/tests/Wolfgang.Etl.TestKit.Tests.Unit/TestExtractorTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Unit/TestExtractorTests.cs
@@ -459,6 +459,213 @@ public class TestExtractorTests
 
 
     // ------------------------------------------------------------------
+    // Func<T> factory constructor
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void Constructor_with_func_factory_when_factory_is_null_throws_ArgumentNullException()
+    {
+        var ex = Assert.Throws<ArgumentNullException>
+        (
+            () => new TestExtractor<int>((Func<int>)null!)
+        );
+
+        Assert.Equal("factory", ex.ParamName);
+    }
+
+
+
+    [Fact]
+    public async Task ExtractAsync_with_func_factory_invokes_factory_once_per_item()
+    {
+        var counter = 0;
+        var extractor = new TestExtractor<int>(() => counter++, 5);
+
+        var results = await extractor.ExtractAsync().ToListAsync();
+
+        Assert.Equal(new[] { 0, 1, 2, 3, 4 }, results);
+    }
+
+
+
+    [Fact]
+    public async Task ExtractAsync_with_func_factory_and_count_yields_count_items()
+    {
+        var extractor = new TestExtractor<int>(() => 7, 3);
+
+        var results = await extractor.ExtractAsync().ToListAsync();
+
+        Assert.Equal(new[] { 7, 7, 7 }, results);
+    }
+
+
+
+    [Fact]
+    public void Constructor_with_func_factory_and_count_when_factory_is_null_throws_ArgumentNullException()
+    {
+        var ex = Assert.Throws<ArgumentNullException>
+        (
+            () => new TestExtractor<int>((Func<int>)null!, 3)
+        );
+
+        Assert.Equal("factory", ex.ParamName);
+    }
+
+
+
+    [Fact]
+    public void Constructor_with_func_factory_and_count_when_count_is_negative_throws_ArgumentOutOfRangeException()
+    {
+        var ex = Assert.Throws<ArgumentOutOfRangeException>
+        (
+            () => new TestExtractor<int>(() => 1, -1)
+        );
+
+        Assert.Equal("count", ex.ParamName);
+    }
+
+
+
+    [Fact]
+    public async Task ExtractAsync_with_indefinite_func_factory_yields_MaximumItemCount_items()
+    {
+        var extractor = new TestExtractor<int>(() => 9);
+        extractor.MaximumItemCount = 4;
+
+        var results = await extractor.ExtractAsync().ToListAsync();
+
+        Assert.Equal(new[] { 9, 9, 9, 9 }, results);
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // Func<int, T> indexed factory constructor
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void Constructor_with_indexed_factory_when_factory_is_null_throws_ArgumentNullException()
+    {
+        var ex = Assert.Throws<ArgumentNullException>
+        (
+            () => new TestExtractor<int>((Func<int, int>)null!)
+        );
+
+        Assert.Equal("factory", ex.ParamName);
+    }
+
+
+
+    [Fact]
+    public async Task ExtractAsync_with_indexed_factory_and_count_yields_expected_items()
+    {
+        var extractor = new TestExtractor<int>(i => i * 2, 5);
+
+        var results = await extractor.ExtractAsync().ToListAsync();
+
+        Assert.Equal(new[] { 0, 2, 4, 6, 8 }, results);
+    }
+
+
+
+    [Fact]
+    public void Constructor_with_indexed_factory_and_count_when_factory_is_null_throws_ArgumentNullException()
+    {
+        var ex = Assert.Throws<ArgumentNullException>
+        (
+            () => new TestExtractor<int>((Func<int, int>)null!, 3)
+        );
+
+        Assert.Equal("factory", ex.ParamName);
+    }
+
+
+
+    [Fact]
+    public void Constructor_with_indexed_factory_and_count_when_count_is_negative_throws_ArgumentOutOfRangeException()
+    {
+        var ex = Assert.Throws<ArgumentOutOfRangeException>
+        (
+            () => new TestExtractor<int>(i => i, -1)
+        );
+
+        Assert.Equal("count", ex.ParamName);
+    }
+
+
+
+    [Fact]
+    public async Task ExtractAsync_with_indefinite_indexed_factory_yields_MaximumItemCount_items()
+    {
+        var extractor = new TestExtractor<int>(i => i);
+        extractor.MaximumItemCount = 3;
+
+        var results = await extractor.ExtractAsync().ToListAsync();
+
+        Assert.Equal(new[] { 0, 1, 2 }, results);
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // Factory + timer constructors
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task Constructor_with_func_factory_and_timer_yields_indefinitely_until_bounded()
+    {
+        using var timer = new ManualProgressTimer();
+        var sut = new TestExtractorWithTimer(() => 5, timer);
+        sut.MaximumItemCount = 3;
+
+        var results = await sut.ExtractAsync().ToListAsync();
+
+        Assert.Equal(new[] { 5, 5, 5 }, results);
+    }
+
+
+
+    [Fact]
+    public async Task Constructor_with_func_factory_count_and_timer_yields_count_items()
+    {
+        using var timer = new ManualProgressTimer();
+        var sut = new TestExtractorWithTimer(() => 5, 2, timer);
+
+        var results = await sut.ExtractAsync().ToListAsync();
+
+        Assert.Equal(new[] { 5, 5 }, results);
+    }
+
+
+
+    [Fact]
+    public async Task Constructor_with_indexed_factory_and_timer_yields_indefinitely_until_bounded()
+    {
+        using var timer = new ManualProgressTimer();
+        var sut = new TestExtractorWithTimer(i => i, timer);
+        sut.MaximumItemCount = 3;
+
+        var results = await sut.ExtractAsync().ToListAsync();
+
+        Assert.Equal(new[] { 0, 1, 2 }, results);
+    }
+
+
+
+    [Fact]
+    public async Task Constructor_with_indexed_factory_count_and_timer_yields_count_items()
+    {
+        using var timer = new ManualProgressTimer();
+        var sut = new TestExtractorWithTimer(i => i * 3, 3, timer);
+
+        var results = await sut.ExtractAsync().ToListAsync();
+
+        Assert.Equal(new[] { 0, 3, 6 }, results);
+    }
+
+
+
+    // ------------------------------------------------------------------
     // Private helpers
     // ------------------------------------------------------------------
 
@@ -486,6 +693,18 @@ public class TestExtractorTests
 
         public TestExtractorWithTimer(IEnumerator<int> enumerator, IProgressTimer timer)
             : base(enumerator, timer) { }
+
+        public TestExtractorWithTimer(Func<int> factory, IProgressTimer timer)
+            : base(factory, timer) { }
+
+        public TestExtractorWithTimer(Func<int> factory, int count, IProgressTimer timer)
+            : base(factory, count, timer) { }
+
+        public TestExtractorWithTimer(Func<int, int> factory, IProgressTimer timer)
+            : base(factory, timer) { }
+
+        public TestExtractorWithTimer(Func<int, int> factory, int count, IProgressTimer timer)
+            : base(factory, count, timer) { }
     }
 
 


### PR DESCRIPTION
Implements #13 — factory-based constructors for `TestExtractor<T>`.

## New constructors (8)
Public:
- `public TestExtractor(Func<T> factory)` — yields **indefinitely** (bound via `MaximumItemCount`/cancellation)
- `public TestExtractor(Func<T> factory, int count)`
- `public TestExtractor(Func<int, T> factory)` — index-aware, yields **indefinitely**
- `public TestExtractor(Func<int, T> factory, int count)`

Protected (timer-injecting counterparts, for test doubles):
- `protected TestExtractor(Func<T> factory, IProgressTimer timer)`
- `protected TestExtractor(Func<T> factory, int count, IProgressTimer timer)`
- `protected TestExtractor(Func<int, T> factory, IProgressTimer timer)`
- `protected TestExtractor(Func<int, T> factory, int count, IProgressTimer timer)`

## Design decisions
- **DRY**: all four factory shapes delegate to the existing `IEnumerable<T>` path by assigning `_enumerable` from private static generator helpers (`Generate`/`GenerateIndexed`). No new field, `ExtractWorkerAsync` untouched.
- **Indefinite generators**: the no-`count` overloads use `while(true)` / unbounded `for` and are intentionally unbounded — the caller MUST bound them via `MaximumItemCount` or cancellation. Documented in XML `<remarks>` on each.
- **Eager validation vs lazy generator**: because the generators are lazy `yield` iterators, argument validation is done **eagerly in the constructor body** (before assigning `_enumerable`), so null/negative args throw at construction time rather than being deferred to enumeration. Every ctor throws `ArgumentNullException(nameof(factory))` (and `nameof(timer)`); the `count` overloads throw `ArgumentOutOfRangeException(nameof(count))` when `count < 0`.

## PublicAPI follow-up
The `PublicAPI.*.txt` analyzer baseline is not on `main` yet (open PR #166), so the analyzer is dormant on this branch and no PublicAPI files were created. **After #166 merges, add the 4 new PUBLIC constructors to `src/Wolfgang.Etl.TestKit/PublicAPI.Unshipped.txt`** (protected ctors are not public API):

```
Wolfgang.Etl.TestKit.TestExtractor<T>.TestExtractor(System.Func<T>! factory) -> void
Wolfgang.Etl.TestKit.TestExtractor<T>.TestExtractor(System.Func<T>! factory, int count) -> void
Wolfgang.Etl.TestKit.TestExtractor<T>.TestExtractor(System.Func<int, T>! factory) -> void
Wolfgang.Etl.TestKit.TestExtractor<T>.TestExtractor(System.Func<int, T>! factory, int count) -> void
```

## Build & test
- `dotnet build src/Wolfgang.Etl.TestKit/Wolfgang.Etl.TestKit.csproj -c Release` — 0 warnings / 0 errors (all TFMs: net462, netstandard2.0, net8.0, net10.0, net481).
- `dotnet test ... -f net8.0` — **73 passed** (16 new tests covering each overload, once-per-item invocation, `MaximumItemCount`-bounded infinite generators, null-factory `ArgumentNullException`, and negative-count `ArgumentOutOfRangeException`).

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)
