### PR TITLE
build: TFM-warning + slnx + PublicAPI hygiene

### DIFF
--- a/ETL-Test-Kit.slnx
+++ b/ETL-Test-Kit.slnx
@@ -6,14 +6,12 @@
     <File Path="Directory.Build.props" />
     <File Path="LICENSE" />
     <File Path="README.md" />
-    <File Path="REPO-INSTRUCTIONS.md" />
   </Folder>
   <Folder Name="/.root/.github/">
     <File Path=".github/CODEOWNERS" />
     <File Path=".github/copilot-instructions.md" />
     <File Path=".github/dependabot.yml" />
     <File Path=".github/pull_request_template.md" />
-    <File Path=".github/version-picker-template.html" />
   </Folder>
   <Folder Name="/.root/.github/ISSUE_TEMPLATE/">
     <File Path=".github/ISSUE_TEMPLATE/BUG_REPORT.yaml" />
@@ -21,7 +19,7 @@
   </Folder>
   <Folder Name="/.root/.github/workflows/">
     <File Path=".github/workflows/build-all-versions.yaml" />
-    <File Path=".github/workflows/codeql.yml" />
+    <File Path=".github/workflows/codeql.yaml" />
     <File Path=".github/workflows/docfx.yaml" />
     <File Path=".github/workflows/pr.yaml" />
     <File Path=".github/workflows/release.yaml" />
@@ -31,8 +29,6 @@
   </Folder>
   <Folder Name="/.root/scripts/">
     <File Path="scripts/format.ps1" />
-    <File Path="scripts/Setup-BranchRuleset.ps1" />
-    <File Path="scripts/Setup-GitHubPages.ps1" />
     <File Path="scripts/Setup-Labels.ps1" />
 
   </Folder>

--- a/src/Wolfgang.Etl.TestKit.Xunit/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.TestKit.Xunit/PublicAPI.Unshipped.txt
@@ -1,31 +1,31 @@
 #nullable enable
+Wolfgang.Etl.TestKit.Xunit.IdempotentExtractorContractTests<TSut, TItem, TProgress>
+Wolfgang.Etl.TestKit.Xunit.IdempotentExtractorContractTests<TSut, TItem, TProgress>.ExtractAsync_when_called_twice_with_progress_both_runs_report_Async() -> System.Threading.Tasks.Task!
+Wolfgang.Etl.TestKit.Xunit.IdempotentExtractorContractTests<TSut, TItem, TProgress>.ExtractAsync_when_called_twice_yields_identical_items_Async() -> System.Threading.Tasks.Task!
+Wolfgang.Etl.TestKit.Xunit.IdempotentExtractorContractTests<TSut, TItem, TProgress>.IdempotentExtractorContractTests() -> void
+Wolfgang.Etl.TestKit.Xunit.IdempotentLoaderContractTests<TSut, TItem>
+Wolfgang.Etl.TestKit.Xunit.IdempotentLoaderContractTests<TSut, TItem>.IdempotentLoaderContractTests() -> void
+Wolfgang.Etl.TestKit.Xunit.IdempotentLoaderContractTests<TSut, TItem>.LoadAsync_when_called_twice_no_state_leaks_Async() -> System.Threading.Tasks.Task!
+Wolfgang.Etl.TestKit.Xunit.IdempotentLoaderContractTests<TSut, TItem>.LoadAsync_when_called_twice_processes_all_items_both_times_Async() -> System.Threading.Tasks.Task!
+Wolfgang.Etl.TestKit.Xunit.IdempotentTransformerContractTests<TSut, TItem>
+Wolfgang.Etl.TestKit.Xunit.IdempotentTransformerContractTests<TSut, TItem>.IdempotentTransformerContractTests() -> void
+Wolfgang.Etl.TestKit.Xunit.IdempotentTransformerContractTests<TSut, TItem>.TransformAsync_when_called_twice_no_accumulated_side_effects_Async() -> System.Threading.Tasks.Task!
+Wolfgang.Etl.TestKit.Xunit.IdempotentTransformerContractTests<TSut, TItem>.TransformAsync_when_called_twice_yields_identical_items_Async() -> System.Threading.Tasks.Task!
 Wolfgang.Etl.TestKit.Xunit.ProgressAssert
 Wolfgang.Etl.TestKit.Xunit.ProgressCapture<T>
 Wolfgang.Etl.TestKit.Xunit.ProgressCapture<T>.Count.get -> int
 Wolfgang.Etl.TestKit.Xunit.ProgressCapture<T>.FinalReport.get -> T?
 Wolfgang.Etl.TestKit.Xunit.ProgressCapture<T>.ProgressCapture() -> void
 Wolfgang.Etl.TestKit.Xunit.ProgressCapture<T>.Reports.get -> System.Collections.Generic.IReadOnlyList<T>!
