### PR TITLE
feat: add ProgressCapture<T> and ProgressAssert helpers (#14)

### DIFF
--- a/src/Wolfgang.Etl.TestKit.Xunit/ProgressAssert.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/ProgressAssert.cs
@@ -1,0 +1,190 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Wolfgang.Etl.TestKit.Xunit;
+
+/// <summary>
+/// Provides xUnit-style assertions for validating sequences of progress reports captured by
+/// a <see cref="ProgressCapture{T}"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Each assertion throws an xUnit assertion exception (via the standard <c>Assert.*</c> API)
+/// when the condition is not met, so failures integrate with xUnit reporting exactly like any
+/// other assertion. These helpers replace the progress-validation boilerplate that downstream
+/// ETL test suites would otherwise copy between projects.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// var capture = new ProgressCapture&lt;Report&gt;();
+///
+/// await extractor.ExtractAsync(capture).ToListAsync();
+///
+/// ProgressAssert.HasReports(capture);
+/// ProgressAssert.IsMonotonicallyIncreasing(capture, r =&gt; r.CurrentItemCount);
+/// ProgressAssert.FinalReportSatisfies(capture, r =&gt; r.CurrentItemCount == 100);
+/// </code>
+/// </example>
+public static class ProgressAssert
+{
+    /// <summary>
+    /// Asserts that <paramref name="capture"/> recorded at least one progress report.
+    /// </summary>
+    /// <typeparam name="T">The type of progress value.</typeparam>
+    /// <param name="capture">The capture to inspect.</param>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="capture"/> is <see langword="null"/>.
+    /// </exception>
+    public static void HasReports<T>(ProgressCapture<T> capture)
+    {
+        if (capture is null)
+        {
+            throw new ArgumentNullException(nameof(capture));
+        }
+
+        Assert.NotEmpty(capture.Reports);
+    }
+
+
+
+    /// <summary>
+    /// Asserts that <paramref name="capture"/> recorded exactly <paramref name="count"/>
+    /// progress reports.
+    /// </summary>
+    /// <typeparam name="T">The type of progress value.</typeparam>
+    /// <param name="capture">The capture to inspect.</param>
+    /// <param name="count">The exact number of reports expected.</param>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="capture"/> is <see langword="null"/>.
+    /// </exception>
+    public static void HasExactly<T>(ProgressCapture<T> capture, int count)
+    {
+        if (capture is null)
+        {
+            throw new ArgumentNullException(nameof(capture));
+        }
+
+        Assert.Equal(count, capture.Reports.Count);
+    }
+
+
+
+    /// <summary>
+    /// Asserts that the value selected by <paramref name="selector"/> never decreases across
+    /// consecutive reports.
+    /// </summary>
+    /// <typeparam name="T">The type of progress value.</typeparam>
+    /// <typeparam name="TKey">The type of the selected, comparable key.</typeparam>
+    /// <param name="capture">The capture to inspect.</param>
+    /// <param name="selector">Selects the comparable value to test from each report.</param>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="capture"/> or <paramref name="selector"/> is <see langword="null"/>.
+    /// </exception>
+    public static void IsMonotonicallyIncreasing<T, TKey>
+    (
+        ProgressCapture<T> capture,
+        Func<T, TKey> selector
+    )
+        where TKey : IComparable<TKey>
+    {
+        if (capture is null)
+        {
+            throw new ArgumentNullException(nameof(capture));
+        }
+
+        if (selector is null)
+        {
+            throw new ArgumentNullException(nameof(selector));
+        }
+
+        var reports = capture.Reports;
+
+        for (var i = 1; i < reports.Count; i++)
+        {
+            var previous = selector(reports[i - 1]);
+            var current = selector(reports[i]);
+
+            Assert.True
+            (
+                current.CompareTo(previous) >= 0,
+                $"Reports were not monotonically increasing: report at index {i} " +
+                $"({current}) is less than the report at index {i - 1} ({previous})."
+            );
+        }
+    }
+
+
+
+    /// <summary>
+    /// Asserts that the final (last) captured report satisfies <paramref name="predicate"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of progress value.</typeparam>
+    /// <param name="capture">The capture to inspect.</param>
+    /// <param name="predicate">The condition the final report must satisfy.</param>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="capture"/> or <paramref name="predicate"/> is <see langword="null"/>.
+    /// </exception>
+    public static void FinalReportSatisfies<T>(ProgressCapture<T> capture, Func<T, bool> predicate)
+    {
+        if (capture is null)
+        {
+            throw new ArgumentNullException(nameof(capture));
+        }
+
+        if (predicate is null)
+        {
+            throw new ArgumentNullException(nameof(predicate));
+        }
+
+        var reports = capture.Reports;
+
+        Assert.True
+        (
+            reports.Count > 0,
+            "Expected at least one report so the final report could be evaluated, but none were captured."
+        );
+
+        Assert.True
+        (
+            predicate(reports[reports.Count - 1]),
+            "The final report did not satisfy the predicate."
+        );
+    }
+
+
+
+    /// <summary>
+    /// Asserts that every captured report satisfies <paramref name="predicate"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of progress value.</typeparam>
+    /// <param name="capture">The capture to inspect.</param>
+    /// <param name="predicate">The condition every report must satisfy.</param>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="capture"/> or <paramref name="predicate"/> is <see langword="null"/>.
+    /// </exception>
+    public static void AllReportsSatisfy<T>(ProgressCapture<T> capture, Func<T, bool> predicate)
+    {
+        if (capture is null)
+        {
+            throw new ArgumentNullException(nameof(capture));
+        }
+
+        if (predicate is null)
+        {
+            throw new ArgumentNullException(nameof(predicate));
+        }
+
+        IReadOnlyList<T> reports = capture.Reports;
+
+        for (var i = 0; i < reports.Count; i++)
+        {
+            Assert.True
+            (
+                predicate(reports[i]),
+                $"The report at index {i} did not satisfy the predicate."
+            );
+        }
+    }
+}

--- a/src/Wolfgang.Etl.TestKit.Xunit/ProgressCapture.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/ProgressCapture.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections.Generic;
+
+namespace Wolfgang.Etl.TestKit.Xunit;
+
+/// <summary>
+/// An <see cref="IProgress{T}"/> implementation that captures every reported value,
+/// synchronously, on the calling thread.
+/// </summary>
+/// <typeparam name="T">The type of progress value.</typeparam>
+/// <remarks>
+/// <para>
+/// Like <see cref="SynchronousProgress{T}"/>, <see cref="ProgressCapture{T}"/> reports on
+/// the same thread that calls <see cref="IProgress{T}.Report"/>, making progress assertions
+/// in tests fully deterministic without delays or manual synchronisation. Unlike
+/// <see cref="SynchronousProgress{T}"/>, it also records every reported value so the full
+/// sequence can be inspected after the operation under test completes.
+/// </para>
+/// <para>
+/// This type subsumes the manual <c>new List&lt;T&gt;()</c> plus
+/// <c>new SynchronousProgress&lt;T&gt;(r =&gt; list.Add(r))</c> wiring that test code would
+/// otherwise repeat. Pair it with <see cref="ProgressAssert"/> for one-liner verification of
+/// the captured sequence.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// var capture = new ProgressCapture&lt;Report&gt;();
+///
+/// await extractor.ExtractAsync(capture).ToListAsync();
+///
+/// ProgressAssert.HasReports(capture);
+/// ProgressAssert.IsMonotonicallyIncreasing(capture, r =&gt; r.CurrentItemCount);
+/// ProgressAssert.FinalReportSatisfies(capture, r =&gt; r.CurrentItemCount == 100);
+/// </code>
+/// </example>
+public sealed class ProgressCapture<T> : IProgress<T>
+{
+    private readonly object _gate = new object();
+
+    private readonly List<T> _reports = new List<T>();
+
+
+
+    /// <summary>
+    /// Gets all captured reports, in the order they were reported.
+    /// </summary>
+    public IReadOnlyList<T> Reports
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _reports.ToArray();
+            }
+        }
+    }
+
+
+
+    /// <summary>
+    /// Gets the last captured report, or <see langword="default"/> if no report has been
+    /// captured.
+    /// </summary>
+    public T? FinalReport
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _reports.Count == 0 ? default : _reports[_reports.Count - 1];
+            }
+        }
+    }
+
+
+
+    /// <summary>
+    /// Gets the number of reports captured so far.
+    /// </summary>
+    public int Count
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _reports.Count;
+            }
+        }
+    }
+
+
+
+    /// <summary>
+    /// Captures <paramref name="value"/> by appending it to <see cref="Reports"/>.
+    /// </summary>
+    /// <param name="value">The progress value to capture.</param>
+    void IProgress<T>.Report(T value)
+    {
+        lock (_gate)
+        {
+            _reports.Add(value);
+        }
+    }
+}

