### PR TITLE
fix: unsubscribe Elapsed on Dispose for all doubles

### DIFF
--- a/src/Wolfgang.Etl.TestKit/FaultyExtractor.cs
+++ b/src/Wolfgang.Etl.TestKit/FaultyExtractor.cs
@@ -57,6 +57,7 @@ public class FaultyExtractor<T> : ExtractorBase<T, Report>
     private Exception? _throwAfterCompletion;
     private readonly IProgressTimer? _progressTimer;
     private bool _progressTimerWired;
+    private Action? _elapsedHandler;
 
 
 
@@ -213,10 +214,32 @@ public class FaultyExtractor<T> : ExtractorBase<T, Report>
         if (!_progressTimerWired)
         {
             _progressTimerWired = true;
-            _progressTimer.Elapsed += () => progress.Report(CreateProgressReport());
+            _elapsedHandler = () => progress.Report(CreateProgressReport());
+            _progressTimer.Elapsed += _elapsedHandler;
         }
 
         return _progressTimer;
+    }
+
+
+
+    /// <summary>
+    /// Unsubscribes the <see cref="IProgressTimer.Elapsed"/> handler from an injected
+    /// timer. The injected timer is owned by the caller and is therefore not disposed here.
+    /// </summary>
+    /// <param name="disposing">
+    /// <see langword="true"/> when called from <see cref="IDisposable.Dispose"/>;
+    /// <see langword="false"/> when called from the finalizer.
+    /// </param>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing && _progressTimer is not null && _elapsedHandler is not null)
+        {
+            _progressTimer.Elapsed -= _elapsedHandler;
+            _elapsedHandler = null;
+        }
+
+        base.Dispose(disposing);
     }
 
 

--- a/src/Wolfgang.Etl.TestKit/FaultyLoader.cs
+++ b/src/Wolfgang.Etl.TestKit/FaultyLoader.cs
@@ -57,6 +57,7 @@ public class FaultyLoader<T> : LoaderBase<T, Report>
     private Exception? _throwAfterCompletion;
     private readonly IProgressTimer? _progressTimer;
     private bool _progressTimerWired;
+    private Action? _elapsedHandler;
 
 
 
@@ -233,10 +234,32 @@ public class FaultyLoader<T> : LoaderBase<T, Report>
         if (!_progressTimerWired)
         {
             _progressTimerWired = true;
-            _progressTimer.Elapsed += () => progress.Report(CreateProgressReport());
+            _elapsedHandler = () => progress.Report(CreateProgressReport());
+            _progressTimer.Elapsed += _elapsedHandler;
         }
 
         return _progressTimer;
+    }
+
+
+
+    /// <summary>
+    /// Unsubscribes the <see cref="IProgressTimer.Elapsed"/> handler from an injected
+    /// timer. The injected timer is owned by the caller and is therefore not disposed here.
+    /// </summary>
+    /// <param name="disposing">
+    /// <see langword="true"/> when called from <see cref="IDisposable.Dispose"/>;
+    /// <see langword="false"/> when called from the finalizer.
+    /// </param>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing && _progressTimer is not null && _elapsedHandler is not null)
+        {
+            _progressTimer.Elapsed -= _elapsedHandler;
+            _elapsedHandler = null;
+        }
+
+        base.Dispose(disposing);
     }
 
 

--- a/src/Wolfgang.Etl.TestKit/FaultyTransformer.cs
+++ b/src/Wolfgang.Etl.TestKit/FaultyTransformer.cs
@@ -53,6 +53,7 @@ public class FaultyTransformer<T> : TransformerBase<T, T, Report>
     private Exception? _throwAfterCompletion;
     private readonly IProgressTimer? _progressTimer;
     private bool _progressTimerWired;
+    private Action? _elapsedHandler;
 
 
 
@@ -196,10 +197,32 @@ public class FaultyTransformer<T> : TransformerBase<T, T, Report>
         if (!_progressTimerWired)
         {
             _progressTimerWired = true;
-            _progressTimer.Elapsed += () => progress.Report(CreateProgressReport());
+            _elapsedHandler = () => progress.Report(CreateProgressReport());
+            _progressTimer.Elapsed += _elapsedHandler;
         }
 
         return _progressTimer;
+    }
+
+
+
+    /// <summary>
+    /// Unsubscribes the <see cref="IProgressTimer.Elapsed"/> handler from an injected
+    /// timer. The injected timer is owned by the caller and is therefore not disposed here.
+    /// </summary>
+    /// <param name="disposing">
+    /// <see langword="true"/> when called from <see cref="IDisposable.Dispose"/>;
+    /// <see langword="false"/> when called from the finalizer.
+    /// </param>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing && _progressTimer is not null && _elapsedHandler is not null)
+        {
+            _progressTimer.Elapsed -= _elapsedHandler;
+            _elapsedHandler = null;
+        }
+
+        base.Dispose(disposing);
     }
 
 

