### PR TITLE
test: add CurrentItemCount per-run reset tests to idempotency bases (#15)

### DIFF
--- a/src/Wolfgang.Etl.TestKit.Xunit/IdempotentExtractorContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/IdempotentExtractorContractTests.cs
@@ -45,15 +45,13 @@ namespace Wolfgang.Etl.TestKit.Xunit;
 /// </code>
 /// </example>
 public abstract class IdempotentExtractorContractTests<TSut, TItem, TProgress>
-    where TSut : IExtractAsync<TItem>, IExtractWithProgressAsync<TItem, TProgress>
+    where TSut : ExtractorBase<TItem, TProgress>, IExtractAsync<TItem>, IExtractWithProgressAsync<TItem, TProgress>
     where TItem : notnull
     where TProgress : notnull
 {
-    // NOTE: A companion test asserting that CurrentItemCount resets to zero between runs is
-    // intentionally deferred. Today CurrentItemCount is cumulative across runs on the same
-    // instance; whether it should reset is under decision in ETL-Abstractions#246. For the
-    // same reason these tests rely on the default MaximumItemCount — setting it would cause a
-    // second run to immediately hit the cumulative limit and yield nothing.
+    // CurrentItemCount resets at the start of each run as of Wolfgang.Etl.Abstractions 0.14.0
+    // (ETL-Abstractions#246). ExtractAsync_when_called_twice_CurrentItemCount_resets_Async below
+    // verifies that per-run reset. These tests rely on the default MaximumItemCount.
 
     // ------------------------------------------------------------------
     // Factory methods
@@ -127,5 +125,30 @@ public abstract class IdempotentExtractorContractTests<TSut, TItem, TProgress>
 
         ProgressAssert.HasReports(firstCapture);
         ProgressAssert.HasReports(secondCapture);
+    }
+
+
+
+    /// <summary>
+    /// Verifies that <c>CurrentItemCount</c> reflects only the most recent run: after extracting
+    /// twice from the same instance, the count equals the number of items yielded by the second
+    /// run alone, not the cumulative total across both runs.
+    /// </summary>
+    /// <remarks>
+    /// This verifies the per-run reset contract introduced in
+    /// <c>Wolfgang.Etl.Abstractions</c> 0.14.0 (ETL-Abstractions#246), where
+    /// <c>CurrentItemCount</c> and <c>CurrentSkippedItemCount</c> reset at the start of each run.
+    /// </remarks>
+    [Fact]
+    public async Task ExtractAsync_when_called_twice_CurrentItemCount_resets_Async()
+    {
+        var sut = CreateSut();
+        var expected = CreateExpectedItems();
+
+        await sut.ExtractAsync().ToListAsync().ConfigureAwait(false);
+
+        await sut.ExtractAsync().ToListAsync().ConfigureAwait(false);
+
+        Assert.Equal(expected.Count, sut.CurrentItemCount);
     }
 }

--- a/src/Wolfgang.Etl.TestKit.Xunit/IdempotentLoaderContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/IdempotentLoaderContractTests.cs
@@ -48,11 +48,9 @@ public abstract class IdempotentLoaderContractTests<TSut, TItem>
     where TSut : ILoadAsync<TItem>
     where TItem : notnull
 {
-    // NOTE: A companion test asserting that CurrentItemCount resets to zero between runs is
-    // intentionally deferred. Today CurrentItemCount is cumulative across runs on the same
-    // instance; whether it should reset is under decision in ETL-Abstractions#246. For the
-    // same reason these tests rely on the default MaximumItemCount — setting it would cause a
-    // second run to immediately hit the cumulative limit and load nothing.
+    // CurrentItemCount resets at the start of each run as of Wolfgang.Etl.Abstractions 0.14.0
+    // (ETL-Abstractions#246). LoadAsync_when_called_twice_CurrentItemCount_resets_Async below
+    // verifies that per-run reset. These tests rely on the default MaximumItemCount.
 
     // ------------------------------------------------------------------
     // Factory methods
@@ -85,6 +83,19 @@ public abstract class IdempotentLoaderContractTests<TSut, TItem>
     /// </remarks>
     /// <param name="sut">The system under test, after a load has completed.</param>
     protected abstract IReadOnlyList<TItem>? TryGetLoadedItems(TSut sut);
+
+    /// <summary>
+    /// Returns the value of <paramref name="sut"/>'s <c>CurrentItemCount</c> after a load.
+    /// </summary>
+    /// <remarks>
+    /// The default implementation reads <see cref="LoaderBase{TDestination, TProgress}.CurrentItemCount"/>
+    /// assuming the loader derives from <see cref="LoaderBase{TDestination, TProgress}"/> with a
+    /// <see cref="Report"/> progress type, which is the convention for ETL loaders. Override this
+    /// when the loader exposes its progress count through a different progress type or member.
+    /// </remarks>
+    /// <param name="sut">The system under test, after a load has completed.</param>
+    protected virtual int GetCurrentItemCount(TSut sut) =>
+        ((LoaderBase<TItem, Report>)(object)sut!).CurrentItemCount;
 
 
 
@@ -156,5 +167,30 @@ public abstract class IdempotentLoaderContractTests<TSut, TItem>
 
         Assert.NotNull(afterSecondRun);
         Assert.Equal(source, afterSecondRun);
+    }
+
+
+
+    /// <summary>
+    /// Verifies that <c>CurrentItemCount</c> reflects only the most recent run: after loading the
+    /// same source twice into the same instance, the count equals the number of items in a single
+    /// run, not the cumulative total across both runs.
+    /// </summary>
+    /// <remarks>
+    /// This verifies the per-run reset contract introduced in
+    /// <c>Wolfgang.Etl.Abstractions</c> 0.14.0 (ETL-Abstractions#246), where
+    /// <c>CurrentItemCount</c> and <c>CurrentSkippedItemCount</c> reset at the start of each run.
+    /// </remarks>
+    [Fact]
+    public async Task LoadAsync_when_called_twice_CurrentItemCount_resets_Async()
+    {
+        var sut = CreateSut();
+        var source = CreateSourceItems();
+
+        await sut.LoadAsync(source.ToAsyncEnumerable()).ConfigureAwait(false);
+
+        await sut.LoadAsync(source.ToAsyncEnumerable()).ConfigureAwait(false);
+
+        Assert.Equal(source.Count, GetCurrentItemCount(sut));
     }
 }