+abstract Wolfgang.Etl.TestKit.Xunit.IdempotentExtractorContractTests<TSut, TItem, TProgress>.CreateExpectedItems() -> System.Collections.Generic.IReadOnlyList<TItem>!
+abstract Wolfgang.Etl.TestKit.Xunit.IdempotentExtractorContractTests<TSut, TItem, TProgress>.CreateSut(int itemCount) -> TSut
+abstract Wolfgang.Etl.TestKit.Xunit.IdempotentLoaderContractTests<TSut, TItem>.CreateSourceItems() -> System.Collections.Generic.IReadOnlyList<TItem>!
+abstract Wolfgang.Etl.TestKit.Xunit.IdempotentLoaderContractTests<TSut, TItem>.CreateSut(int itemCount) -> TSut
+abstract Wolfgang.Etl.TestKit.Xunit.IdempotentLoaderContractTests<TSut, TItem>.TryGetLoadedItems(TSut sut) -> System.Collections.Generic.IReadOnlyList<TItem>?
+abstract Wolfgang.Etl.TestKit.Xunit.IdempotentTransformerContractTests<TSut, TItem>.CreateExpectedItems() -> System.Collections.Generic.IReadOnlyList<TItem>!
+abstract Wolfgang.Etl.TestKit.Xunit.IdempotentTransformerContractTests<TSut, TItem>.CreateSut(int itemCount) -> TSut
 static Wolfgang.Etl.TestKit.Xunit.ProgressAssert.AllReportsSatisfy<T>(Wolfgang.Etl.TestKit.Xunit.ProgressCapture<T>! capture, System.Func<T, bool>! predicate) -> void
 static Wolfgang.Etl.TestKit.Xunit.ProgressAssert.FinalReportSatisfies<T>(Wolfgang.Etl.TestKit.Xunit.ProgressCapture<T>! capture, System.Func<T, bool>! predicate) -> void
 static Wolfgang.Etl.TestKit.Xunit.ProgressAssert.HasExactly<T>(Wolfgang.Etl.TestKit.Xunit.ProgressCapture<T>! capture, int count) -> void
 static Wolfgang.Etl.TestKit.Xunit.ProgressAssert.HasReports<T>(Wolfgang.Etl.TestKit.Xunit.ProgressCapture<T>! capture) -> void
 static Wolfgang.Etl.TestKit.Xunit.ProgressAssert.IsMonotonicallyIncreasing<T, TKey>(Wolfgang.Etl.TestKit.Xunit.ProgressCapture<T>! capture, System.Func<T, TKey>! selector) -> void