--- a/src/Wolfgang.Etl.TestKit.Xunit/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.TestKit.Xunit/PublicAPI.Unshipped.txt
@@ -1,1 +1,12 @@
 #nullable enable
+Wolfgang.Etl.TestKit.Xunit.ProgressAssert
+Wolfgang.Etl.TestKit.Xunit.ProgressCapture<T>
+Wolfgang.Etl.TestKit.Xunit.ProgressCapture<T>.Count.get -> int
+Wolfgang.Etl.TestKit.Xunit.ProgressCapture<T>.FinalReport.get -> T?
+Wolfgang.Etl.TestKit.Xunit.ProgressCapture<T>.ProgressCapture() -> void
+Wolfgang.Etl.TestKit.Xunit.ProgressCapture<T>.Reports.get -> System.Collections.Generic.IReadOnlyList<T>!
+static Wolfgang.Etl.TestKit.Xunit.ProgressAssert.AllReportsSatisfy<T>(Wolfgang.Etl.TestKit.Xunit.ProgressCapture<T>! capture, System.Func<T, bool>! predicate) -> void
+static Wolfgang.Etl.TestKit.Xunit.ProgressAssert.FinalReportSatisfies<T>(Wolfgang.Etl.TestKit.Xunit.ProgressCapture<T>! capture, System.Func<T, bool>! predicate) -> void
+static Wolfgang.Etl.TestKit.Xunit.ProgressAssert.HasExactly<T>(Wolfgang.Etl.TestKit.Xunit.ProgressCapture<T>! capture, int count) -> void
+static Wolfgang.Etl.TestKit.Xunit.ProgressAssert.HasReports<T>(Wolfgang.Etl.TestKit.Xunit.ProgressCapture<T>! capture) -> void
+static Wolfgang.Etl.TestKit.Xunit.ProgressAssert.IsMonotonicallyIncreasing<T, TKey>(Wolfgang.Etl.TestKit.Xunit.ProgressCapture<T>! capture, System.Func<T, TKey>! selector) -> void