--- a/src/Wolfgang.Etl.TestKit.Xunit/IdempotentTransformerContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/IdempotentTransformerContractTests.cs
@@ -44,11 +44,9 @@ public abstract class IdempotentTransformerContractTests<TSut, TItem>
     where TSut : ITransformAsync<TItem, TItem>
     where TItem : notnull
 {
-    // NOTE: A companion test asserting that CurrentItemCount resets to zero between runs is
-    // intentionally deferred. Today CurrentItemCount is cumulative across runs on the same
-    // instance; whether it should reset is under decision in ETL-Abstractions#246. For the
-    // same reason these tests rely on the default MaximumItemCount — setting it would cause a
-    // second run to immediately hit the cumulative limit and yield nothing.
+    // CurrentItemCount resets at the start of each run as of Wolfgang.Etl.Abstractions 0.14.0
+    // (ETL-Abstractions#246). TransformAsync_when_called_twice_CurrentItemCount_resets_Async below
+    // verifies that per-run reset. These tests rely on the default MaximumItemCount.
 
     // ------------------------------------------------------------------
     // Factory methods
@@ -70,6 +68,20 @@ public abstract class IdempotentTransformerContractTests<TSut, TItem>
     /// return at least 5 items.
     /// </summary>
     protected abstract IReadOnlyList<TItem> CreateExpectedItems();
+
+    /// <summary>
+    /// Returns the value of <paramref name="sut"/>'s <c>CurrentItemCount</c> after a transform.
+    /// </summary>
+    /// <remarks>
+    /// The default implementation reads
+    /// <see cref="TransformerBase{TSource, TDestination, TProgress}.CurrentItemCount"/> assuming the
+    /// transformer derives from <see cref="TransformerBase{TSource, TDestination, TProgress}"/> with a
+    /// <see cref="Report"/> progress type, which is the convention for ETL transformers. Override this
+    /// when the transformer exposes its progress count through a different progress type or member.
+    /// </remarks>
+    /// <param name="sut">The system under test, after a transform has completed.</param>
+    protected virtual int GetCurrentItemCount(TSut sut) =>
+        ((TransformerBase<TItem, TItem, Report>)(object)sut!).CurrentItemCount;
 
 
 
@@ -127,5 +139,36 @@ public abstract class IdempotentTransformerContractTests<TSut, TItem>
         Assert.Equal(firstRun.Count, secondRun.Count);
         Assert.Equal(input.Count, secondRun.Count);
         Assert.Equal(firstRun, secondRun);
+    }
+
+
+
+    /// <summary>
+    /// Verifies that <c>CurrentItemCount</c> reflects only the most recent run: after transforming
+    /// the same input twice on the same instance, the count equals the number of items produced by
+    /// the second run alone, not the cumulative total across both runs.
+    /// </summary>
+    /// <remarks>
+    /// This verifies the per-run reset contract introduced in
+    /// <c>Wolfgang.Etl.Abstractions</c> 0.14.0 (ETL-Abstractions#246), where
+    /// <c>CurrentItemCount</c> and <c>CurrentSkippedItemCount</c> reset at the start of each run.
+    /// </remarks>
+    [Fact]
+    public async Task TransformAsync_when_called_twice_CurrentItemCount_resets_Async()
+    {
+        var sut = CreateSut();
+        var expected = CreateExpectedItems();
+
+        await sut
+            .TransformAsync(expected.ToAsyncEnumerable())
+            .ToListAsync()
+            .ConfigureAwait(false);
+
+        await sut
+            .TransformAsync(expected.ToAsyncEnumerable())
+            .ToListAsync()
+            .ConfigureAwait(false);
+
+        Assert.Equal(expected.Count, GetCurrentItemCount(sut));
     }
 }