-Wolfgang.Etl.TestKit.Xunit.IdempotentExtractorContractTests<TSut, TItem, TProgress>
-Wolfgang.Etl.TestKit.Xunit.IdempotentExtractorContractTests<TSut, TItem, TProgress>.IdempotentExtractorContractTests() -> void
-Wolfgang.Etl.TestKit.Xunit.IdempotentExtractorContractTests<TSut, TItem, TProgress>.ExtractAsync_when_called_twice_yields_identical_items_Async() -> System.Threading.Tasks.Task!
-Wolfgang.Etl.TestKit.Xunit.IdempotentExtractorContractTests<TSut, TItem, TProgress>.ExtractAsync_when_called_twice_with_progress_both_runs_report_Async() -> System.Threading.Tasks.Task!
-abstract Wolfgang.Etl.TestKit.Xunit.IdempotentExtractorContractTests<TSut, TItem, TProgress>.CreateSut(int itemCount) -> TSut
-abstract Wolfgang.Etl.TestKit.Xunit.IdempotentExtractorContractTests<TSut, TItem, TProgress>.CreateExpectedItems() -> System.Collections.Generic.IReadOnlyList<TItem>!
-Wolfgang.Etl.TestKit.Xunit.IdempotentLoaderContractTests<TSut, TItem>
-Wolfgang.Etl.TestKit.Xunit.IdempotentLoaderContractTests<TSut, TItem>.IdempotentLoaderContractTests() -> void
-Wolfgang.Etl.TestKit.Xunit.IdempotentLoaderContractTests<TSut, TItem>.LoadAsync_when_called_twice_processes_all_items_both_times_Async() -> System.Threading.Tasks.Task!
-Wolfgang.Etl.TestKit.Xunit.IdempotentLoaderContractTests<TSut, TItem>.LoadAsync_when_called_twice_no_state_leaks_Async() -> System.Threading.Tasks.Task!
-abstract Wolfgang.Etl.TestKit.Xunit.IdempotentLoaderContractTests<TSut, TItem>.CreateSut(int itemCount) -> TSut
-abstract Wolfgang.Etl.TestKit.Xunit.IdempotentLoaderContractTests<TSut, TItem>.CreateSourceItems() -> System.Collections.Generic.IReadOnlyList<TItem>!
-abstract Wolfgang.Etl.TestKit.Xunit.IdempotentLoaderContractTests<TSut, TItem>.TryGetLoadedItems(TSut sut) -> System.Collections.Generic.IReadOnlyList<TItem>?
-Wolfgang.Etl.TestKit.Xunit.IdempotentTransformerContractTests<TSut, TItem>
-Wolfgang.Etl.TestKit.Xunit.IdempotentTransformerContractTests<TSut, TItem>.IdempotentTransformerContractTests() -> void
-Wolfgang.Etl.TestKit.Xunit.IdempotentTransformerContractTests<TSut, TItem>.TransformAsync_when_called_twice_yields_identical_items_Async() -> System.Threading.Tasks.Task!
-Wolfgang.Etl.TestKit.Xunit.IdempotentTransformerContractTests<TSut, TItem>.TransformAsync_when_called_twice_no_accumulated_side_effects_Async() -> System.Threading.Tasks.Task!
-abstract Wolfgang.Etl.TestKit.Xunit.IdempotentTransformerContractTests<TSut, TItem>.CreateSut(int itemCount) -> TSut
-abstract Wolfgang.Etl.TestKit.Xunit.IdempotentTransformerContractTests<TSut, TItem>.CreateExpectedItems() -> System.Collections.Generic.IReadOnlyList<TItem>!

--- a/src/Wolfgang.Etl.TestKit/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.TestKit/PublicAPI.Unshipped.txt
@@ -18,14 +18,14 @@ Wolfgang.Etl.TestKit.FaultyTransformer<T>.FaultyTransformer() -> void
 Wolfgang.Etl.TestKit.FaultyTransformer<T>.FaultyTransformer(Wolfgang.Etl.Abstractions.IProgressTimer! timer) -> void
 Wolfgang.Etl.TestKit.FaultyTransformer<T>.ThrowAfterCompletion(System.Exception! exception) -> Wolfgang.Etl.TestKit.FaultyTransformer<T>!
 Wolfgang.Etl.TestKit.FaultyTransformer<T>.ThrowAt(int index, System.Exception! exception) -> Wolfgang.Etl.TestKit.FaultyTransformer<T>!
-Wolfgang.Etl.TestKit.TestExtractor<T>.TestExtractor(System.Func<int, T> factory) -> void
-Wolfgang.Etl.TestKit.TestExtractor<T>.TestExtractor(System.Func<int, T> factory, int count) -> void
-Wolfgang.Etl.TestKit.TestExtractor<T>.TestExtractor(System.Func<int, T> factory, int count, Wolfgang.Etl.Abstractions.IProgressTimer timer) -> void
-Wolfgang.Etl.TestKit.TestExtractor<T>.TestExtractor(System.Func<int, T> factory, Wolfgang.Etl.Abstractions.IProgressTimer timer) -> void
 Wolfgang.Etl.TestKit.TestExtractor<T>.TestExtractor(System.Func<T> factory) -> void
