### PR TITLE
fix: correct repo URL slug + bump to 0.9.0

### DIFF
--- a/src/Wolfgang.Etl.TestKit.Xunit/Wolfgang.Etl.TestKit.Xunit.csproj
+++ b/src/Wolfgang.Etl.TestKit.Xunit/Wolfgang.Etl.TestKit.Xunit.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net462;net481;netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>
-    <Version>0.8.1</Version>
+    <Version>0.9.0</Version>
     <!-- Pin AssemblyVersion to a fixed binding-stability baseline so consumers
          do not need to recompile / add binding redirects on every minor/patch
          bump. Bump only on a deliberate breaking API change. FileVersion +
@@ -15,8 +15,8 @@
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Title>Wolfgang.Etl.TestKit.Xunit</Title>
     <Description>Abstract xUnit contract test base classes for verifying custom ETL extractors, transformers, and loaders built on Wolfgang.Etl.Abstractions.</Description>
-    <PackageProjectUrl>https://github.com/Chris-Wolfgang/ETL-TestKit</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/Chris-Wolfgang/ETL-TestKit</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/Chris-Wolfgang/ETL-Test-Kit</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/Chris-Wolfgang/ETL-Test-Kit</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>False</PackageRequireLicenseAcceptance>

--- a/src/Wolfgang.Etl.TestKit/Wolfgang.Etl.TestKit.csproj
+++ b/src/Wolfgang.Etl.TestKit/Wolfgang.Etl.TestKit.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net462;net481;netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>
-    <Version>0.8.1</Version>
+    <Version>0.9.0</Version>
     <!-- Pin AssemblyVersion to a fixed binding-stability baseline so consumers
          do not need to recompile / add binding redirects on every minor/patch
          bump. Bump only on a deliberate breaking API change. FileVersion +
@@ -15,8 +15,8 @@
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Title>Wolfgang.Etl.TestKit</Title>
     <Description>An implementation of Extractor, Transformer and Loader for use in ETL examples and benchmarks. Built on Wolfgang.Etl.Abstractions.</Description>
-    <PackageProjectUrl>https://github.com/Chris-Wolfgang/ETL-TestKit</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/Chris-Wolfgang/ETL-TestKit</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/Chris-Wolfgang/ETL-Test-Kit</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/Chris-Wolfgang/ETL-Test-Kit</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>False</PackageRequireLicenseAcceptance>


### PR DESCRIPTION
## Summary

The `<PackageProjectUrl>` and `<RepositoryUrl>` in both package projects pointed at a non-existent repo slug `Chris-Wolfgang/ETL-TestKit` (no hyphen). This broke SourceLink commit resolution and the NuGet Project URL. Corrected to the real slug `Chris-Wolfgang/ETL-Test-Kit` (hyphenated) in both `<PackageProjectUrl>` and `<RepositoryUrl>` — 4 lines across the two csproj files.

Also bumped `<Version>` from `0.8.1` to `0.9.0` (MINOR) in both projects, reflecting the new public API shipping this release cycle.

## Changes
- `src/Wolfgang.Etl.TestKit/Wolfgang.Etl.TestKit.csproj`: URL slug fix (2 lines) + version bump
- `src/Wolfgang.Etl.TestKit.Xunit/Wolfgang.Etl.TestKit.Xunit.csproj`: URL slug fix (2 lines) + version bump

## Verification
- `dotnet build src/Wolfgang.Etl.TestKit.Xunit/Wolfgang.Etl.TestKit.Xunit.csproj -c Release` → 0 warnings, 0 errors

Note: `Closes #N` intentionally not used — the release auto-closes its issues when vNext merges to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)