--- a/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/ProgressAssertTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/ProgressAssertTests.cs
@@ -1,0 +1,366 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+using Wolfgang.Etl.TestKit;
+using Wolfgang.Etl.TestKit.Xunit;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Wolfgang.Etl.TestKit.Xunit.Tests.Unit;
+
+/// <summary>
+/// Unit tests for <see cref="ProgressAssert"/>.
+/// </summary>
+public class ProgressAssertTests
+{
+    /// <summary>
+    /// Casts a <see cref="ProgressCapture{T}"/> to <see cref="IProgress{T}"/> so its
+    /// explicitly-implemented <see cref="IProgress{T}.Report"/> can be invoked.
+    /// </summary>
+    private static void Report<T>(ProgressCapture<T> capture, T value) =>
+        ((IProgress<T>)capture).Report(value);
+
+
+
+    // ------------------------------------------------------------------
+    // HasReports
+    // ------------------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="ProgressAssert.HasReports{T}"/> passes when at least one
+    /// report was captured.
+    /// </summary>
+    [Fact]
+    public void HasReports_when_reports_present_does_not_throw()
+    {
+        var capture = new ProgressCapture<int>();
+        Report(capture, 1);
+
+        var exception = Record.Exception(() => ProgressAssert.HasReports(capture));
+
+        Assert.Null(exception);
+    }
+
+
+
+    /// <summary>
+    /// Verifies that <see cref="ProgressAssert.HasReports{T}"/> fails when no reports were
+    /// captured.
+    /// </summary>
+    [Fact]
+    public void HasReports_when_no_reports_throws()
+    {
+        var capture = new ProgressCapture<int>();
+
+        Assert.ThrowsAny<XunitException>(() => ProgressAssert.HasReports(capture));
+    }
+
+
+
+    /// <summary>
+    /// Verifies that <see cref="ProgressAssert.HasReports{T}"/> guards against a null capture.
+    /// </summary>
+    [Fact]
+    public void HasReports_when_capture_null_throws_ArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => ProgressAssert.HasReports<int>(null!));
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // HasExactly
+    // ------------------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="ProgressAssert.HasExactly{T}"/> passes when the count matches.
+    /// </summary>
+    [Fact]
+    public void HasExactly_when_count_matches_does_not_throw()
+    {
+        var capture = new ProgressCapture<int>();
+        Report(capture, 1);
+        Report(capture, 2);
+
+        var exception = Record.Exception(() => ProgressAssert.HasExactly(capture, 2));
+
+        Assert.Null(exception);
+    }
+
+
+
+    /// <summary>
+    /// Verifies that <see cref="ProgressAssert.HasExactly{T}"/> fails when the count differs.
+    /// </summary>
+    [Fact]
+    public void HasExactly_when_count_differs_throws()
+    {
+        var capture = new ProgressCapture<int>();
+        Report(capture, 1);
+
+        Assert.ThrowsAny<XunitException>(() => ProgressAssert.HasExactly(capture, 5));
+    }
+
+
+
+    /// <summary>
+    /// Verifies that <see cref="ProgressAssert.HasExactly{T}"/> guards against a null capture.
+    /// </summary>
+    [Fact]
+    public void HasExactly_when_capture_null_throws_ArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => ProgressAssert.HasExactly<int>(null!, 1));
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // IsMonotonicallyIncreasing
+    // ------------------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="ProgressAssert.IsMonotonicallyIncreasing{T, TKey}"/> passes
+    /// when selected values never decrease (including equal consecutive values).
+    /// </summary>
+    [Fact]
+    public void IsMonotonicallyIncreasing_when_non_decreasing_does_not_throw()
+    {
+        var capture = new ProgressCapture<int>();
+        Report(capture, 1);
+        Report(capture, 1);
+        Report(capture, 3);
+
+        var exception = Record.Exception(() =>
+            ProgressAssert.IsMonotonicallyIncreasing(capture, v => v));
+
+        Assert.Null(exception);
+    }
+
+
+
+    /// <summary>
+    /// Verifies that <see cref="ProgressAssert.IsMonotonicallyIncreasing{T, TKey}"/> fails
+    /// when a selected value decreases.
+    /// </summary>
+    [Fact]
+    public void IsMonotonicallyIncreasing_when_decreasing_throws()
+    {
+        var capture = new ProgressCapture<int>();
+        Report(capture, 1);
+        Report(capture, 5);
+        Report(capture, 4);
+
+        Assert.ThrowsAny<XunitException>(() =>
+            ProgressAssert.IsMonotonicallyIncreasing(capture, v => v));
+    }
+
+
+
+    /// <summary>
+    /// Verifies that <see cref="ProgressAssert.IsMonotonicallyIncreasing{T, TKey}"/> guards
+    /// against a null capture.
+    /// </summary>
+    [Fact]
+    public void IsMonotonicallyIncreasing_when_capture_null_throws_ArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            ProgressAssert.IsMonotonicallyIncreasing<int, int>(null!, v => v));
+    }
+
+
+
+    /// <summary>
+    /// Verifies that <see cref="ProgressAssert.IsMonotonicallyIncreasing{T, TKey}"/> guards
+    /// against a null selector.
+    /// </summary>
+    [Fact]
+    public void IsMonotonicallyIncreasing_when_selector_null_throws_ArgumentNullException()
+    {
+        var capture = new ProgressCapture<int>();
+
+        Assert.Throws<ArgumentNullException>(() =>
+            ProgressAssert.IsMonotonicallyIncreasing<int, int>(capture, null!));
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // FinalReportSatisfies
+    // ------------------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="ProgressAssert.FinalReportSatisfies{T}"/> passes when the
+    /// final report matches the predicate.
+    /// </summary>
+    [Fact]
+    public void FinalReportSatisfies_when_final_matches_does_not_throw()
+    {
+        var capture = new ProgressCapture<int>();
+        Report(capture, 1);
+        Report(capture, 100);
+
+        var exception = Record.Exception(() =>
+            ProgressAssert.FinalReportSatisfies(capture, v => v == 100));
+
+        Assert.Null(exception);
+    }
+
+
+
+    /// <summary>
+    /// Verifies that <see cref="ProgressAssert.FinalReportSatisfies{T}"/> fails when the
+    /// final report does not match the predicate.
+    /// </summary>
+    [Fact]
+    public void FinalReportSatisfies_when_final_does_not_match_throws()
+    {
+        var capture = new ProgressCapture<int>();
+        Report(capture, 100);
+        Report(capture, 50);
+
+        Assert.ThrowsAny<XunitException>(() =>
+            ProgressAssert.FinalReportSatisfies(capture, v => v == 100));
+    }
+
+
+
+    /// <summary>
+    /// Verifies that <see cref="ProgressAssert.FinalReportSatisfies{T}"/> fails clearly when
+    /// there are no reports.
+    /// </summary>
+    [Fact]
+    public void FinalReportSatisfies_when_no_reports_throws()
+    {
+        var capture = new ProgressCapture<int>();
+
+        Assert.ThrowsAny<XunitException>(() =>
+            ProgressAssert.FinalReportSatisfies(capture, _ => true));
+    }
+
+
+
+    /// <summary>
+    /// Verifies that <see cref="ProgressAssert.FinalReportSatisfies{T}"/> guards against a
+    /// null capture.
+    /// </summary>
+    [Fact]
+    public void FinalReportSatisfies_when_capture_null_throws_ArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            ProgressAssert.FinalReportSatisfies<int>(null!, _ => true));
+    }
+
+
+
+    /// <summary>
+    /// Verifies that <see cref="ProgressAssert.FinalReportSatisfies{T}"/> guards against a
+    /// null predicate.
+    /// </summary>
+    [Fact]
+    public void FinalReportSatisfies_when_predicate_null_throws_ArgumentNullException()
+    {
+        var capture = new ProgressCapture<int>();
+
+        Assert.Throws<ArgumentNullException>(() =>
+            ProgressAssert.FinalReportSatisfies<int>(capture, null!));
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // AllReportsSatisfy
+    // ------------------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="ProgressAssert.AllReportsSatisfy{T}"/> passes when every
+    /// report matches the predicate.
+    /// </summary>
+    [Fact]
+    public void AllReportsSatisfy_when_all_match_does_not_throw()
+    {
+        var capture = new ProgressCapture<int>();
+        Report(capture, 2);
+        Report(capture, 4);
+        Report(capture, 6);
+
+        var exception = Record.Exception(() =>
+            ProgressAssert.AllReportsSatisfy(capture, v => v % 2 == 0));
+
+        Assert.Null(exception);
+    }
+
+
+
+    /// <summary>
+    /// Verifies that <see cref="ProgressAssert.AllReportsSatisfy{T}"/> fails when any report
+    /// does not match the predicate.
+    /// </summary>
+    [Fact]
+    public void AllReportsSatisfy_when_one_does_not_match_throws()
+    {
+        var capture = new ProgressCapture<int>();
+        Report(capture, 2);
+        Report(capture, 3);
+        Report(capture, 4);
+
+        Assert.ThrowsAny<XunitException>(() =>
+            ProgressAssert.AllReportsSatisfy(capture, v => v % 2 == 0));
+    }
+
+
+
+    /// <summary>
+    /// Verifies that <see cref="ProgressAssert.AllReportsSatisfy{T}"/> guards against a null
+    /// capture.
+    /// </summary>
+    [Fact]
+    public void AllReportsSatisfy_when_capture_null_throws_ArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            ProgressAssert.AllReportsSatisfy<int>(null!, _ => true));
+    }
+
+
+
+    /// <summary>
+    /// Verifies that <see cref="ProgressAssert.AllReportsSatisfy{T}"/> guards against a null
+    /// predicate.
+    /// </summary>
+    [Fact]
+    public void AllReportsSatisfy_when_predicate_null_throws_ArgumentNullException()
+    {
+        var capture = new ProgressCapture<int>();
+
+        Assert.Throws<ArgumentNullException>(() =>
+            ProgressAssert.AllReportsSatisfy<int>(capture, null!));
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // End-to-end with a real TestExtractor
+    // ------------------------------------------------------------------
+
+    /// <summary>
+    /// Drives a real <see cref="TestExtractor{T}"/> through
+    /// <c>ExtractAsync(IProgress&lt;Report&gt;)</c> with a <see cref="ProgressCapture{T}"/>
+    /// and verifies the captured progress is monotonically increasing with a sensible final
+    /// item count.
+    /// </summary>
+    [Fact]
+    public async Task ProgressCapture_with_TestExtractor_captures_monotonic_progress_Async()
+    {
+        var items = Enumerable.Range(1, 50).ToList();
+        var extractor = new TestExtractor<int>(items);
+        var capture = new ProgressCapture<Report>();
+
+        var extracted = await extractor.ExtractAsync(capture).ToListAsync().ConfigureAwait(false);
+
+        Assert.Equal(items, extracted);
+        ProgressAssert.HasReports(capture);
+        ProgressAssert.IsMonotonicallyIncreasing(capture, r => r.CurrentItemCount);
+        ProgressAssert.AllReportsSatisfy(capture, r => r.CurrentItemCount >= 0);
+        ProgressAssert.FinalReportSatisfies(capture, r => r.CurrentItemCount == items.Count);
+    }
+}

