### PR TITLE
test: raise Wolfgang.Etl.TestKit coverage to ≥90%

### DIFF
--- a/tests/Wolfgang.Etl.TestKit.Tests.Unit/FaultyExtractorTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Unit/FaultyExtractorTests.cs
@@ -313,6 +313,101 @@ public class FaultyExtractorTests
 
 
 
+    // ------------------------------------------------------------------
+    // Progress + injected timer
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task ExtractAsync_with_progress_and_injected_timer_reports_progress_when_timer_fires()
+    {
+        using var timer = new ManualProgressTimer();
+        var sut = new FaultyExtractorWithTimer(new List<int> { 1, 2, 3 }, timer);
+        Report? captured = null;
+        var progress = new SynchronousProgress<Report>(r => captured = r);
+
+        await using var enumerator = sut.ExtractAsync(progress).GetAsyncEnumerator();
+        await enumerator.MoveNextAsync();
+        timer.Fire();
+        while (await enumerator.MoveNextAsync()) { }
+
+        Assert.NotNull(captured);
+        Assert.True(captured!.CurrentItemCount >= 1);
+    }
+
+
+
+    [Fact]
+    public async Task ExtractAsync_with_progress_and_no_injected_timer_yields_all_items()
+    {
+        var sut = new FaultyExtractor<int>(new List<int> { 1, 2, 3 });
+        var progress = new SynchronousProgress<Report>(_ => { });
+
+        var results = await sut.ExtractAsync(progress).ToListAsync();
+
+        Assert.Equal(new[] { 1, 2, 3 }, results);
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // Dispose
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task Dispose_after_timer_wired_unsubscribes_so_firing_timer_does_not_report()
+    {
+        using var timer = new ManualProgressTimer();
+        var reportCount = 0;
+        var progress = new SynchronousProgress<Report>(_ => reportCount++);
+
+        var sut = new FaultyExtractorWithTimer(new List<int> { 1, 2, 3 }, timer);
+
+        // Pull one item so the timer is created and the Elapsed handler is wired,
+        // but leave the enumerator undrained so the base class does not dispose the
+        // injected timer in its finally. Disposing the SUT now runs the unsubscribe
+        // branch of Dispose(bool); firing afterwards must produce no report.
+        var enumerator = sut.ExtractAsync(progress).GetAsyncEnumerator();
+        await enumerator.MoveNextAsync();
+
+        sut.Dispose();
+        timer.Fire();
+
+        Assert.Equal(0, reportCount);
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // SkipItemCount / MaximumItemCount
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task ExtractAsync_skips_items_up_to_SkipItemCount()
+    {
+        var sut = new FaultyExtractor<int>(new[] { 1, 2, 3, 4, 5 });
+        sut.SkipItemCount = 2;
+
+        var results = await sut.ExtractAsync().ToListAsync();
+
+        Assert.Equal(new[] { 3, 4, 5 }, results);
+        Assert.Equal(2, sut.CurrentSkippedItemCount);
+    }
+
+
+
+    [Fact]
+    public async Task ExtractAsync_stops_at_MaximumItemCount()
+    {
+        var sut = new FaultyExtractor<int>(new[] { 1, 2, 3, 4, 5 });
+        sut.MaximumItemCount = 2;
+
+        var results = await sut.ExtractAsync().ToListAsync();
+
+        Assert.Equal(new[] { 1, 2 }, results);
+    }
+
+
+
     private sealed class FaultyExtractorWithTimer : FaultyExtractor<int>
     {
         public FaultyExtractorWithTimer(IEnumerable<int> items, IProgressTimer timer)

--- a/tests/Wolfgang.Etl.TestKit.Tests.Unit/FaultyLoaderTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Unit/FaultyLoaderTests.cs
@@ -277,6 +277,112 @@ public class FaultyLoaderTests
 
 
 
+    // ------------------------------------------------------------------
+    // Progress + injected timer
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task LoadAsync_with_progress_and_injected_timer_reports_progress_when_timer_fires()
+    {
+        using var timer = new ManualProgressTimer();
+        var loader = new FaultyLoaderWithTimer(collectItems: true, timer);
+        Report? captured = null;
+        var progress = new SynchronousProgress<Report>(r => captured = r);
+        var gate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var task = loader.LoadAsync(GatedSourceAsync(gate), progress);
+        timer.Fire();
+        gate.SetResult(true);
+        await task;
+
+        Assert.NotNull(captured);
+        Assert.True(captured!.CurrentItemCount >= 1);
+    }
+
+
+
+    [Fact]
+    public async Task LoadAsync_with_progress_and_no_injected_timer_loads_all_items()
+    {
+        var loader = new FaultyLoader<int>(collectItems: true);
+        var progress = new SynchronousProgress<Report>(_ => { });
+
+        await loader.LoadAsync(new FaultyExtractor<int>(new[] { 1, 2, 3 }).ExtractAsync(), progress);
+
+        Assert.Equal(new[] { 1, 2, 3 }, loader.GetCollectedItems());
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // Dispose
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task Dispose_after_timer_wired_runs_unsubscribe_branch_without_error()
+    {
+        using var timer = new ManualProgressTimer();
+        var progress = new SynchronousProgress<Report>(_ => { });
+
+        var loader = new FaultyLoaderWithTimer(collectItems: false, timer);
+
+        // A completed load wires (and leaves wired) the Elapsed handler. Disposing the
+        // loader then exercises the unsubscribe branch of Dispose(bool). The injected
+        // timer is owned by the caller, so disposing the loader must not dispose it.
+        await loader.LoadAsync(new FaultyExtractor<int>(new[] { 1, 2, 3 }).ExtractAsync(), progress);
+
+        var exception = Record.Exception(() => loader.Dispose());
+
+        Assert.Null(exception);
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // SkipItemCount / MaximumItemCount
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task LoadAsync_skips_items_up_to_SkipItemCount()
+    {
+        var loader = new FaultyLoader<int>(collectItems: true);
+        loader.SkipItemCount = 2;
+
+        await loader.LoadAsync(new FaultyExtractor<int>(new[] { 1, 2, 3, 4, 5 }).ExtractAsync());
+
+        Assert.Equal(new[] { 3, 4, 5 }, loader.GetCollectedItems());
+        Assert.Equal(2, loader.CurrentSkippedItemCount);
+    }
+
+
+
+    [Fact]
+    public async Task LoadAsync_stops_at_MaximumItemCount()
+    {
+        var loader = new FaultyLoader<int>(collectItems: true);
+        loader.MaximumItemCount = 2;
+
+        await loader.LoadAsync(new FaultyExtractor<int>(new[] { 1, 2, 3, 4, 5 }).ExtractAsync());
+
+        Assert.Equal(new[] { 1, 2 }, loader.GetCollectedItems());
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // Helpers
+    // ------------------------------------------------------------------
+
+    private static async IAsyncEnumerable<int> GatedSourceAsync(TaskCompletionSource<bool> gate)
+    {
+        yield return 1;
+        await gate.Task.ConfigureAwait(false);
+        yield return 2;
+        yield return 3;
+    }
+
+
+
     private sealed class FaultyLoaderWithTimer : FaultyLoader<int>
     {
         public FaultyLoaderWithTimer(bool collectItems, IProgressTimer timer)

--- a/tests/Wolfgang.Etl.TestKit.Tests.Unit/FaultyTransformerTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Unit/FaultyTransformerTests.cs
@@ -306,6 +306,107 @@ public class FaultyTransformerTests
 
 
 
+    // ------------------------------------------------------------------
+    // Progress + injected timer
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task TransformAsync_with_progress_and_injected_timer_reports_progress_when_timer_fires()
+    {
+        using var timer = new ManualProgressTimer();
+        var transformer = new FaultyTransformerWithTimer(timer);
+        var extractor   = new FaultyExtractor<int>(new[] { 1, 2, 3 });
+        Report? captured = null;
+        var progress = new SynchronousProgress<Report>(r => captured = r);
+
+        await using var enumerator =
+            transformer.TransformAsync(extractor.ExtractAsync(), progress).GetAsyncEnumerator();
+        await enumerator.MoveNextAsync();
+        timer.Fire();
+        while (await enumerator.MoveNextAsync()) { }
+
+        Assert.NotNull(captured);
+        Assert.True(captured!.CurrentItemCount >= 1);
+    }
+
+
+
+    [Fact]
+    public async Task TransformAsync_with_progress_and_no_injected_timer_yields_all_items()
+    {
+        var transformer = new FaultyTransformer<int>();
+        var extractor   = new FaultyExtractor<int>(new[] { 1, 2, 3 });
+        var progress    = new SynchronousProgress<Report>(_ => { });
+
+        var results = await transformer.TransformAsync(extractor.ExtractAsync(), progress).ToListAsync();
+
+        Assert.Equal(new[] { 1, 2, 3 }, results);
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // Dispose
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task Dispose_after_timer_wired_unsubscribes_so_firing_timer_does_not_report()
+    {
+        using var timer = new ManualProgressTimer();
+        var reportCount = 0;
+        var progress = new SynchronousProgress<Report>(_ => reportCount++);
+
+        var transformer = new FaultyTransformerWithTimer(timer);
+        var extractor   = new FaultyExtractor<int>(new[] { 1, 2, 3 });
+
+        // Pull one item so the timer is wired, but leave the enumerator undrained so
+        // the base class does not dispose the injected timer in its finally. Disposing
+        // the SUT runs the unsubscribe branch; firing afterwards must produce no report.
+        var enumerator =
+            transformer.TransformAsync(extractor.ExtractAsync(), progress).GetAsyncEnumerator();
+        await enumerator.MoveNextAsync();
+
+        transformer.Dispose();
+        timer.Fire();
+
+        Assert.Equal(0, reportCount);
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // SkipItemCount / MaximumItemCount
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task TransformAsync_skips_items_up_to_SkipItemCount()
+    {
+        var extractor   = new FaultyExtractor<int>(new[] { 1, 2, 3, 4, 5 });
+        var transformer = new FaultyTransformer<int>();
+        transformer.SkipItemCount = 2;
+
+        var results = await transformer.TransformAsync(extractor.ExtractAsync()).ToListAsync();
+
+        Assert.Equal(new[] { 3, 4, 5 }, results);
+        Assert.Equal(2, transformer.CurrentSkippedItemCount);
+    }
+
+
+
+    [Fact]
+    public async Task TransformAsync_stops_at_MaximumItemCount()
+    {
+        var extractor   = new FaultyExtractor<int>(new[] { 1, 2, 3, 4, 5 });
+        var transformer = new FaultyTransformer<int>();
+        transformer.MaximumItemCount = 2;
+
+        var results = await transformer.TransformAsync(extractor.ExtractAsync()).ToListAsync();
+
+        Assert.Equal(new[] { 1, 2 }, results);
+    }
+
+
+
     private sealed class FaultyTransformerWithTimer : FaultyTransformer<int>
     {
         public FaultyTransformerWithTimer(IProgressTimer timer) : base(timer) { }

--- a/tests/Wolfgang.Etl.TestKit.Tests.Unit/TestExtractorTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Unit/TestExtractorTests.cs
@@ -666,6 +666,193 @@ public class TestExtractorTests
 
 
     // ------------------------------------------------------------------
+    // Factory + timer constructors — argument validation
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void Constructor_with_func_factory_and_timer_when_factory_is_null_throws_ArgumentNullException()
+    {
+        using var timer = new ManualProgressTimer();
+        var ex = Assert.Throws<ArgumentNullException>
+        (
+            () => new TestExtractorWithTimer((Func<int>)null!, timer)
+        );
+
+        Assert.Equal("factory", ex.ParamName);
+    }
+
+
+
+    [Fact]
+    public void Constructor_with_func_factory_and_timer_when_timer_is_null_throws_ArgumentNullException()
+    {
+        var ex = Assert.Throws<ArgumentNullException>
+        (
+            () => new TestExtractorWithTimer(() => 1, null!)
+        );
+
+        Assert.Equal("timer", ex.ParamName);
+    }
+
+
+
+    [Fact]
+    public void Constructor_with_func_factory_count_and_timer_when_factory_is_null_throws_ArgumentNullException()
+    {
+        using var timer = new ManualProgressTimer();
+        var ex = Assert.Throws<ArgumentNullException>
+        (
+            () => new TestExtractorWithTimer((Func<int>)null!, 3, timer)
+        );
+
+        Assert.Equal("factory", ex.ParamName);
+    }
+
+
+
+    [Fact]
+    public void Constructor_with_func_factory_count_and_timer_when_count_is_negative_throws_ArgumentOutOfRangeException()
+    {
+        using var timer = new ManualProgressTimer();
+        var ex = Assert.Throws<ArgumentOutOfRangeException>
+        (
+            () => new TestExtractorWithTimer(() => 1, -1, timer)
+        );
+
+        Assert.Equal("count", ex.ParamName);
+    }
+
+
+
+    [Fact]
+    public void Constructor_with_func_factory_count_and_timer_when_timer_is_null_throws_ArgumentNullException()
+    {
+        var ex = Assert.Throws<ArgumentNullException>
+        (
+            () => new TestExtractorWithTimer(() => 1, 3, null!)
+        );
+
+        Assert.Equal("timer", ex.ParamName);
+    }
+
+
+
+    [Fact]
+    public void Constructor_with_indexed_factory_and_timer_when_factory_is_null_throws_ArgumentNullException()
+    {
+        using var timer = new ManualProgressTimer();
+        var ex = Assert.Throws<ArgumentNullException>
+        (
+            () => new TestExtractorWithTimer((Func<int, int>)null!, timer)
+        );
+
+        Assert.Equal("factory", ex.ParamName);
+    }
+
+
+
+    [Fact]
+    public void Constructor_with_indexed_factory_and_timer_when_timer_is_null_throws_ArgumentNullException()
+    {
+        var ex = Assert.Throws<ArgumentNullException>
+        (
+            () => new TestExtractorWithTimer((Func<int, int>)(i => i), null!)
+        );
+
+        Assert.Equal("timer", ex.ParamName);
+    }
+
+
+
+    [Fact]
+    public void Constructor_with_indexed_factory_count_and_timer_when_factory_is_null_throws_ArgumentNullException()
+    {
+        using var timer = new ManualProgressTimer();
+        var ex = Assert.Throws<ArgumentNullException>
+        (
+            () => new TestExtractorWithTimer((Func<int, int>)null!, 3, timer)
+        );
+
+        Assert.Equal("factory", ex.ParamName);
+    }
+
+
+
+    [Fact]
+    public void Constructor_with_indexed_factory_count_and_timer_when_count_is_negative_throws_ArgumentOutOfRangeException()
+    {
+        using var timer = new ManualProgressTimer();
+        var ex = Assert.Throws<ArgumentOutOfRangeException>
+        (
+            () => new TestExtractorWithTimer((Func<int, int>)(i => i), -1, timer)
+        );
+
+        Assert.Equal("count", ex.ParamName);
+    }
+
+
+
+    [Fact]
+    public void Constructor_with_indexed_factory_count_and_timer_when_timer_is_null_throws_ArgumentNullException()
+    {
+        var ex = Assert.Throws<ArgumentNullException>
+        (
+            () => new TestExtractorWithTimer((Func<int, int>)(i => i), 3, null!)
+        );
+
+        Assert.Equal("timer", ex.ParamName);
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // Progress + injected timer / Dispose
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task ExtractAsync_with_progress_and_injected_timer_reports_progress_when_timer_fires()
+    {
+        using var timer = new ManualProgressTimer();
+        var sut = new TestExtractorWithTimer(new List<int> { 1, 2, 3 }, timer);
+        Report? captured = null;
+        var progress = new SynchronousProgress<Report>(r => captured = r);
+
+        await using var enumerator = sut.ExtractAsync(progress).GetAsyncEnumerator();
+        await enumerator.MoveNextAsync();
+        timer.Fire();
+        while (await enumerator.MoveNextAsync()) { }
+
+        Assert.NotNull(captured);
+        Assert.True(captured!.CurrentItemCount >= 1);
+    }
+
+
+
+    [Fact]
+    public async Task Dispose_after_timer_wired_unsubscribes_so_firing_timer_does_not_report()
+    {
+        using var timer = new ManualProgressTimer();
+        var reportCount = 0;
+        var progress = new SynchronousProgress<Report>(_ => reportCount++);
+
+        var sut = new TestExtractorWithTimer(new List<int> { 1, 2, 3 }, timer);
+
+        // Pull one item so the timer is created and the Elapsed handler is wired,
+        // but leave the enumerator undrained so the base class does not dispose the
+        // injected timer in its finally. Disposing the SUT now runs the unsubscribe
+        // branch of Dispose(bool); firing afterwards must produce no report.
+        var enumerator = sut.ExtractAsync(progress).GetAsyncEnumerator();
+        await enumerator.MoveNextAsync();
+
+        sut.Dispose();
+        timer.Fire();
+
+        Assert.Equal(0, reportCount);
+    }
+
+
+
+    // ------------------------------------------------------------------
     // Private helpers
     // ------------------------------------------------------------------
 

--- a/tests/Wolfgang.Etl.TestKit.Tests.Unit/TestLoaderTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Unit/TestLoaderTests.cs
@@ -325,6 +325,60 @@ public class TestLoaderTests
 
 
 
+    // ------------------------------------------------------------------
+    // Progress + injected timer / Dispose
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task LoadAsync_with_progress_and_injected_timer_reports_progress_when_timer_fires()
+    {
+        using var timer = new ManualProgressTimer();
+        var loader = new TestLoaderWithTimer(collectItems: true, timer);
+        Report? captured = null;
+        var progress = new SynchronousProgress<Report>(r => captured = r);
+        var gate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var task = loader.LoadAsync(GatedSourceAsync(gate), progress);
+        timer.Fire();
+        gate.SetResult(true);
+        await task;
+
+        Assert.NotNull(captured);
+        Assert.True(captured!.CurrentItemCount >= 1);
+    }
+
+
+
+    [Fact]
+    public async Task Dispose_after_timer_wired_runs_unsubscribe_branch_without_error()
+    {
+        using var timer = new ManualProgressTimer();
+        var progress = new SynchronousProgress<Report>(_ => { });
+
+        var loader = new TestLoaderWithTimer(collectItems: false, timer);
+
+        // A completed load wires (and leaves wired) the Elapsed handler. Disposing the
+        // loader then exercises the unsubscribe branch of Dispose(bool). The injected
+        // timer is owned by the caller, so disposing the loader must not dispose it.
+        await loader.LoadAsync(new TestExtractor<int>(new List<int> { 1, 2, 3 }).ExtractAsync(), progress);
+
+        var exception = Record.Exception(() => loader.Dispose());
+
+        Assert.Null(exception);
+    }
+
+
+
+    private static async IAsyncEnumerable<int> GatedSourceAsync(TaskCompletionSource<bool> gate)
+    {
+        yield return 1;
+        await gate.Task.ConfigureAwait(false);
+        yield return 2;
+        yield return 3;
+    }
+
+
+
     private sealed class ExposedTestLoader<T>(bool collectItems) : TestLoader<T>(collectItems) where T : notnull
     {
         public Report GetProgressReport() => CreateProgressReport();

--- a/tests/Wolfgang.Etl.TestKit.Tests.Unit/TestTransformerTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Unit/TestTransformerTests.cs
@@ -179,6 +179,56 @@ public class TestTransformerTests
 
 
 
+    // ------------------------------------------------------------------
+    // Progress + injected timer / Dispose
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task TransformAsync_with_progress_and_injected_timer_reports_progress_when_timer_fires()
+    {
+        using var timer = new ManualProgressTimer();
+        var transformer = new TestTransformerWithTimer(timer);
+        var extractor   = new TestExtractor<int>(new List<int> { 1, 2, 3 });
+        Report? captured = null;
+        var progress = new SynchronousProgress<Report>(r => captured = r);
+
+        await using var enumerator =
+            transformer.TransformAsync(extractor.ExtractAsync(), progress).GetAsyncEnumerator();
+        await enumerator.MoveNextAsync();
+        timer.Fire();
+        while (await enumerator.MoveNextAsync()) { }
+
+        Assert.NotNull(captured);
+        Assert.True(captured!.CurrentItemCount >= 1);
+    }
+
+
+
+    [Fact]
+    public async Task Dispose_after_timer_wired_unsubscribes_so_firing_timer_does_not_report()
+    {
+        using var timer = new ManualProgressTimer();
+        var reportCount = 0;
+        var progress = new SynchronousProgress<Report>(_ => reportCount++);
+
+        var transformer = new TestTransformerWithTimer(timer);
+        var extractor   = new TestExtractor<int>(new List<int> { 1, 2, 3 });
+
+        // Pull one item so the timer is wired, but leave the enumerator undrained so
+        // the base class does not dispose the injected timer in its finally. Disposing
+        // the SUT runs the unsubscribe branch; firing afterwards must produce no report.
+        var enumerator =
+            transformer.TransformAsync(extractor.ExtractAsync(), progress).GetAsyncEnumerator();
+        await enumerator.MoveNextAsync();
+
+        transformer.Dispose();
+        timer.Fire();
+
+        Assert.Equal(0, reportCount);
+    }
+
+
+
     private sealed class ExposedTestTransformer<T> : TestTransformer<T> where T : notnull
     {
         public Report GetProgressReport() => CreateProgressReport();


### PR DESCRIPTION
## Why
The `vNext → main` release PR (#187) fails CI's **per-assembly 90% coverage gate**: the `Wolfgang.Etl.TestKit` assembly sat at **80.3%**. This PR adds test-only coverage to clear the gate and unblock #187.

## Result
**Assembly `Wolfgang.Etl.TestKit`: 80.3% → 99.13% line coverage.**

Per-class (before → after):

| Class | Before | After |
|---|---|---|
| FaultyExtractor | 72.8% | 100% |
| FaultyTransformer | 69.2% | 100% |
| FaultyLoader | 75% | 100% |
| TestTransformer | 83.3% | 94.1% |
| TestLoader | 86.8% | 95.8% |
| TestExtractor | 89.7% | 98.7% |

## What was covered
The previously-uncovered paths, all shared by the six doubles:

1. **Progress + injected-timer path** — `CreateProgressTimer` wiring (both the `_progressTimer is null → base` and the `!_progressTimerWired → subscribe` branches), `CreateProgressReport`, and the `Elapsed` handler firing a progress report. Added on all three `Faulty*` doubles and the `Test*` doubles, plus the `TestExtractor` factory/indexed factory-with-timer constructor argument-validation branches.
2. **`Dispose(bool)` unsubscribe branch** — covered on all six doubles.
3. **`SkipItemCount` / `MaximumItemCount` enforcement** on the `Faulty*` doubles (skip-continue and max-break branches).

All new tests mirror the existing patterns (the `*WithTimer` nested subclass exposing the protected timer ctor, `ManualProgressTimer` + `SynchronousProgress<Report>` from `Wolfgang.Etl.TestKit.Xunit`). Test code only — no `src/` production file was modified.

## Verification (local)
- `dotnet build -c Release`: 0 warnings, 0 errors (warnings-as-errors) across all test TFMs.
- Full multi-TFM run: **153/153 passed** on net6.0/7.0/8.0/9.0/10.0 and net462/472/48/481.
- Coverage (`--collect:"XPlat Code Coverage"`, net8.0): assembly line-rate **0.9913**; every double class ≥ 0.94.

🤖 Generated with [Claude Code](https://claude.com/claude-code)