--- a/src/Wolfgang.Etl.TestKit.Xunit/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.TestKit.Xunit/PublicAPI.Unshipped.txt
@@ -14,18 +14,23 @@ Wolfgang.Etl.TestKit.Xunit.IdempotentExtractorContractTests<TSut, TItem, TProgre
 Wolfgang.Etl.TestKit.Xunit.IdempotentExtractorContractTests<TSut, TItem, TProgress>.IdempotentExtractorContractTests() -> void
 Wolfgang.Etl.TestKit.Xunit.IdempotentExtractorContractTests<TSut, TItem, TProgress>.ExtractAsync_when_called_twice_yields_identical_items_Async() -> System.Threading.Tasks.Task!
 Wolfgang.Etl.TestKit.Xunit.IdempotentExtractorContractTests<TSut, TItem, TProgress>.ExtractAsync_when_called_twice_with_progress_both_runs_report_Async() -> System.Threading.Tasks.Task!
+Wolfgang.Etl.TestKit.Xunit.IdempotentExtractorContractTests<TSut, TItem, TProgress>.ExtractAsync_when_called_twice_CurrentItemCount_resets_Async() -> System.Threading.Tasks.Task!
 abstract Wolfgang.Etl.TestKit.Xunit.IdempotentExtractorContractTests<TSut, TItem, TProgress>.CreateSut(int itemCount) -> TSut
 abstract Wolfgang.Etl.TestKit.Xunit.IdempotentExtractorContractTests<TSut, TItem, TProgress>.CreateExpectedItems() -> System.Collections.Generic.IReadOnlyList<TItem>!
 Wolfgang.Etl.TestKit.Xunit.IdempotentLoaderContractTests<TSut, TItem>
 Wolfgang.Etl.TestKit.Xunit.IdempotentLoaderContractTests<TSut, TItem>.IdempotentLoaderContractTests() -> void
 Wolfgang.Etl.TestKit.Xunit.IdempotentLoaderContractTests<TSut, TItem>.LoadAsync_when_called_twice_processes_all_items_both_times_Async() -> System.Threading.Tasks.Task!
 Wolfgang.Etl.TestKit.Xunit.IdempotentLoaderContractTests<TSut, TItem>.LoadAsync_when_called_twice_no_state_leaks_Async() -> System.Threading.Tasks.Task!
+Wolfgang.Etl.TestKit.Xunit.IdempotentLoaderContractTests<TSut, TItem>.LoadAsync_when_called_twice_CurrentItemCount_resets_Async() -> System.Threading.Tasks.Task!
 abstract Wolfgang.Etl.TestKit.Xunit.IdempotentLoaderContractTests<TSut, TItem>.CreateSut(int itemCount) -> TSut
 abstract Wolfgang.Etl.TestKit.Xunit.IdempotentLoaderContractTests<TSut, TItem>.CreateSourceItems() -> System.Collections.Generic.IReadOnlyList<TItem>!
 abstract Wolfgang.Etl.TestKit.Xunit.IdempotentLoaderContractTests<TSut, TItem>.TryGetLoadedItems(TSut sut) -> System.Collections.Generic.IReadOnlyList<TItem>?
+virtual Wolfgang.Etl.TestKit.Xunit.IdempotentLoaderContractTests<TSut, TItem>.GetCurrentItemCount(TSut sut) -> int
 Wolfgang.Etl.TestKit.Xunit.IdempotentTransformerContractTests<TSut, TItem>
 Wolfgang.Etl.TestKit.Xunit.IdempotentTransformerContractTests<TSut, TItem>.IdempotentTransformerContractTests() -> void
 Wolfgang.Etl.TestKit.Xunit.IdempotentTransformerContractTests<TSut, TItem>.TransformAsync_when_called_twice_yields_identical_items_Async() -> System.Threading.Tasks.Task!
 Wolfgang.Etl.TestKit.Xunit.IdempotentTransformerContractTests<TSut, TItem>.TransformAsync_when_called_twice_no_accumulated_side_effects_Async() -> System.Threading.Tasks.Task!
