### PR TITLE
release: v0.10.0 — ISupportDryRun contract-test base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `SupportsDryRunContractTests<TSut>` — an opt-in xUnit contract-test base that verifies
+  a stage implementing `ISupportDryRun` actually *skips its external side effect* when
+  `IsDryRun` is `true` (not merely exposes the property). Stage-agnostic: the derived test
+  supplies `RunAsync` and `SideEffectOccurredAsync`. Requires `Wolfgang.Etl.Abstractions`
+  0.15.0. (ETL-Abstractions#259, ETL-Test-Kit#195)
+- `TestLoader<T>` now implements `ISupportDryRun`: in dry-run mode it still enumerates the
+  source and advances progress counters but skips collecting items, serving as the
+  reference implementation exercised by the new contract base.
+
 ### Changed
+
+- Built against `Wolfgang.Etl.Abstractions` 0.15.0 (was 0.14.1).
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,18 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `SupportsDryRunContractTests<TSut>` — an opt-in xUnit contract-test base that verifies
-  a stage implementing `ISupportDryRun` actually *skips its external side effect* when
-  `IsDryRun` is `true` (not merely exposes the property). Stage-agnostic: the derived test
-  supplies `RunAsync` and `SideEffectOccurredAsync`. Requires `Wolfgang.Etl.Abstractions`
-  0.15.0. (ETL-Abstractions#259, ETL-Test-Kit#195)
-- `TestLoader<T>` now implements `ISupportDryRun`: in dry-run mode it still enumerates the
-  source and advances progress counters but skips collecting items, serving as the
-  reference implementation exercised by the new contract base.
-
 ### Changed
-
-- Built against `Wolfgang.Etl.Abstractions` 0.15.0 (was 0.14.1).
 
 ### Deprecated
 
@@ -29,6 +18,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### Security
+
+## [0.10.0] - 2026-06-29
+
+Adds an opt-in contract-test base for the `ISupportDryRun` interface introduced in
+`Wolfgang.Etl.Abstractions` 0.15.0. No breaking change.
+
+### Added
+
+- `SupportsDryRunContractTests<TSut>` — an opt-in xUnit contract-test base that verifies
+  a stage implementing `ISupportDryRun` actually *skips its external side effect* when
+  `IsDryRun` is `true` (not merely exposes the property). Stage-agnostic: the derived test
+  supplies `CreateSut()` and a single `RunAndReportSideEffectAsync(bool)`. Requires
+  `Wolfgang.Etl.Abstractions` 0.15.0. (ETL-Abstractions#259, ETL-Test-Kit#195)
+- `TestLoader<T>` now implements `ISupportDryRun`: in dry-run mode it still enumerates the
+  source and advances progress counters but skips collecting items, serving as the
+  reference implementation exercised by the new contract base.
+
+### Changed
+
+- Built against `Wolfgang.Etl.Abstractions` 0.15.0 (was 0.14.1).
 
 ## [0.9.0] - 2026-06-23
 

--- a/src/Wolfgang.Etl.TestKit.Xunit/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.TestKit.Xunit/PublicAPI.Unshipped.txt
@@ -1,1 +1,10 @@
 #nullable enable
+Wolfgang.Etl.TestKit.Xunit.SupportsDryRunContractTests<TSut>
+Wolfgang.Etl.TestKit.Xunit.SupportsDryRunContractTests<TSut>.SupportsDryRunContractTests() -> void
+Wolfgang.Etl.TestKit.Xunit.SupportsDryRunContractTests<TSut>.IsDryRun_can_be_set_back_to_false() -> void
+Wolfgang.Etl.TestKit.Xunit.SupportsDryRunContractTests<TSut>.IsDryRun_can_be_set_to_true() -> void
+Wolfgang.Etl.TestKit.Xunit.SupportsDryRunContractTests<TSut>.IsDryRun_defaults_to_false() -> void
+Wolfgang.Etl.TestKit.Xunit.SupportsDryRunContractTests<TSut>.When_IsDryRun_is_false_side_effect_occurs_Async() -> System.Threading.Tasks.Task!
+Wolfgang.Etl.TestKit.Xunit.SupportsDryRunContractTests<TSut>.When_IsDryRun_is_true_side_effect_is_skipped_Async() -> System.Threading.Tasks.Task!
+abstract Wolfgang.Etl.TestKit.Xunit.SupportsDryRunContractTests<TSut>.CreateSut() -> TSut
+abstract Wolfgang.Etl.TestKit.Xunit.SupportsDryRunContractTests<TSut>.RunAndReportSideEffectAsync(bool isDryRun) -> System.Threading.Tasks.Task<bool>!

--- a/src/Wolfgang.Etl.TestKit.Xunit/SupportsDryRunContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/SupportsDryRunContractTests.cs
@@ -1,0 +1,151 @@
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+using Xunit;
+
+namespace Wolfgang.Etl.TestKit.Xunit;
+
+/// <summary>
+/// Abstract base class providing xUnit contract tests for any type that implements
+/// <see cref="ISupportDryRun"/>.
+/// </summary>
+/// <typeparam name="TSut">
+/// The type under test. Must implement <see cref="ISupportDryRun"/>.
+/// </typeparam>
+/// <remarks>
+/// <para>
+/// Inherit from this class to verify that your stage honours the
+/// <see cref="ISupportDryRun"/> contract — that it actually <em>skips its external
+/// side effect</em> when <see cref="ISupportDryRun.IsDryRun"/> is <see langword="true"/>,
+/// rather than merely exposing the property. The interface is opt-in and the ETL base
+/// classes deliberately do not implement it, so this contract is the only guarantee
+/// that an implementer truly performs no write/acknowledgement in dry-run mode.
+/// </para>
+/// <para>
+/// The base is stage-agnostic: implement <see cref="RunAndReportSideEffectAsync"/> to
+/// create your stage with the supplied dry-run setting, drive it to completion (a loader's
+/// <c>LoadAsync</c>, an extractor's enumerated <c>ExtractAsync</c>, and so on), and report
+/// whether the external side effect occurred.
+/// </para>
+/// <para>
+/// This contract covers <see cref="ISupportDryRun.IsDryRun"/> only. That the pipeline
+/// still runs fully in dry-run mode (progress counters advancing, items enumerated) is
+/// covered by the stage's own base-class contract tests — for example
+/// <see cref="LoaderBaseContractTests{TSut, TItem, TProgress}"/> — which a dry-run loader
+/// should also inherit.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// public class MyLoaderDryRunContractTests
+///     : SupportsDryRunContractTests&lt;MyLoader&gt;
+/// {
+///     protected override MyLoader CreateSut() => new MyLoader(connectionString);
+///
+///     protected override async Task&lt;bool&gt; RunAndReportSideEffectAsync(bool isDryRun)
+///     {
+///         var loader = new MyLoader(connectionString) { IsDryRun = isDryRun };
+///         await loader.LoadAsync(CreateSourceItems().ToAsyncEnumerable());
+///         return await CountRowsAsync(connectionString) &gt; 0;
+///     }
+/// }
+/// </code>
+/// </example>
+public abstract class SupportsDryRunContractTests<TSut>
+    where TSut : class, ISupportDryRun
+{
+    // ------------------------------------------------------------------
+    // Factory / harness methods
+    // ------------------------------------------------------------------
+
+    /// <summary>
+    /// Creates the system under test with <see cref="ISupportDryRun.IsDryRun"/> at its
+    /// default value. Used by the property-contract tests.
+    /// </summary>
+    protected abstract TSut CreateSut();
+
+    /// <summary>
+    /// Creates a stage with <see cref="ISupportDryRun.IsDryRun"/> set to
+    /// <paramref name="isDryRun"/>, runs it through a complete execution — the same call a
+    /// consumer would make — and reports whether the external side effect occurred (for
+    /// example rows written, a message acknowledged, or a file moved).
+    /// </summary>
+    /// <param name="isDryRun">The value to assign to <see cref="ISupportDryRun.IsDryRun"/>.</param>
+    /// <returns><see langword="true"/> if the side effect occurred; otherwise <see langword="false"/>.</returns>
+    protected abstract Task<bool> RunAndReportSideEffectAsync(bool isDryRun);
+
+
+
+    // ------------------------------------------------------------------
+    // IsDryRun property contract
+    // ------------------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="ISupportDryRun.IsDryRun"/> defaults to <see langword="false"/>.
+    /// </summary>
+    [Fact]
+    public void IsDryRun_defaults_to_false()
+    {
+        var sut = CreateSut();
+        Assert.False(sut.IsDryRun);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ISupportDryRun.IsDryRun"/> can be set to <see langword="true"/>.
+    /// </summary>
+    [Fact]
+    public void IsDryRun_can_be_set_to_true()
+    {
+        var sut = CreateSut();
+        sut.IsDryRun = true;
+        Assert.True(sut.IsDryRun);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ISupportDryRun.IsDryRun"/> can be set back to
+    /// <see langword="false"/> after being set to <see langword="true"/>.
+    /// </summary>
+    [Fact]
+    public void IsDryRun_can_be_set_back_to_false()
+    {
+        var sut = CreateSut();
+        sut.IsDryRun = true;
+        sut.IsDryRun = false;
+        Assert.False(sut.IsDryRun);
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // Dry-run behaviour contract
+    // ------------------------------------------------------------------
+
+    /// <summary>
+    /// Control case: verifies that when <see cref="ISupportDryRun.IsDryRun"/> is
+    /// <see langword="false"/>, a full run <em>does</em> perform the external side effect.
+    /// Without this, a stage that never produces a side effect could pass the dry-run
+    /// test vacuously.
+    /// </summary>
+    [Fact]
+    public async Task When_IsDryRun_is_false_side_effect_occurs_Async()
+    {
+        Assert.True
+        (
+            await RunAndReportSideEffectAsync(isDryRun: false).ConfigureAwait(false),
+            "Expected the side effect to occur when IsDryRun is false."
+        );
+    }
+
+    /// <summary>
+    /// Verifies that when <see cref="ISupportDryRun.IsDryRun"/> is <see langword="true"/>,
+    /// a full run completes but the external side effect is <em>skipped</em>.
+    /// </summary>
+    [Fact]
+    public async Task When_IsDryRun_is_true_side_effect_is_skipped_Async()
+    {
+        Assert.False
+        (
+            await RunAndReportSideEffectAsync(isDryRun: true).ConfigureAwait(false),
+            "Expected the side effect to be skipped when IsDryRun is true."
+        );
+    }
+}

--- a/src/Wolfgang.Etl.TestKit.Xunit/Wolfgang.Etl.TestKit.Xunit.csproj
+++ b/src/Wolfgang.Etl.TestKit.Xunit/Wolfgang.Etl.TestKit.Xunit.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net462;net481;netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>
-    <Version>0.9.0</Version>
+    <Version>0.10.0</Version>
     <!-- Pin AssemblyVersion to a fixed binding-stability baseline so consumers
          do not need to recompile / add binding redirects on every minor/patch
          bump. Bump only on a deliberate breaking API change. FileVersion +
@@ -70,7 +70,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Bcl.Memory" Version="10.0.9" />
-    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.14.1" />
+    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.15.0" />
     <PackageReference Include="System.Linq.Async" Version="7.0.1" />
     <PackageReference Include="xunit.abstractions" Version="2.0.3" />
     <PackageReference Include="xunit.assert" Version="2.9.3" />

--- a/src/Wolfgang.Etl.TestKit/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.TestKit/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Wolfgang.Etl.TestKit.TestLoader<T>.IsDryRun.get -> bool
+Wolfgang.Etl.TestKit.TestLoader<T>.IsDryRun.set -> void

--- a/src/Wolfgang.Etl.TestKit/TestLoader.cs
+++ b/src/Wolfgang.Etl.TestKit/TestLoader.cs
@@ -49,7 +49,7 @@ namespace Wolfgang.Etl.TestKit;
 /// // loader.GetCollectedItems() returns null in this mode
 /// </code>
 /// </example>
-public class TestLoader<T> : LoaderBase<T, Report>
+public class TestLoader<T> : LoaderBase<T, Report>, ISupportDryRun
     where T : notnull
 {
     // ------------------------------------------------------------------
@@ -132,6 +132,19 @@ public class TestLoader<T> : LoaderBase<T, Report>
 
 
 
+    /// <summary>
+    /// Gets or sets a value indicating whether the loader runs in dry-run mode.
+    /// </summary>
+    /// <value>
+    /// When <see langword="true"/>, the loader still enumerates the full source and
+    /// advances its progress counters, but skips its side effect — items are not added
+    /// to the collection buffer, so <see cref="GetCollectedItems"/> reports nothing was
+    /// loaded. Defaults to <see langword="false"/>.
+    /// </value>
+    public bool IsDryRun { get; set; }
+
+
+
     // ------------------------------------------------------------------
     // LoaderBase overrides
     // ------------------------------------------------------------------
@@ -210,7 +223,7 @@ public class TestLoader<T> : LoaderBase<T, Report>
                     break;
                 }
 
-                if (_collectItems)
+                if (_collectItems && !IsDryRun)
                 {
                     _buffer.Add(item);
                 }

--- a/src/Wolfgang.Etl.TestKit/Wolfgang.Etl.TestKit.csproj
+++ b/src/Wolfgang.Etl.TestKit/Wolfgang.Etl.TestKit.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net462;net481;netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>
-    <Version>0.9.0</Version>
+    <Version>0.10.0</Version>
     <!-- Pin AssemblyVersion to a fixed binding-stability baseline so consumers
          do not need to recompile / add binding redirects on every minor/patch
          bump. Bump only on a deliberate breaking API change. FileVersion +
@@ -65,7 +65,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Bcl.Memory" Version="10.0.9" />
-    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.14.1" />
+    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.15.0" />
     <PackageReference Include="System.Linq.Async" Version="7.0.1" />
   </ItemGroup>
 

--- a/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/TestLoaderDryRunContractTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/TestLoaderDryRunContractTests.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Wolfgang.Etl.TestKit.Xunit.Tests.Unit;
+
+/// <summary>
+/// Verifies that <see cref="TestLoader{T}"/> satisfies the
+/// <see cref="SupportsDryRunContractTests{TSut}"/> contract.
+/// </summary>
+/// <remarks>
+/// This class also serves as a reference example of how to wire up
+/// <see cref="SupportsDryRunContractTests{TSut}"/> for your own dry-run-aware stage.
+/// The observable side effect for <see cref="TestLoader{T}"/> is collecting items into
+/// its buffer; dry-run mode skips it, so <c>GetCollectedItems()</c> reports nothing.
+/// </remarks>
+public class TestLoaderDryRunContractTests
+    : SupportsDryRunContractTests<TestLoader<int>>
+{
+    private static IAsyncEnumerable<int> SourceItemsAsync() =>
+        Enumerable.Range(1, 5).ToAsyncEnumerable();
+
+    /// <inheritdoc/>
+    protected override TestLoader<int> CreateSut() =>
+        new TestLoader<int>(collectItems: true);
+
+    /// <inheritdoc/>
+    protected override async Task<bool> RunAndReportSideEffectAsync(bool isDryRun)
+    {
+        var loader = new TestLoader<int>(collectItems: true) { IsDryRun = isDryRun };
+        await loader.LoadAsync(SourceItemsAsync()).ConfigureAwait(false);
+        return loader.GetCollectedItems()?.Count > 0;
+    }
+}


### PR DESCRIPTION
## Release v0.10.0

Folds the 0.10.0 cycle from `vNext` into `main`.

### Added
- `SupportsDryRunContractTests<TSut>` — opt-in xUnit contract-test base verifying a stage that implements `ISupportDryRun` actually **skips its external side effect** when `IsDryRun` is `true` (not merely exposes the property). Stage-agnostic via `CreateSut()` + `RunAndReportSideEffectAsync(bool)`. (#195, PR #196)
- `TestLoader<T>` now implements `ISupportDryRun` (reference implementation exercised by the new contract base).

### Changed
- Built against `Wolfgang.Etl.Abstractions` 0.15.0 (was 0.14.1).

### Verification
- Release build all TFMs (net462;net481;netstandard2.0;net8.0;net10.0): 0 warnings / 0 errors
- Tests (net8.0): TestKit 153, TestKit.Xunit 241
- Coverage: `Wolfgang.Etl.TestKit` 99.13%, `Wolfgang.Etl.TestKit.Xunit` 99.32% (≥ 95% gate)

### Version
- `0.9.0` → `0.10.0` for both `Wolfgang.Etl.TestKit` and `Wolfgang.Etl.TestKit.Xunit` (additive surface = MINOR)

Closes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)