--- a/src/Wolfgang.Etl.TestKit/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.TestKit/PublicAPI.Unshipped.txt
@@ -28,10 +28,16 @@ Wolfgang.Etl.TestKit.TestExtractor<T>.TestExtractor(System.Func<int, T> factory,
 Wolfgang.Etl.TestKit.TestExtractor<T>.TestExtractor(System.Func<int, T> factory, int count, Wolfgang.Etl.Abstractions.IProgressTimer timer) -> void
 override Wolfgang.Etl.TestKit.FaultyExtractor<T>.CreateProgressReport() -> Wolfgang.Etl.Abstractions.Report!
 override Wolfgang.Etl.TestKit.FaultyExtractor<T>.CreateProgressTimer(System.IProgress<Wolfgang.Etl.Abstractions.Report!>! progress) -> Wolfgang.Etl.Abstractions.IProgressTimer!
+override Wolfgang.Etl.TestKit.FaultyExtractor<T>.Dispose(bool disposing) -> void
 override Wolfgang.Etl.TestKit.FaultyExtractor<T>.ExtractWorkerAsync(System.Threading.CancellationToken token) -> System.Collections.Generic.IAsyncEnumerable<T>!
 override Wolfgang.Etl.TestKit.FaultyLoader<T>.CreateProgressReport() -> Wolfgang.Etl.Abstractions.Report!
 override Wolfgang.Etl.TestKit.FaultyLoader<T>.CreateProgressTimer(System.IProgress<Wolfgang.Etl.Abstractions.Report!>! progress) -> Wolfgang.Etl.Abstractions.IProgressTimer!
+override Wolfgang.Etl.TestKit.FaultyLoader<T>.Dispose(bool disposing) -> void
 override Wolfgang.Etl.TestKit.FaultyLoader<T>.LoadWorkerAsync(System.Collections.Generic.IAsyncEnumerable<T>! items, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task!
 override Wolfgang.Etl.TestKit.FaultyTransformer<T>.CreateProgressReport() -> Wolfgang.Etl.Abstractions.Report!
 override Wolfgang.Etl.TestKit.FaultyTransformer<T>.CreateProgressTimer(System.IProgress<Wolfgang.Etl.Abstractions.Report!>! progress) -> Wolfgang.Etl.Abstractions.IProgressTimer!
+override Wolfgang.Etl.TestKit.FaultyTransformer<T>.Dispose(bool disposing) -> void
 override Wolfgang.Etl.TestKit.FaultyTransformer<T>.TransformWorkerAsync(System.Collections.Generic.IAsyncEnumerable<T>! items, System.Threading.CancellationToken token) -> System.Collections.Generic.IAsyncEnumerable<T>!
+override Wolfgang.Etl.TestKit.TestExtractor<T>.Dispose(bool disposing) -> void
+override Wolfgang.Etl.TestKit.TestLoader<T>.Dispose(bool disposing) -> void
+override Wolfgang.Etl.TestKit.TestTransformer<T>.Dispose(bool disposing) -> void

--- a/src/Wolfgang.Etl.TestKit/TestExtractor.cs
+++ b/src/Wolfgang.Etl.TestKit/TestExtractor.cs
@@ -61,6 +61,7 @@ public class TestExtractor<T> : ExtractorBase<T, Report>
     private readonly IEnumerator<T>? _enumerator;
     private readonly IProgressTimer? _progressTimer;
     private bool _progressTimerWired;
+    private Action? _elapsedHandler;
 
 
 
@@ -482,10 +483,32 @@ public class TestExtractor<T> : ExtractorBase<T, Report>
         if (!_progressTimerWired)
         {
             _progressTimerWired = true;
-            _progressTimer.Elapsed += () => progress.Report(CreateProgressReport());
+            _elapsedHandler = () => progress.Report(CreateProgressReport());
+            _progressTimer.Elapsed += _elapsedHandler;
         }
 
         return _progressTimer;
+    }
+
+
+
+    /// <summary>
+    /// Unsubscribes the <see cref="IProgressTimer.Elapsed"/> handler from an injected
+    /// timer. The injected timer is owned by the caller and is therefore not disposed here.
+    /// </summary>
+    /// <param name="disposing">
+    /// <see langword="true"/> when called from <see cref="IDisposable.Dispose"/>;
+    /// <see langword="false"/> when called from the finalizer.
+    /// </param>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing && _progressTimer is not null && _elapsedHandler is not null)
+        {
+            _progressTimer.Elapsed -= _elapsedHandler;
+            _elapsedHandler = null;
+        }
+
+        base.Dispose(disposing);
     }
 
 

--- a/src/Wolfgang.Etl.TestKit/TestLoader.cs
+++ b/src/Wolfgang.Etl.TestKit/TestLoader.cs
@@ -60,6 +60,7 @@ public class TestLoader<T> : LoaderBase<T, Report>
     private readonly List<T> _buffer = new List<T>();
     private readonly IProgressTimer? _progressTimer;
     private bool _progressTimerWired;
+    private Action? _elapsedHandler;
 
 
 
