### PR TITLE
deps: bump Wolfgang.Etl.Abstractions 0.13.1 -> 0.14.0

### DIFF
--- a/src/Wolfgang.Etl.TestKit.Xunit/Wolfgang.Etl.TestKit.Xunit.csproj
+++ b/src/Wolfgang.Etl.TestKit.Xunit/Wolfgang.Etl.TestKit.Xunit.csproj
@@ -70,7 +70,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Bcl.Memory" Version="10.0.9" />
-    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.13.1" />
+    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.14.0" />
     <PackageReference Include="System.Linq.Async" Version="7.0.1" />
     <PackageReference Include="xunit.abstractions" Version="2.0.3" />
     <PackageReference Include="xunit.assert" Version="2.9.3" />

--- a/src/Wolfgang.Etl.TestKit/Wolfgang.Etl.TestKit.csproj
+++ b/src/Wolfgang.Etl.TestKit/Wolfgang.Etl.TestKit.csproj
@@ -65,7 +65,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Bcl.Memory" Version="10.0.9" />
-    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.13.1" />
+    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.14.0" />
     <PackageReference Include="System.Linq.Async" Version="7.0.1" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
Bumps `Wolfgang.Etl.Abstractions` from **0.13.1 → 0.14.0** (newly published to NuGet) in both source projects:
- `src/Wolfgang.Etl.TestKit/Wolfgang.Etl.TestKit.csproj`
- `src/Wolfgang.Etl.TestKit.Xunit/Wolfgang.Etl.TestKit.Xunit.csproj`

The TestKit package `<Version>` is intentionally left at 0.8.1 (the release PR handles versioning).

## Transitive restore
No cascade. `dotnet restore` on both projects was clean — no NU1605/downgrade, no Microsoft.Bcl.* / System.Linq.Async / System.Linq.AsyncEnumerable conflicts. No new direct PackageReferences were added.

## Build & analyzer fallout
None. Both src projects build clean in Release across all TFMs (net462;netstandard2.0;net8.0;net10.0;net481), **0 warnings / 0 errors** with treat-warnings-as-errors ON.

Although the Abstractions base classes now implement `IDisposable`/`IAsyncDisposable`, no disposal analyzer (CA1063/CA2213/CA1816/etc.) fired on any of the doubles. **No `Dispose(bool)` override was added** and **no disposal redesign was done** — the diff is the version bump only.

## PublicAPI
No `PublicAPI.Unshipped.txt` entries needed — no new public/protected members were declared in these assemblies. (Inherited `Dispose`/`DisposeAsync` from the base are tracked by Abstractions, not here.)

## Per-run reset note (ETL-Abstractions#246)
0.14.0 resets `CurrentItemCount`/`CurrentSkippedItemCount` and timing at the start of each run. Contract tests create a fresh SUT per test, so they're unaffected. The repo's idempotency tests (`TestExtractor`/`TestLoader`/`TestTransformer`IdempotencyTests) run twice on a single instance and assert **output** identity (not cumulative counts) — they still pass. The #15 deferred reset tests are now implementable as a follow-up (not included here, to keep this diff minimal).

## Test results (Release, net8.0)
- `Wolfgang.Etl.TestKit.Tests.Unit`: **122 passed**, 0 failed
- `Wolfgang.Etl.TestKit.Xunit.Tests.Unit`: **233 passed**, 0 failed (includes idempotency tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