--- a/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/ProgressCaptureTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/ProgressCaptureTests.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Collections.Generic;
+using Wolfgang.Etl.TestKit.Xunit;
+using Xunit;
+
+namespace Wolfgang.Etl.TestKit.Xunit.Tests.Unit;
+
+/// <summary>
+/// Unit tests for <see cref="ProgressCapture{T}"/>.
+/// </summary>
+public class ProgressCaptureTests
+{
+    /// <summary>
+    /// Casts a <see cref="ProgressCapture{T}"/> to <see cref="IProgress{T}"/> so its
+    /// explicitly-implemented <see cref="IProgress{T}.Report"/> can be invoked.
+    /// </summary>
+    private static void Report<T>(ProgressCapture<T> capture, T value) =>
+        ((IProgress<T>)capture).Report(value);
+
+
+
+    /// <summary>
+    /// Verifies that a freshly created capture has captured no reports.
+    /// </summary>
+    [Fact]
+    public void Reports_when_nothing_reported_is_empty()
+    {
+        var capture = new ProgressCapture<int>();
+
+        Assert.Empty(capture.Reports);
+    }
+
+
+
+    /// <summary>
+    /// Verifies that <see cref="ProgressCapture{T}.Count"/> is zero before any report.
+    /// </summary>
+    [Fact]
+    public void Count_when_nothing_reported_is_zero()
+    {
+        var capture = new ProgressCapture<int>();
+
+        Assert.Equal(0, capture.Count);
+    }
+
+
+
+    /// <summary>
+    /// Verifies that <see cref="ProgressCapture{T}.FinalReport"/> is the default value of a
+    /// value type when nothing has been reported.
+    /// </summary>
+    [Fact]
+    public void FinalReport_when_nothing_reported_is_default_value_type()
+    {
+        var capture = new ProgressCapture<int>();
+
+        Assert.Equal(0, capture.FinalReport);
+    }
+
+
+
+    /// <summary>
+    /// Verifies that <see cref="ProgressCapture{T}.FinalReport"/> is <see langword="null"/>
+    /// for a reference type when nothing has been reported.
+    /// </summary>
+    [Fact]
+    public void FinalReport_when_nothing_reported_is_null_reference_type()
+    {
+        var capture = new ProgressCapture<string>();
+
+        Assert.Null(capture.FinalReport);
+    }
+
+
+
+    /// <summary>
+    /// Verifies that reports are recorded in the order they are reported.
+    /// </summary>
+    [Fact]
+    public void Reports_records_values_in_order()
+    {
+        var capture = new ProgressCapture<int>();
+
+        Report(capture, 1);
+        Report(capture, 2);
+        Report(capture, 3);
+
+        Assert.Equal(new[] { 1, 2, 3 }, capture.Reports);
+    }
+
+
+
+    /// <summary>
+    /// Verifies that <see cref="ProgressCapture{T}.Count"/> reflects the number of reports.
+    /// </summary>
+    [Fact]
+    public void Count_reflects_number_of_reports()
+    {
+        var capture = new ProgressCapture<int>();
+
+        Report(capture, 10);
+        Report(capture, 20);
+
+        Assert.Equal(2, capture.Count);
+    }
+
+
+
+    /// <summary>
+    /// Verifies that <see cref="ProgressCapture{T}.FinalReport"/> returns the last value.
+    /// </summary>
+    [Fact]
+    public void FinalReport_returns_last_reported_value()
+    {
+        var capture = new ProgressCapture<int>();
+
+        Report(capture, 5);
+        Report(capture, 6);
+        Report(capture, 7);
+
+        Assert.Equal(7, capture.FinalReport);
+    }
+
+
+
+    /// <summary>
+    /// Verifies that the explicit <see cref="IProgress{T}.Report"/> implementation runs
+    /// synchronously on the calling thread.
+    /// </summary>
+    [Fact]
+    public void Report_runs_synchronously_on_calling_thread()
+    {
+        var capture = new ProgressCapture<int>();
+
+        Report(capture, 42);
+
+        // If Report were posted to another thread, the value would not be visible yet.
+        Assert.Equal(1, capture.Count);
+    }
+}