@@ -146,10 +147,32 @@ public class TestLoader<T> : LoaderBase<T, Report>
         if (!_progressTimerWired)
         {
             _progressTimerWired = true;
-            _progressTimer.Elapsed += () => progress.Report(CreateProgressReport());
+            _elapsedHandler = () => progress.Report(CreateProgressReport());
+            _progressTimer.Elapsed += _elapsedHandler;
         }
 
         return _progressTimer;
+    }
+
+
+
+    /// <summary>
+    /// Unsubscribes the <see cref="IProgressTimer.Elapsed"/> handler from an injected
+    /// timer. The injected timer is owned by the caller and is therefore not disposed here.
+    /// </summary>
+    /// <param name="disposing">
+    /// <see langword="true"/> when called from <see cref="IDisposable.Dispose"/>;
+    /// <see langword="false"/> when called from the finalizer.
+    /// </param>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing && _progressTimer is not null && _elapsedHandler is not null)
+        {
+            _progressTimer.Elapsed -= _elapsedHandler;
+            _elapsedHandler = null;
+        }
+
+        base.Dispose(disposing);
     }
 
 

--- a/src/Wolfgang.Etl.TestKit/TestTransformer.cs
+++ b/src/Wolfgang.Etl.TestKit/TestTransformer.cs
@@ -42,6 +42,7 @@ public class TestTransformer<T> : TransformerBase<T, T, Report>
 
     private readonly IProgressTimer? _progressTimer;
     private bool _progressTimerWired;
+    private Action? _elapsedHandler;
 
 
 
@@ -90,10 +91,32 @@ public class TestTransformer<T> : TransformerBase<T, T, Report>
         if (!_progressTimerWired)
         {
             _progressTimerWired = true;
-            _progressTimer.Elapsed += () => progress.Report(CreateProgressReport());
+            _elapsedHandler = () => progress.Report(CreateProgressReport());
+            _progressTimer.Elapsed += _elapsedHandler;
         }
 
         return _progressTimer;
+    }
+
+
+
+    /// <summary>
+    /// Unsubscribes the <see cref="IProgressTimer.Elapsed"/> handler from an injected
+    /// timer. The injected timer is owned by the caller and is therefore not disposed here.
+    /// </summary>
+    /// <param name="disposing">
+    /// <see langword="true"/> when called from <see cref="IDisposable.Dispose"/>;
+    /// <see langword="false"/> when called from the finalizer.
+    /// </param>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing && _progressTimer is not null && _elapsedHandler is not null)
+        {
+            _progressTimer.Elapsed -= _elapsedHandler;
+            _elapsedHandler = null;
+        }
+
+        base.Dispose(disposing);
     }
 
 


### PR DESCRIPTION
## The leak
Now that the Abstractions base (0.14.0) is `IDisposable`/`IAsyncDisposable`, each double subscribes to the **caller-owned** injected `IProgressTimer.Elapsed` in `CreateProgressTimer` but never unsubscribes. The timer outlives the double (it's owned by the caller), so the closure — and the double it captures — stays rooted for the timer's lifetime. A test that injects a long-lived `ManualProgressTimer` across many doubles accumulates dead subscribers.

## The fix
In all 6 doubles (`TestExtractor`, `TestLoader`, `TestTransformer`, `FaultyExtractor`, `FaultyLoader`, `FaultyTransformer`):
- The `CreateProgressTimer` subscription now stores the handler in a new `private Action? _elapsedHandler;` field (inside the existing `_progressTimerWired` guard, so wire-once semantics are unchanged).
- Each double adds `protected override void Dispose(bool disposing)` that removes the stored handler from the injected timer's `Elapsed` and clears the field, then calls `base.Dispose(disposing)`.

The injected `_progressTimer` is **intentionally not disposed** — it is caller-owned. The extractors already dispose their owned enumerator in the worker `finally`, so nothing else needs disposing here.

## Public API
The new `protected override void Dispose(bool)` on each unsealed public double is tracked by PublicApiAnalyzer (RS0016). Six entries added to `PublicAPI.Unshipped.txt`, file kept canonically sorted:

```
override Wolfgang.Etl.TestKit.FaultyExtractor<T>.Dispose(bool disposing) -> void
override Wolfgang.Etl.TestKit.FaultyLoader<T>.Dispose(bool disposing) -> void
override Wolfgang.Etl.TestKit.FaultyTransformer<T>.Dispose(bool disposing) -> void
override Wolfgang.Etl.TestKit.TestExtractor<T>.Dispose(bool disposing) -> void
override Wolfgang.Etl.TestKit.TestLoader<T>.Dispose(bool disposing) -> void
override Wolfgang.Etl.TestKit.TestTransformer<T>.Dispose(bool disposing) -> void
```

## Verification
- `dotnet build ETL-Test-Kit.slnx -c Release` → 0 warnings / 0 errors, all TFMs (net462; netstandard2.0; net481; net8.0; net10.0).
- Tests `-c Release -f net8.0` → all green (355 = 233 Xunit contract + 122 unit). No new tests added; existing disposal coverage still passes.

Stacked on #183 (`fix/source-polish`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
