### PR TITLE
refactor: FaultyExtractor async-hop + double style consistency

### DIFF
--- a/src/Wolfgang.Etl.TestKit/FaultyExtractor.cs
+++ b/src/Wolfgang.Etl.TestKit/FaultyExtractor.cs
@@ -234,6 +234,12 @@ public class FaultyExtractor<T> : ExtractorBase<T, Report>
     {
         token.ThrowIfCancellationRequested();
 
+        // The wrapped source is synchronous, so this iterator would otherwise
+        // contain no await. Yield once up front to honour the async-iterator
+        // contract on every exit path (including the MaximumItemCount yield-break
+        // and ThrowAfterCompletion throw), reachable however the loop terminates.
+        await Task.Yield();
+
         var enumerator = _items.GetEnumerator();
 
         try
@@ -285,7 +291,5 @@ public class FaultyExtractor<T> : ExtractorBase<T, Report>
         {
             throw _throwAfterCompletion;
         }
-
-        await Task.Yield(); // satisfies async method contract without causing extra allocations
     }
 }

--- a/src/Wolfgang.Etl.TestKit/FaultyLoader.cs
+++ b/src/Wolfgang.Etl.TestKit/FaultyLoader.cs
@@ -242,15 +242,16 @@ public class FaultyLoader<T> : LoaderBase<T, Report>
 
 
     /// <inheritdoc/>
-    protected override Report CreateProgressReport() =>
-        new Report(CurrentItemCount);
+    protected override Report CreateProgressReport() => new(CurrentItemCount);
 
 
 
     /// <inheritdoc/>
-    protected override async Task LoadWorkerAsync(
+    protected override async Task LoadWorkerAsync
+    (
         IAsyncEnumerable<T> items,
-        CancellationToken token)
+        CancellationToken token
+    )
     {
         token.ThrowIfCancellationRequested();
 

--- a/src/Wolfgang.Etl.TestKit/FaultyTransformer.cs
+++ b/src/Wolfgang.Etl.TestKit/FaultyTransformer.cs
@@ -61,8 +61,8 @@ public class FaultyTransformer<T> : TransformerBase<T, T, Report>
     // ------------------------------------------------------------------
 
     /// <summary>
-    /// Initializes a new <see cref="FaultyTransformer{T}"/> using the default production
-    /// timer.
+    /// Initializes a new <see cref="FaultyTransformer{T}"/> using the default
+    /// base-class progress timer.
     /// </summary>
     public FaultyTransformer() { }
 
@@ -205,15 +205,16 @@ public class FaultyTransformer<T> : TransformerBase<T, T, Report>
 
 
     /// <inheritdoc/>
-    protected override Report CreateProgressReport() =>
-        new Report(CurrentItemCount);
+    protected override Report CreateProgressReport() => new(CurrentItemCount);
 
 
 
     /// <inheritdoc/>
-    protected override async IAsyncEnumerable<T> TransformWorkerAsync(
+    protected override async IAsyncEnumerable<T> TransformWorkerAsync
+    (
         IAsyncEnumerable<T> items,
-        [EnumeratorCancellation] CancellationToken token)
+        [EnumeratorCancellation] CancellationToken token
+    )
     {
         token.ThrowIfCancellationRequested();
 

--- a/src/Wolfgang.Etl.TestKit/TestLoader.cs
+++ b/src/Wolfgang.Etl.TestKit/TestLoader.cs
@@ -126,7 +126,7 @@ public class TestLoader<T> : LoaderBase<T, Report>
     /// </returns>
     public IReadOnlyList<T>? GetCollectedItems() =>
         _collectItems
-            ? _buffer.ToList()
+            ? _buffer.ToArray()
             : null;
 
 
@@ -155,15 +155,16 @@ public class TestLoader<T> : LoaderBase<T, Report>
 
 
     /// <inheritdoc/>
-    protected override Report CreateProgressReport() =>
-        new Report(CurrentItemCount);
+    protected override Report CreateProgressReport() => new(CurrentItemCount);
 
 
 
     /// <inheritdoc/>
-    protected override async Task LoadWorkerAsync(
+    protected override async Task LoadWorkerAsync
+    (
         IAsyncEnumerable<T> items,
-        CancellationToken token)
+        CancellationToken token
+    )
     {
         token.ThrowIfCancellationRequested();
 

--- a/src/Wolfgang.Etl.TestKit/TestTransformer.cs
+++ b/src/Wolfgang.Etl.TestKit/TestTransformer.cs
@@ -51,7 +51,7 @@ public class TestTransformer<T> : TransformerBase<T, T, Report>
 
     /// <summary>
     /// Initializes a new <see cref="TestTransformer{T}"/> using the default
-    /// production timer.
+    /// base-class progress timer.
     /// </summary>
     public TestTransformer() { }
 
@@ -99,15 +99,16 @@ public class TestTransformer<T> : TransformerBase<T, T, Report>
 
 
     /// <inheritdoc/>
-    protected override Report CreateProgressReport() =>
-        new Report(CurrentItemCount);
+    protected override Report CreateProgressReport() => new(CurrentItemCount);
 
 
 
     /// <inheritdoc/>
-    protected override async IAsyncEnumerable<T> TransformWorkerAsync(
+    protected override async IAsyncEnumerable<T> TransformWorkerAsync
+    (
         IAsyncEnumerable<T> items,
-        [EnumeratorCancellation] CancellationToken token)
+        [EnumeratorCancellation] CancellationToken token
+    )
     {
         token.ThrowIfCancellationRequested();
 


### PR DESCRIPTION
Pure source cleanup from code review — **no public-API change** (zero PublicAPI.txt edits required).

## Changes
1. **`FaultyExtractor.ExtractWorkerAsync` async-hop placement.** Moved `await Task.Yield()` from after the loop/finally (where it sat *below* the `ThrowAfterCompletion` throw and was therefore unreachable on the `ThrowAfterCompletion` and `MaximumItemCount` `yield break` paths) to the top of the method, right after the initial `token.ThrowIfCancellationRequested()` — mirroring `TestExtractor.ExtractWorkerAsync`. The comment now accurately states it runs on every exit path. The old misleading trailing comment is removed.
2. **Style consistency (no behaviour change):**
   - Worker-method signatures use the CLAUDE.md Allman-paren form (`(` and `)` on their own lines) in `TestLoader`, `FaultyLoader`, `TestTransformer`, `FaultyTransformer` — matching the extractors.
   - `CreateProgressReport()` uses target-typed `new(CurrentItemCount)` across all doubles (was `new Report(...)` in the four loaders/transformers).
   - `TestLoader.GetCollectedItems()` snapshot switched from `_buffer.ToList()` to `_buffer.ToArray()` so both loaders use the same cheaper fixed-length snapshot; return type unchanged (`IReadOnlyList<T>?`).
   - Reworded the `TestTransformer`/`FaultyTransformer` parameterless-ctor `<summary>` from "default production timer" (inaccurate — the ctor sets no timer) to "default base-class progress timer".

## Verification
- `dotnet build ETL-Test-Kit.slnx -c Release` → 0 warnings / 0 errors, all TFMs (net462; netstandard2.0; net481; net8.0; net10.0).
- Tests `-c Release -f net8.0` → all green (355 = 233 Xunit contract + 122 unit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
