### PR TITLE
ci: add benchmarks.yaml workflow (protected-file split for 0.9.0)

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -1,0 +1,103 @@
+name: Benchmarks
+
+# Runs BenchmarkDotNet after a merge to main, then publishes the results to
+# the gh-pages branch under /dev/bench/ where benchmark-action/github-action-benchmark
+# renders an interactive line chart.
+#
+# This workflow is decoupled from PR validation and release: it does NOT gate
+# merging or publishing — it just adds one data point per qualifying push.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'benchmarks/**'
+      - '.github/workflows/benchmarks.yaml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Serialize benchmark publishes so two pushes to main close together can't race
+# on the gh-pages branch. cancel-in-progress: false — every merge represents a
+# meaningful data point, so we queue rather than discard.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  benchmark:
+    name: Run BenchmarkDotNet & publish chart
+    runs-on: ubuntu-latest
+
+    permissions:
+      # Required to push the rendered chart + history to the gh-pages branch.
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: |
+            10.0.x
+
+      - name: Restore
+        run: dotnet restore benchmarks/Wolfgang.Etl.TestKit.Benchmarks/Wolfgang.Etl.TestKit.Benchmarks.csproj
+
+      - name: Build (Release)
+        run: dotnet build -c Release --no-restore benchmarks/Wolfgang.Etl.TestKit.Benchmarks/Wolfgang.Etl.TestKit.Benchmarks.csproj
+
+      - name: Run benchmarks
+        working-directory: benchmarks/Wolfgang.Etl.TestKit.Benchmarks
+        # ShortRun keeps total runtime small (~3-5 min). GitHub-hosted runners
+        # are noisy, so chart trends are reliable for allocations and double-digit
+        # time changes; smaller deltas are not.
+        run: dotnet run -c Release --no-build -- --filter "*" --job short --memory --exporters json
+
+      - name: Merge per-class BDN reports
+        id: locate
+        working-directory: benchmarks/Wolfgang.Etl.TestKit.Benchmarks
+        run: |
+          # BDN's --exporters json writes one *-report-full-compressed.json per
+          # benchmark class. github-action-benchmark consumes a single file, so
+          # we combine the .Benchmarks arrays into one synthetic report.
+          # nullglob: empty match expands to nothing (instead of the literal
+          # pattern), so the explicit "no report found" branch can run before
+          # set -e + pipefail aborts the step.
+          shopt -s nullglob
+          reports=(BenchmarkDotNet.Artifacts/results/*-report-full-compressed.json)
+          if [ ${#reports[@]} -eq 0 ]; then
+            echo "::error::No BenchmarkDotNet JSON report found"
+            exit 1
+          fi
+          echo "Merging ${#reports[@]} report(s):"
+          printf '  %s\n' "${reports[@]}"
+          jq -s '{
+            Title: "BenchmarkDotNet combined report",
+            HostEnvironmentInfo: .[0].HostEnvironmentInfo,
+            Benchmarks: [.[].Benchmarks[]]
+          }' "${reports[@]}" > benchmarks-result.json
+          echo "report=benchmarks/Wolfgang.Etl.TestKit.Benchmarks/benchmarks-result.json" >> "$GITHUB_OUTPUT"
+
+      - name: Publish chart to gh-pages
+        # Pinned to v1.22.1 commit per repo convention (third-party actions
+        # publishing to gh-pages are pinned by SHA, not mutable tag).
+        uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba  # v1.22.1
+        with:
+          name: BenchmarkDotNet
+          tool: 'benchmarkdotnet'
+          output-file-path: ${{ steps.locate.outputs.report }}
+          gh-pages-branch: gh-pages
+          benchmark-data-dir-path: dev/bench
+          auto-push: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          # Don't fail the workflow if a metric regresses — this is a tracker,
+          # not a gate. Tighten later if the noise floor settles.
+          alert-threshold: '200%'
+          fail-on-alert: false


### PR DESCRIPTION
## Protected-file split for the 0.9.0 release

The `vNext → main` release PR (#187) trips the **Detect .NET Projects** protected-file guard because it introduces **one** protected file — `.github/workflows/benchmarks.yaml` (the BenchmarkDotNet → gh-pages chart workflow from #81, merged to `vNext` only).

This PR extracts that single file to `main` directly so the admin-bypass is scoped to just it. After this merges, #187 no longer introduces a protected-file change and passes the guard, so it can merge normally.

- One file, new addition, taken verbatim from `vNext`.
- Requires a maintainer **admin-bypass** merge (that's the point of the split).

🤖 Generated with [Claude Code](https://claude.com/claude-code)