### PR TITLE
deps: bump Wolfgang.Etl.Abstractions 0.14.0 → 0.14.1

### DIFF
--- a/src/Wolfgang.Etl.TestKit.Xunit/Wolfgang.Etl.TestKit.Xunit.csproj
+++ b/src/Wolfgang.Etl.TestKit.Xunit/Wolfgang.Etl.TestKit.Xunit.csproj
@@ -70,7 +70,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Bcl.Memory" Version="10.0.9" />
-    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.14.0" />
+    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.14.1" />
     <PackageReference Include="System.Linq.Async" Version="7.0.1" />
     <PackageReference Include="xunit.abstractions" Version="2.0.3" />
     <PackageReference Include="xunit.assert" Version="2.9.3" />

--- a/src/Wolfgang.Etl.TestKit/Wolfgang.Etl.TestKit.csproj
+++ b/src/Wolfgang.Etl.TestKit/Wolfgang.Etl.TestKit.csproj
@@ -65,7 +65,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Bcl.Memory" Version="10.0.9" />
-    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.14.0" />
+    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.14.1" />
     <PackageReference Include="System.Linq.Async" Version="7.0.1" />
   </ItemGroup>
 


### PR DESCRIPTION
Bumps the Abstractions dependency to **0.14.1** (the bug-fix release) in both src csprojs — the last gate before cutting ETL-Test-Kit 0.9.0.

**0.14.1** is a PATCH: guards `Report.EstimatedRemaining` against a `TimeSpan` overflow + docs-accuracy fixes — **no public API change**. The test doubles don't touch `EstimatedRemaining`, so this is behavior-neutral here.

## Verification
- No transitive cascade on restore.
- `dotnet build ETL-Test-Kit.slnx -c Release` → 0 warnings / 0 errors (all TFMs).
- Tests `-c Release -f net8.0` → 122 (TestKit) + 236 (Xunit) green.

Targets `vNext`. After this + #185 land, `vNext` is ready for the `vNext → main` 0.9.0 release PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)