+Wolfgang.Etl.TestKit.Xunit.IdempotentTransformerContractTests<TSut, TItem>.TransformAsync_when_called_twice_CurrentItemCount_resets_Async() -> System.Threading.Tasks.Task!
 abstract Wolfgang.Etl.TestKit.Xunit.IdempotentTransformerContractTests<TSut, TItem>.CreateSut(int itemCount) -> TSut
 abstract Wolfgang.Etl.TestKit.Xunit.IdempotentTransformerContractTests<TSut, TItem>.CreateExpectedItems() -> System.Collections.Generic.IReadOnlyList<TItem>!
+virtual Wolfgang.Etl.TestKit.Xunit.IdempotentTransformerContractTests<TSut, TItem>.GetCurrentItemCount(TSut sut) -> int


### PR DESCRIPTION
Adds the 3 previously-deferred `CurrentItemCount`-reset tests to the opt-in idempotency contract bases (the companions deferred in #15 pending ETL-Abstractions#246). #246 is resolved and live in `Wolfgang.Etl.Abstractions` 0.14.0 (already referenced on `vNext`): `CurrentItemCount`/`CurrentSkippedItemCount` now reset at the start of each run.

## Tests added (one `[Fact]` per base)
- `IdempotentExtractorContractTests.ExtractAsync_when_called_twice_CurrentItemCount_resets_Async`
- `IdempotentLoaderContractTests.LoadAsync_when_called_twice_CurrentItemCount_resets_Async`
- `IdempotentTransformerContractTests.TransformAsync_when_called_twice_CurrentItemCount_resets_Async`

Each runs the SUT twice on the same instance, then asserts `CurrentItemCount` equals a single run's item count (not 2x), proving the per-run reset contract introduced in Abstractions 0.14.0 (ETL-Abstractions#246). The stale `// NOTE: deferred pending #246` comment in each base was replaced with a note that the reset is now verified.

## How `CurrentItemCount` is accessed
`CurrentItemCount` is declared only on the generic Abstractions base classes (`ExtractorBase<,>`, `LoaderBase<,>`, `TransformerBase<,,>`); there is no non-generic base that exposes it.

- **Extractor** — the base already had a `TProgress` type parameter, so I tightened its constraint from the interfaces to `where TSut : ExtractorBase<TItem, TProgress>, ...` (matching the existing `ExtractorBaseContractTests` style) and read `sut.CurrentItemCount` directly. No new type parameter, no break to the existing consumer subclass.
- **Loader / Transformer** — these bases have no `TProgress` type parameter. Adding one (to constrain to `LoaderBase<TItem, TProgress>` / `TransformerBase<TItem, TItem, TProgress>`) would break the existing two-arg consumer subclasses, and constraining to a hardcoded `Report` progress (`LoaderBase<TItem, Report>`) triggered a spurious RS0016/RS0017 pair on the unrelated, already-shipped-on-vNext `TryGetLoadedItems` API entry. Per the CLAUDE.md guidance to prefer a small protected hook when tightening would break subclasses, I added a `protected virtual int GetCurrentItemCount(TSut sut)` to each base. Its default reads `CurrentItemCount` off `LoaderBase<TItem, Report>` / `TransformerBase<TItem, TItem, Report>` (the ETL convention) and is overridable for non-`Report` components. The existing consumer subclasses use `Report`, so no consumer code changed.

## PublicAPI.Unshipped.txt entries added
```
Wolfgang.Etl.TestKit.Xunit.IdempotentExtractorContractTests<TSut, TItem, TProgress>.ExtractAsync_when_called_twice_CurrentItemCount_resets_Async() -> System.Threading.Tasks.Task!
Wolfgang.Etl.TestKit.Xunit.IdempotentLoaderContractTests<TSut, TItem>.LoadAsync_when_called_twice_CurrentItemCount_resets_Async() -> System.Threading.Tasks.Task!
virtual Wolfgang.Etl.TestKit.Xunit.IdempotentLoaderContractTests<TSut, TItem>.GetCurrentItemCount(TSut sut) -> int
Wolfgang.Etl.TestKit.Xunit.IdempotentTransformerContractTests<TSut, TItem>.TransformAsync_when_called_twice_CurrentItemCount_resets_Async() -> System.Threading.Tasks.Task!
virtual Wolfgang.Etl.TestKit.Xunit.IdempotentTransformerContractTests<TSut, TItem>.GetCurrentItemCount(TSut sut) -> int
```

## Build & test
- `dotnet build src/Wolfgang.Etl.TestKit.Xunit -c Release` — Build succeeded, 0 warnings / 0 errors across all TFMs.
- `dotnet test tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit -c Release -f net8.0` — Passed! 236/236. The 3 new reset tests pass, confirming 0.14.0 resets the count per run.

Tests only — no production code or test doubles changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