### PR DESCRIPTION
Implements #14 (Progress Assertion Helpers) in `Wolfgang.Etl.TestKit.Xunit`.

## What's new

### `ProgressCapture<T> : IProgress<T>` (`ProgressCapture.cs`)
A capturing, synchronous `IProgress<T>` (reports on the calling thread, like `SynchronousProgress<T>`) that records every reported value:
- `IReadOnlyList<T> Reports` — all captured reports, in order (returns a snapshot)
- `T? FinalReport` — last report, or `default` if none
- `int Count` — number of captured reports
- explicit `void IProgress<T>.Report(T value)` — appends under a lock

Replaces the manual `new List<T>()` + `new SynchronousProgress<T>(r => list.Add(r))` wiring downstream suites repeat. `SynchronousProgress<T>` is left in place (still used by the contract bases); `ProgressCapture<T>` is a separate opt-in utility.

### `ProgressAssert` (static) (`ProgressAssert.cs`)
The five v1 assertions from the issue, each null-guarding its args (`ArgumentNullException`) and throwing xUnit assertion exceptions via `Assert.*` (no custom exception type):
- `HasReports<T>(ProgressCapture<T>)`
- `HasExactly<T>(ProgressCapture<T>, int count)`
- `IsMonotonicallyIncreasing<T, TKey>(ProgressCapture<T>, Func<T, TKey>) where TKey : IComparable<TKey>` — reports the breaking index in the failure message
- `FinalReportSatisfies<T>(ProgressCapture<T>, Func<T, bool>)` — fails clearly when there are zero reports
- `AllReportsSatisfy<T>(ProgressCapture<T>, Func<T, bool>)` — reports the breaking index