+Wolfgang.Etl.TestKit.TestExtractor<T>.TestExtractor(System.Func<T> factory, Wolfgang.Etl.Abstractions.IProgressTimer timer) -> void
 Wolfgang.Etl.TestKit.TestExtractor<T>.TestExtractor(System.Func<T> factory, int count) -> void
 Wolfgang.Etl.TestKit.TestExtractor<T>.TestExtractor(System.Func<T> factory, int count, Wolfgang.Etl.Abstractions.IProgressTimer timer) -> void
-Wolfgang.Etl.TestKit.TestExtractor<T>.TestExtractor(System.Func<T> factory, Wolfgang.Etl.Abstractions.IProgressTimer timer) -> void
+Wolfgang.Etl.TestKit.TestExtractor<T>.TestExtractor(System.Func<int, T> factory) -> void
+Wolfgang.Etl.TestKit.TestExtractor<T>.TestExtractor(System.Func<int, T> factory, Wolfgang.Etl.Abstractions.IProgressTimer timer) -> void
+Wolfgang.Etl.TestKit.TestExtractor<T>.TestExtractor(System.Func<int, T> factory, int count) -> void
+Wolfgang.Etl.TestKit.TestExtractor<T>.TestExtractor(System.Func<int, T> factory, int count, Wolfgang.Etl.Abstractions.IProgressTimer timer) -> void
 override Wolfgang.Etl.TestKit.FaultyExtractor<T>.CreateProgressReport() -> Wolfgang.Etl.Abstractions.Report!
 override Wolfgang.Etl.TestKit.FaultyExtractor<T>.CreateProgressTimer(System.IProgress<Wolfgang.Etl.Abstractions.Report!>! progress) -> Wolfgang.Etl.Abstractions.IProgressTimer!
 override Wolfgang.Etl.TestKit.FaultyExtractor<T>.ExtractWorkerAsync(System.Threading.CancellationToken token) -> System.Collections.Generic.IAsyncEnumerable<T>!

--- a/tests/Wolfgang.Etl.TestKit.Tests.Unit/Wolfgang.Etl.TestKit.Tests.Unit.csproj
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Unit/Wolfgang.Etl.TestKit.Tests.Unit.csproj
@@ -39,7 +39,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net5.0' OR '$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1' OR '$(TargetFramework)' == 'net5.0' OR '$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0'">
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
 

--- a/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/Wolfgang.Etl.TestKit.Xunit.Tests.Unit.csproj
+++ b/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/Wolfgang.Etl.TestKit.Xunit.Tests.Unit.csproj
@@ -38,7 +38,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net5.0' OR '$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1' OR '$(TargetFramework)' == 'net5.0' OR '$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0'">
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
 


### PR DESCRIPTION
## Summary

Three build-hygiene fixes from the code review.

### (a) netcoreapp3.1 TFM-support warnings
Both test projects list `netcoreapp3.1` in `<TargetFrameworks>` but their `SuppressTfmSupportBuildWarnings` PropertyGroups only covered net4x and net5/6/7. Extended the net5/6/7 PropertyGroup `Condition` in each to also match `netcoreapp3.1`. The 6 TFM-support warnings (3 TFMs × 2 test projects) are now gone.

### (b) Stale `.slnx` references
Removed solution-file references to files that no longer exist, and fixed one wrong extension:
- removed `REPO-INSTRUCTIONS.md`
- removed `.github/version-picker-template.html`
- removed `scripts/Setup-BranchRuleset.ps1`
- removed `scripts/Setup-GitHubPages.ps1`
- `.github/workflows/codeql.yml` → `.github/workflows/codeql.yaml` (the real file)

Each removed path was confirmed missing; the corrected `codeql.yaml` confirmed present.

### (c) PublicAPI.Unshipped sort
`PublicAPI.Unshipped.txt` in both `src` projects was not canonically sorted. Re-sorted each ordinally (matching `PublicAPI.Shipped.txt`'s convention) with the `#nullable enable` header preserved as the first line.

## Verification
`dotnet build ETL-Test-Kit.slnx -c Release` → **0 Warning(s), 0 Error(s)** (TFM warnings gone, no RS0016/RS0017/RS0024/RS0025).

## Stack
Based on `fix/changelog` (PR #180).

🤖 Generated with [Claude Code](https://claude.com/claude-code)