### PR TITLE
chore(deps): bump Wolfgang.Etl.Abstractions to 0.16.0

### DIFF
--- a/src/Wolfgang.Etl.TestKit.Xunit/Wolfgang.Etl.TestKit.Xunit.csproj
+++ b/src/Wolfgang.Etl.TestKit.Xunit/Wolfgang.Etl.TestKit.Xunit.csproj
@@ -70,7 +70,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Bcl.Memory" Version="10.0.10" />
-    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.15.0" />
+    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.16.0" />
     <PackageReference Include="System.Linq.Async" Version="7.0.1" />
     <PackageReference Include="xunit.abstractions" Version="2.0.3" />
     <PackageReference Include="xunit.assert" Version="2.9.3" />

--- a/src/Wolfgang.Etl.TestKit/Wolfgang.Etl.TestKit.csproj
+++ b/src/Wolfgang.Etl.TestKit/Wolfgang.Etl.TestKit.csproj
@@ -65,7 +65,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Bcl.Memory" Version="10.0.10" />
-    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.15.0" />
+    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.16.0" />
     <PackageReference Include="System.Linq.Async" Version="7.0.1" />
   </ItemGroup>
 


### PR DESCRIPTION
Bumps `Wolfgang.Etl.Abstractions` from 0.15.0 to 0.16.0 in both source projects (TestKit and TestKit.Xunit).

- Restore clean, no NU1605 / transitive cascade.
- Release build: 0 warnings, 0 errors.
- Tests: 394 pass (net8.0).

Targets `vNext` for the 0.11.0 release cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)