## Design decision — Option B (static asserts)
Implemented the static `ProgressAssert` class (Option B), not the fluent Option A: simpler, lower surface area, and consistent with xUnit's own `Assert.*` style, per the issue's own assessment.

## Nullable handling across TFMs
`FinalReport` is typed `T?` on an unconstrained `T`. With `<Nullable>enable</Nullable>` (set in `Directory.Build.props`), `T?` on an unconstrained type parameter is the correct "maybe-null" annotation and needs no `[MaybeNull]` attribute — it compiles cleanly with **0 warnings** across all five source TFMs (net462, net481, netstandard2.0, net8.0, net10.0) under treat-warnings-as-errors.

## Build & test
- `dotnet build src/Wolfgang.Etl.TestKit.Xunit/...csproj -c Release` → **0 warnings, 0 errors** (all 5 TFMs)
- `dotnet test tests/...Xunit.Tests.Unit -c Release -f net8.0` (new tests) → **28 passed, 0 failed**
- Coverage includes a realistic end-to-end test driving a real `TestExtractor<int>` through `ExtractAsync(capture)` and asserting monotonic `CurrentItemCount` + final count, plus passing/failing cases and null-arg guards for every assertion.

## PublicAPI follow-up (PR #166 not yet merged)
No `PublicAPI.*.txt` files were created (baseline lands with #166). After #166 merges, add these to `src/Wolfgang.Etl.TestKit.Xunit/PublicAPI.Unshipped.txt`:

```
Wolfgang.Etl.TestKit.Xunit.ProgressCapture<T>
Wolfgang.Etl.TestKit.Xunit.ProgressCapture<T>.ProgressCapture() -> void
Wolfgang.Etl.TestKit.Xunit.ProgressCapture<T>.Reports.get -> System.Collections.Generic.IReadOnlyList<T>!
Wolfgang.Etl.TestKit.Xunit.ProgressCapture<T>.FinalReport.get -> T?
Wolfgang.Etl.TestKit.Xunit.ProgressCapture<T>.Count.get -> int
Wolfgang.Etl.TestKit.Xunit.ProgressAssert
static Wolfgang.Etl.TestKit.Xunit.ProgressAssert.HasReports<T>(Wolfgang.Etl.TestKit.Xunit.ProgressCapture<T>! capture) -> void
static Wolfgang.Etl.TestKit.Xunit.ProgressAssert.HasExactly<T>(Wolfgang.Etl.TestKit.Xunit.ProgressCapture<T>! capture, int count) -> void
static Wolfgang.Etl.TestKit.Xunit.ProgressAssert.IsMonotonicallyIncreasing<T, TKey>(Wolfgang.Etl.TestKit.Xunit.ProgressCapture<T>! capture, System.Func<T, TKey>! selector) -> void
static Wolfgang.Etl.TestKit.Xunit.ProgressAssert.FinalReportSatisfies<T>(Wolfgang.Etl.TestKit.Xunit.ProgressCapture<T>! capture, System.Func<T, bool>! predicate) -> void
static Wolfgang.Etl.TestKit.Xunit.ProgressAssert.AllReportsSatisfy<T>(Wolfgang.Etl.TestKit.Xunit.ProgressCapture<T>! capture, System.Func<T, bool>! predicate) -> void
```

Note: the explicit interface implementation `IProgress<T>.Report` is not a public API entry.

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)