### PR TITLE
feat: add opt-in idempotency contract test base classes (#15)

### DIFF
--- a/src/Wolfgang.Etl.TestKit.Xunit/IdempotentExtractorContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/IdempotentExtractorContractTests.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+using Xunit;
+
+namespace Wolfgang.Etl.TestKit.Xunit;
+
+/// <summary>
+/// Abstract base class providing opt-in xUnit idempotency contract tests for any type that
+/// implements <see cref="IExtractWithProgressAsync{TSource, TProgress}"/>.
+/// </summary>
+/// <typeparam name="TSut">
+/// The type under test. Must implement
+/// <see cref="IExtractWithProgressAsync{TItem, TProgress}"/>.
+/// </typeparam>
+/// <typeparam name="TItem">The type of item the extractor yields.</typeparam>
+/// <typeparam name="TProgress">The type of the progress report.</typeparam>
+/// <remarks>
+/// <para>
+/// <b>This base class is opt-in.</b> Inherit from it <em>only</em> if your extractor supports
+/// being run more than once on the <em>same</em> instance and is expected to produce the same
+/// result each time (idempotent extraction). Single-use components — for example a
+/// stream-backed extractor that consumes a forward-only source on its first run — must
+/// <em>not</em> inherit this class, because a second extraction would observe an exhausted
+/// source rather than a repeatable one.
+/// </para>
+/// <para>
+/// Each test calls <see cref="CreateSut(int)"/> exactly once and then exercises the SUT twice,
+/// asserting that the second run behaves identically to the first.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// public class MyExtractorIdempotencyTests
+///     : IdempotentExtractorContractTests&lt;MyExtractor, MyRecord, Report&gt;
+/// {
+///     protected override MyExtractor CreateSut(int itemCount) =>
+///         new MyExtractor(GetReEnumerableTestData(), itemCount);
+///
+///     protected override IReadOnlyList&lt;MyRecord&gt; CreateExpectedItems() =>
+///         new List&lt;MyRecord&gt; { new("a"), new("b"), new("c"), new("d"), new("e") };
+/// }
+/// </code>
+/// </example>
+public abstract class IdempotentExtractorContractTests<TSut, TItem, TProgress>
+    where TSut : IExtractAsync<TItem>, IExtractWithProgressAsync<TItem, TProgress>
+    where TItem : notnull
+    where TProgress : notnull
+{
+    // NOTE: A companion test asserting that CurrentItemCount resets to zero between runs is
+    // intentionally deferred. Today CurrentItemCount is cumulative across runs on the same
+    // instance; whether it should reset is under decision in ETL-Abstractions#246. For the
+    // same reason these tests rely on the default MaximumItemCount — setting it would cause a
+    // second run to immediately hit the cumulative limit and yield nothing.
+
+    // ------------------------------------------------------------------
+    // Factory methods
+    // ------------------------------------------------------------------
+
+    /// <summary>
+    /// Creates the system under test configured to yield exactly <paramref name="itemCount"/> items.
+    /// The items yielded must match the first <paramref name="itemCount"/> items returned by
+    /// <see cref="CreateExpectedItems"/>, and must be re-yieldable so the instance can be run twice.
+    /// </summary>
+    /// <param name="itemCount">The number of items the SUT should yield. Pass 0 for an empty source.</param>
+    protected abstract TSut CreateSut(int itemCount);
+
+    private const int DefaultItemCount = 5;
+
+    /// <summary>Creates the SUT with <see cref="DefaultItemCount"/> items.</summary>
+    private TSut CreateSut() => CreateSut(DefaultItemCount);
+
+    /// <summary>
+    /// Returns the expected items that the SUT should yield when created with
+    /// <see cref="CreateSut(int)"/>. Must return at least 5 items.
+    /// </summary>
+    protected abstract IReadOnlyList<TItem> CreateExpectedItems();
+
+
+
+    // ------------------------------------------------------------------
+    // Tests
+    // ------------------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that extracting twice from the same instance yields identical items, in the
+    /// same order, on both runs.
+    /// </summary>
+    [Fact]
+    public async Task ExtractAsync_when_called_twice_yields_identical_items_Async()
+    {
+        var sut = CreateSut();
+        var expected = CreateExpectedItems();
+
+        var firstRun = await sut
+            .ExtractAsync(new Progress<TProgress>())
+            .ToListAsync()
+            .ConfigureAwait(false);
+
+        var secondRun = await sut
+            .ExtractAsync(new Progress<TProgress>())
+            .ToListAsync()
+            .ConfigureAwait(false);
+
+        Assert.Equal(expected, firstRun);
+        Assert.Equal(firstRun, secondRun);
+        Assert.Equal(expected, secondRun);
+    }
+
+
+
+    /// <summary>
+    /// Verifies that extracting twice from the same instance reports progress on each run.
+    /// </summary>
+    [Fact]
+    public async Task ExtractAsync_when_called_twice_with_progress_both_runs_report_Async()
+    {
+        var sut = CreateSut();
+
+        var firstCapture = new ProgressCapture<TProgress>();
+        await sut.ExtractAsync(firstCapture).ToListAsync().ConfigureAwait(false);
+
+        var secondCapture = new ProgressCapture<TProgress>();
+        await sut.ExtractAsync(secondCapture).ToListAsync().ConfigureAwait(false);
+
+        ProgressAssert.HasReports(firstCapture);
+        ProgressAssert.HasReports(secondCapture);
+    }
+}

--- a/src/Wolfgang.Etl.TestKit.Xunit/IdempotentLoaderContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/IdempotentLoaderContractTests.cs
@@ -1,0 +1,160 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+using Xunit;
+
+namespace Wolfgang.Etl.TestKit.Xunit;
+
+/// <summary>
+/// Abstract base class providing opt-in xUnit idempotency contract tests for any type that
+/// implements <see cref="ILoadAsync{TDestination}"/>.
+/// </summary>
+/// <typeparam name="TSut">
+/// The type under test. Must implement <see cref="ILoadAsync{TDestination}"/>.
+/// </typeparam>
+/// <typeparam name="TItem">The type of item the loader consumes.</typeparam>
+/// <remarks>
+/// <para>
+/// <b>This base class is opt-in.</b> Inherit from it <em>only</em> if your loader supports
+/// being run more than once on the <em>same</em> instance, processing the full input each time
+/// and carrying no state over from a previous run. Single-use components — for example a loader
+/// that opens a destination stream once and disposes it after the first load — must <em>not</em>
+/// inherit this class.
+/// </para>
+/// <para>
+/// Each test calls <see cref="CreateSut(int)"/> exactly once and then loads
+/// <see cref="CreateSourceItems"/> twice, asserting that the second run is unaffected by the
+/// first.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// public class MyLoaderIdempotencyTests
+///     : IdempotentLoaderContractTests&lt;MyLoader, MyRecord&gt;
+/// {
+///     protected override MyLoader CreateSut(int itemCount) =>
+///         new MyLoader(collectItems: true);
+///
+///     protected override IReadOnlyList&lt;MyRecord&gt; CreateSourceItems() =>
+///         new List&lt;MyRecord&gt; { new("a"), new("b"), new("c"), new("d"), new("e") };
+///
+///     protected override IReadOnlyList&lt;MyRecord&gt;? TryGetLoadedItems(MyLoader sut) =>
+///         sut.GetCollectedItems();
+/// }
+/// </code>
+/// </example>
+public abstract class IdempotentLoaderContractTests<TSut, TItem>
+    where TSut : ILoadAsync<TItem>
+    where TItem : notnull
+{
+    // NOTE: A companion test asserting that CurrentItemCount resets to zero between runs is
+    // intentionally deferred. Today CurrentItemCount is cumulative across runs on the same
+    // instance; whether it should reset is under decision in ETL-Abstractions#246. For the
+    // same reason these tests rely on the default MaximumItemCount — setting it would cause a
+    // second run to immediately hit the cumulative limit and load nothing.
+
+    // ------------------------------------------------------------------
+    // Factory methods
+    // ------------------------------------------------------------------
+
+    /// <summary>Creates the system under test.</summary>
+    /// <param name="itemCount">
+    /// The number of items the SUT is sized for. Pass 0 for an empty source.
+    /// </param>
+    protected abstract TSut CreateSut(int itemCount);
+
+    private const int DefaultItemCount = 5;
+
+    /// <summary>Creates the SUT with <see cref="DefaultItemCount"/> items.</summary>
+    private TSut CreateSut() => CreateSut(DefaultItemCount);
+
+    /// <summary>
+    /// Returns the source items used to feed the loader. Must return at least 5 items.
+    /// </summary>
+    protected abstract IReadOnlyList<TItem> CreateSourceItems();
+
+    /// <summary>
+    /// Returns the items collected by <paramref name="sut"/> during the most recent load, or
+    /// <see langword="null"/> if the loader does not collect items.
+    /// </summary>
+    /// <remarks>
+    /// Override to return the loader's collected snapshot (for example
+    /// <c>sut.GetCollectedItems()</c>). When this returns <see langword="null"/> the
+    /// no-state-leak test treats the loader as non-collecting and skips its collection check.
+    /// </remarks>
+    /// <param name="sut">The system under test, after a load has completed.</param>
+    protected abstract IReadOnlyList<TItem>? TryGetLoadedItems(TSut sut);
+
+
+
+    // ------------------------------------------------------------------
+    // Tests
+    // ------------------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that loading the same source twice into the same instance processes all input
+    /// items on both runs.
+    /// </summary>
+    [Fact]
+    public async Task LoadAsync_when_called_twice_processes_all_items_both_times_Async()
+    {
+        var sut = CreateSut();
+        var source = CreateSourceItems();
+
+        var firstException = await Record.ExceptionAsync
+        (
+            () => sut.LoadAsync(source.ToAsyncEnumerable())
+        ).ConfigureAwait(false);
+
+        Assert.Null(firstException);
+
+        var firstLoaded = TryGetLoadedItems(sut);
+        if (firstLoaded is not null)
+        {
+            Assert.Equal(source.Count, firstLoaded.Count);
+        }
+
+        var secondException = await Record.ExceptionAsync
+        (
+            () => sut.LoadAsync(source.ToAsyncEnumerable())
+        ).ConfigureAwait(false);
+
+        Assert.Null(secondException);
+
+        var secondLoaded = TryGetLoadedItems(sut);
+        if (secondLoaded is not null)
+        {
+            Assert.Equal(source.Count, secondLoaded.Count);
+        }
+    }
+
+
+
+    /// <summary>
+    /// Verifies that a collecting loader carries no state across runs: after a second load, the
+    /// collected snapshot contains only the second run's items, with no carryover from the first.
+    /// </summary>
+    [Fact]
+    public async Task LoadAsync_when_called_twice_no_state_leaks_Async()
+    {
+        var sut = CreateSut();
+        var source = CreateSourceItems();
+
+        await sut.LoadAsync(source.ToAsyncEnumerable()).ConfigureAwait(false);
+
+        var afterFirstRun = TryGetLoadedItems(sut);
+        if (afterFirstRun is null)
+        {
+            // Non-collecting loader: there is no snapshot to inspect for carryover.
+            return;
+        }
+
+        await sut.LoadAsync(source.ToAsyncEnumerable()).ConfigureAwait(false);
+
+        var afterSecondRun = TryGetLoadedItems(sut);
+
+        Assert.NotNull(afterSecondRun);
+        Assert.Equal(source, afterSecondRun);
+    }
+}

--- a/src/Wolfgang.Etl.TestKit.Xunit/IdempotentTransformerContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/IdempotentTransformerContractTests.cs
@@ -1,0 +1,131 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+using Xunit;
+
+namespace Wolfgang.Etl.TestKit.Xunit;
+
+/// <summary>
+/// Abstract base class providing opt-in xUnit idempotency contract tests for any type that
+/// implements <see cref="ITransformAsync{TSource, TDestination}"/>.
+/// </summary>
+/// <typeparam name="TSut">
+/// The type under test. Must implement <see cref="ITransformAsync{TSource, TDestination}"/>.
+/// </typeparam>
+/// <typeparam name="TItem">The type of item the transformer consumes and produces.</typeparam>
+/// <remarks>
+/// <para>
+/// <b>This base class is opt-in.</b> Inherit from it <em>only</em> if your transformer supports
+/// being run more than once on the <em>same</em> instance and produces the same output for the
+/// same input each time, with no accumulated side effects. Single-use components — for example a
+/// transformer that maintains running state intended to span a single pipeline — must
+/// <em>not</em> inherit this class.
+/// </para>
+/// <para>
+/// Each test calls <see cref="CreateSut(int)"/> exactly once and then transforms the same input
+/// twice, asserting that the second run is unaffected by the first.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// public class MyTransformerIdempotencyTests
+///     : IdempotentTransformerContractTests&lt;MyTransformer, MyRecord&gt;
+/// {
+///     protected override MyTransformer CreateSut(int itemCount) =>
+///         new MyTransformer();
+///
+///     protected override IReadOnlyList&lt;MyRecord&gt; CreateExpectedItems() =>
+///         new List&lt;MyRecord&gt; { new("a"), new("b"), new("c"), new("d"), new("e") };
+/// }
+/// </code>
+/// </example>
+public abstract class IdempotentTransformerContractTests<TSut, TItem>
+    where TSut : ITransformAsync<TItem, TItem>
+    where TItem : notnull
+{
+    // NOTE: A companion test asserting that CurrentItemCount resets to zero between runs is
+    // intentionally deferred. Today CurrentItemCount is cumulative across runs on the same
+    // instance; whether it should reset is under decision in ETL-Abstractions#246. For the
+    // same reason these tests rely on the default MaximumItemCount — setting it would cause a
+    // second run to immediately hit the cumulative limit and yield nothing.
+
+    // ------------------------------------------------------------------
+    // Factory methods
+    // ------------------------------------------------------------------
+
+    /// <summary>Creates the system under test.</summary>
+    /// <param name="itemCount">
+    /// The number of items the SUT is sized for. Pass 0 for an empty source.
+    /// </param>
+    protected abstract TSut CreateSut(int itemCount);
+
+    private const int DefaultItemCount = 5;
+
+    /// <summary>Creates the SUT with <see cref="DefaultItemCount"/> items.</summary>
+    private TSut CreateSut() => CreateSut(DefaultItemCount);
+
+    /// <summary>
+    /// Returns the items used as input to the transformer and expected back unchanged. Must
+    /// return at least 5 items.
+    /// </summary>
+    protected abstract IReadOnlyList<TItem> CreateExpectedItems();
+
+
+
+    // ------------------------------------------------------------------
+    // Tests
+    // ------------------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that transforming the same input twice on the same instance yields identical
+    /// output, in the same order, on both runs.
+    /// </summary>
+    [Fact]
+    public async Task TransformAsync_when_called_twice_yields_identical_items_Async()
+    {
+        var sut = CreateSut();
+        var expected = CreateExpectedItems();
+
+        var firstRun = await sut
+            .TransformAsync(expected.ToAsyncEnumerable())
+            .ToListAsync()
+            .ConfigureAwait(false);
+
+        var secondRun = await sut
+            .TransformAsync(expected.ToAsyncEnumerable())
+            .ToListAsync()
+            .ConfigureAwait(false);
+
+        Assert.Equal(expected, firstRun);
+        Assert.Equal(firstRun, secondRun);
+        Assert.Equal(expected, secondRun);
+    }
+
+
+
+    /// <summary>
+    /// Verifies that a second transform run is not influenced by the first: the second run's
+    /// output shows no growth, duplication, or other accumulated side effect.
+    /// </summary>
+    [Fact]
+    public async Task TransformAsync_when_called_twice_no_accumulated_side_effects_Async()
+    {
+        var sut = CreateSut();
+        var input = CreateExpectedItems();
+
+        var firstRun = await sut
+            .TransformAsync(input.ToAsyncEnumerable())
+            .ToListAsync()
+            .ConfigureAwait(false);
+
+        var secondRun = await sut
+            .TransformAsync(input.ToAsyncEnumerable())
+            .ToListAsync()
+            .ConfigureAwait(false);
+
+        Assert.Equal(firstRun.Count, secondRun.Count);
+        Assert.Equal(input.Count, secondRun.Count);
+        Assert.Equal(firstRun, secondRun);
+    }
+}

--- a/src/Wolfgang.Etl.TestKit.Xunit/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.TestKit.Xunit/PublicAPI.Unshipped.txt
@@ -10,3 +10,22 @@ static Wolfgang.Etl.TestKit.Xunit.ProgressAssert.FinalReportSatisfies<T>(Wolfgan
 static Wolfgang.Etl.TestKit.Xunit.ProgressAssert.HasExactly<T>(Wolfgang.Etl.TestKit.Xunit.ProgressCapture<T>! capture, int count) -> void
 static Wolfgang.Etl.TestKit.Xunit.ProgressAssert.HasReports<T>(Wolfgang.Etl.TestKit.Xunit.ProgressCapture<T>! capture) -> void
 static Wolfgang.Etl.TestKit.Xunit.ProgressAssert.IsMonotonicallyIncreasing<T, TKey>(Wolfgang.Etl.TestKit.Xunit.ProgressCapture<T>! capture, System.Func<T, TKey>! selector) -> void
+Wolfgang.Etl.TestKit.Xunit.IdempotentExtractorContractTests<TSut, TItem, TProgress>
+Wolfgang.Etl.TestKit.Xunit.IdempotentExtractorContractTests<TSut, TItem, TProgress>.IdempotentExtractorContractTests() -> void
+Wolfgang.Etl.TestKit.Xunit.IdempotentExtractorContractTests<TSut, TItem, TProgress>.ExtractAsync_when_called_twice_yields_identical_items_Async() -> System.Threading.Tasks.Task!
+Wolfgang.Etl.TestKit.Xunit.IdempotentExtractorContractTests<TSut, TItem, TProgress>.ExtractAsync_when_called_twice_with_progress_both_runs_report_Async() -> System.Threading.Tasks.Task!
+abstract Wolfgang.Etl.TestKit.Xunit.IdempotentExtractorContractTests<TSut, TItem, TProgress>.CreateSut(int itemCount) -> TSut
+abstract Wolfgang.Etl.TestKit.Xunit.IdempotentExtractorContractTests<TSut, TItem, TProgress>.CreateExpectedItems() -> System.Collections.Generic.IReadOnlyList<TItem>!
+Wolfgang.Etl.TestKit.Xunit.IdempotentLoaderContractTests<TSut, TItem>
+Wolfgang.Etl.TestKit.Xunit.IdempotentLoaderContractTests<TSut, TItem>.IdempotentLoaderContractTests() -> void
+Wolfgang.Etl.TestKit.Xunit.IdempotentLoaderContractTests<TSut, TItem>.LoadAsync_when_called_twice_processes_all_items_both_times_Async() -> System.Threading.Tasks.Task!
+Wolfgang.Etl.TestKit.Xunit.IdempotentLoaderContractTests<TSut, TItem>.LoadAsync_when_called_twice_no_state_leaks_Async() -> System.Threading.Tasks.Task!
+abstract Wolfgang.Etl.TestKit.Xunit.IdempotentLoaderContractTests<TSut, TItem>.CreateSut(int itemCount) -> TSut
+abstract Wolfgang.Etl.TestKit.Xunit.IdempotentLoaderContractTests<TSut, TItem>.CreateSourceItems() -> System.Collections.Generic.IReadOnlyList<TItem>!
+abstract Wolfgang.Etl.TestKit.Xunit.IdempotentLoaderContractTests<TSut, TItem>.TryGetLoadedItems(TSut sut) -> System.Collections.Generic.IReadOnlyList<TItem>?
+Wolfgang.Etl.TestKit.Xunit.IdempotentTransformerContractTests<TSut, TItem>
+Wolfgang.Etl.TestKit.Xunit.IdempotentTransformerContractTests<TSut, TItem>.IdempotentTransformerContractTests() -> void
+Wolfgang.Etl.TestKit.Xunit.IdempotentTransformerContractTests<TSut, TItem>.TransformAsync_when_called_twice_yields_identical_items_Async() -> System.Threading.Tasks.Task!
+Wolfgang.Etl.TestKit.Xunit.IdempotentTransformerContractTests<TSut, TItem>.TransformAsync_when_called_twice_no_accumulated_side_effects_Async() -> System.Threading.Tasks.Task!
+abstract Wolfgang.Etl.TestKit.Xunit.IdempotentTransformerContractTests<TSut, TItem>.CreateSut(int itemCount) -> TSut
+abstract Wolfgang.Etl.TestKit.Xunit.IdempotentTransformerContractTests<TSut, TItem>.CreateExpectedItems() -> System.Collections.Generic.IReadOnlyList<TItem>!

--- a/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/TestExtractorIdempotencyTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/TestExtractorIdempotencyTests.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using System.Linq;
+using Wolfgang.Etl.Abstractions;
+
+namespace Wolfgang.Etl.TestKit.Xunit.Tests.Unit;
+
+public class TestExtractorIdempotencyTests
+    : IdempotentExtractorContractTests<TestExtractor<int>, int, Report>
+{
+    protected override TestExtractor<int> CreateSut(int itemCount) =>
+        new TestExtractor<int>(Enumerable.Range(1, itemCount).ToList());
+
+    protected override IReadOnlyList<int> CreateExpectedItems() =>
+        Enumerable.Range(1, 5).ToList();
+}

--- a/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/TestLoaderIdempotencyTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/TestLoaderIdempotencyTests.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Wolfgang.Etl.TestKit.Xunit.Tests.Unit;
+
+public class TestLoaderIdempotencyTests
+    : IdempotentLoaderContractTests<TestLoader<int>, int>
+{
+    protected override TestLoader<int> CreateSut(int itemCount) =>
+        new TestLoader<int>(collectItems: true);
+
+    protected override IReadOnlyList<int> CreateSourceItems() =>
+        Enumerable.Range(1, 5).ToList();
+
+    protected override IReadOnlyList<int>? TryGetLoadedItems(TestLoader<int> sut) =>
+        sut?.GetCollectedItems();
+}

--- a/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/TestTransformerIdempotencyTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/TestTransformerIdempotencyTests.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Wolfgang.Etl.TestKit.Xunit.Tests.Unit;
+
+public class TestTransformerIdempotencyTests
+    : IdempotentTransformerContractTests<TestTransformer<int>, int>
+{
+    protected override TestTransformer<int> CreateSut(int itemCount) =>
+        new TestTransformer<int>();
+
+    protected override IReadOnlyList<int> CreateExpectedItems() =>
+        Enumerable.Range(1, 5).ToList();
+}


### PR DESCRIPTION
## Summary

Implements #15 — opt-in idempotency contract tests for the `Wolfgang.Etl.TestKit.Xunit` package. Three abstract base classes verify that an ETL component produces identical results when run **twice on the same instance**.

### Base classes (3)

| Class | Constraint | Abstract members |
|-------|-----------|------------------|
| `IdempotentExtractorContractTests<TSut, TItem, TProgress>` | `TSut : IExtractAsync<TItem>, IExtractWithProgressAsync<TItem, TProgress>` | `CreateSut(int)`, `CreateExpectedItems()` |
| `IdempotentLoaderContractTests<TSut, TItem>` | `TSut : ILoadAsync<TItem>` | `CreateSut(int)`, `CreateSourceItems()`, `TryGetLoadedItems(TSut)` |
| `IdempotentTransformerContractTests<TSut, TItem>` | `TSut : ITransformAsync<TItem, TItem>` | `CreateSut(int)`, `CreateExpectedItems()` |

All carry `TItem : notnull` / `TProgress : notnull`, matching the existing contract bases.

### Tests (6 — 2 per base)

1. `ExtractAsync_when_called_twice_yields_identical_items_Async`
2. `ExtractAsync_when_called_twice_with_progress_both_runs_report_Async`
3. `LoadAsync_when_called_twice_processes_all_items_both_times_Async`
4. `LoadAsync_when_called_twice_no_state_leaks_Async`
5. `TransformAsync_when_called_twice_yields_identical_items_Async`
6. `TransformAsync_when_called_twice_no_accumulated_side_effects_Async`

Each calls `CreateSut(...)` once and exercises the SUT twice. Consumer concrete subclasses (`TestExtractorIdempotencyTests`, `TestLoaderIdempotencyTests`, `TestTransformerIdempotencyTests`) wire the real TestKit doubles so the contracts execute in CI — the loader subclass uses a **collecting** `TestLoader<int>` so test #4 is meaningful.

### Opt-in rationale

Each base's class-level `<remarks>` documents that it is **opt-in**: inherit only if the component supports being run more than once on the same instance. Single-use components (e.g. a stream-backed extractor with a forward-only source) must not inherit it.

### Deferred (not added)

The three `*_CurrentItemCount_resets_*` tests from the issue draft are **intentionally deferred**. Today `CurrentItemCount` is **cumulative** across runs; the reset-vs-cumulative contract is under decision in **ETL-Abstractions#246**. A `// NOTE:` comment in each base records this. Because the count is cumulative, the tests deliberately do **not** set `MaximumItemCount` (a second run would immediately hit a cumulative limit and yield nothing) and rely on default limits.

### Design notes / deviation from the issue draft

The repo's real contract bases are **interface-constrained** (`IExtractAsync`, `ILoadAsync`, `ITransformAsync`), not `ExtractorBase`/`TProgress`-based. These new bases mirror that reality:
- Extractor needs both the parameterless and progress-aware extract methods (the interfaces are segregated in Abstractions 0.13.1), so it constrains to both `IExtractAsync<TItem>` and `IExtractWithProgressAsync<TItem, TProgress>`.
- The loader base omits `TProgress` (its two tests don't use progress) to avoid an unused public type parameter, matching the shape of `LoadAsyncContractTests<TSut, TItem>`.
- Loader test #4 reads the collected snapshot via a new abstract `TryGetLoadedItems(TSut)` hook (returns `null` for non-collecting loaders, in which case the carryover check is skipped) so the base does not depend on the concrete `TestLoader`.

### PublicAPI.Unshipped.txt entries added

```
Wolfgang.Etl.TestKit.Xunit.IdempotentExtractorContractTests<TSut, TItem, TProgress>
Wolfgang.Etl.TestKit.Xunit.IdempotentExtractorContractTests<TSut, TItem, TProgress>.IdempotentExtractorContractTests() -> void
Wolfgang.Etl.TestKit.Xunit.IdempotentExtractorContractTests<TSut, TItem, TProgress>.ExtractAsync_when_called_twice_yields_identical_items_Async() -> System.Threading.Tasks.Task!
Wolfgang.Etl.TestKit.Xunit.IdempotentExtractorContractTests<TSut, TItem, TProgress>.ExtractAsync_when_called_twice_with_progress_both_runs_report_Async() -> System.Threading.Tasks.Task!
abstract Wolfgang.Etl.TestKit.Xunit.IdempotentExtractorContractTests<TSut, TItem, TProgress>.CreateSut(int itemCount) -> TSut
abstract Wolfgang.Etl.TestKit.Xunit.IdempotentExtractorContractTests<TSut, TItem, TProgress>.CreateExpectedItems() -> System.Collections.Generic.IReadOnlyList<TItem>!
Wolfgang.Etl.TestKit.Xunit.IdempotentLoaderContractTests<TSut, TItem>
Wolfgang.Etl.TestKit.Xunit.IdempotentLoaderContractTests<TSut, TItem>.IdempotentLoaderContractTests() -> void
Wolfgang.Etl.TestKit.Xunit.IdempotentLoaderContractTests<TSut, TItem>.LoadAsync_when_called_twice_processes_all_items_both_times_Async() -> System.Threading.Tasks.Task!
Wolfgang.Etl.TestKit.Xunit.IdempotentLoaderContractTests<TSut, TItem>.LoadAsync_when_called_twice_no_state_leaks_Async() -> System.Threading.Tasks.Task!
abstract Wolfgang.Etl.TestKit.Xunit.IdempotentLoaderContractTests<TSut, TItem>.CreateSut(int itemCount) -> TSut
abstract Wolfgang.Etl.TestKit.Xunit.IdempotentLoaderContractTests<TSut, TItem>.CreateSourceItems() -> System.Collections.Generic.IReadOnlyList<TItem>!
abstract Wolfgang.Etl.TestKit.Xunit.IdempotentLoaderContractTests<TSut, TItem>.TryGetLoadedItems(TSut sut) -> System.Collections.Generic.IReadOnlyList<TItem>?
Wolfgang.Etl.TestKit.Xunit.IdempotentTransformerContractTests<TSut, TItem>
Wolfgang.Etl.TestKit.Xunit.IdempotentTransformerContractTests<TSut, TItem>.IdempotentTransformerContractTests() -> void
Wolfgang.Etl.TestKit.Xunit.IdempotentTransformerContractTests<TSut, TItem>.TransformAsync_when_called_twice_yields_identical_items_Async() -> System.Threading.Tasks.Task!
Wolfgang.Etl.TestKit.Xunit.IdempotentTransformerContractTests<TSut, TItem>.TransformAsync_when_called_twice_no_accumulated_side_effects_Async() -> System.Threading.Tasks.Task!
abstract Wolfgang.Etl.TestKit.Xunit.IdempotentTransformerContractTests<TSut, TItem>.CreateSut(int itemCount) -> TSut
abstract Wolfgang.Etl.TestKit.Xunit.IdempotentTransformerContractTests<TSut, TItem>.CreateExpectedItems() -> System.Collections.Generic.IReadOnlyList<TItem>!
```

### Build / test results

- `dotnet build src/Wolfgang.Etl.TestKit.Xunit -c Release` — **succeeded, 0 warnings / 0 errors** across all TFMs (net462; netstandard2.0; net481; net8.0; net10.0). PublicAPI analyzer (RS0016) clean.
- `dotnet test tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit -c Release -f net8.0` — **233 passed, 0 failed** (227 → 233; the 6 new idempotency tests all green).

> Note: `Closes #15` won't auto-fire on a merge into `vNext`; the issue stays open until `vNext` merges to `main`.

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)
