### PR TITLE
ci: add OSSF Scorecard security-posture scan (#142)

### DIFF
--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -33,7 +33,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 
@@ -45,6 +45,6 @@ jobs:
           publish_results: true
 
       - name: Upload SARIF to Code Scanning
-        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
+        uses: github/codeql-action/upload-sarif@e0647621c2984b5ed2f768cb892365bf2a616ad1 # v4
         with:
           sarif_file: results.sarif

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -1,0 +1,50 @@
+name: OSSF Scorecard
+
+# Automated security-posture scoring via the OpenSSF Scorecard (#142).
+#
+# Scorecard evaluates the repo against supply-chain / security best practices
+# (branch protection, pinned dependencies, token permissions, dangerous
+# workflow patterns, ...) and uploads findings to Code Scanning. Runs on a
+# weekly schedule and on branch-protection changes; not per-PR (it scores the
+# repository, not a diff).
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '31 6 * * 1'   # Mondays at 06:31 UTC
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions: read-all
+
+concurrency:
+  group: scorecard-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      security-events: write   # upload the SARIF results
+      id-token: write          # publish results to the OpenSSF API
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a  # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload SARIF to Code Scanning
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ An Extractor, Transformer and Loader designed to be used in testing libraries bu
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![.NET](https://img.shields.io/badge/.NET-Multi--Targeted-purple.svg)](https://dotnet.microsoft.com/)
 [![GitHub](https://img.shields.io/badge/GitHub-Repository-181717?logo=github)](https://github.com/Chris-Wolfgang/ETL-Test-Kit)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/Chris-Wolfgang/ETL-Test-Kit/badge)](https://scorecard.dev/viewer/?uri=github.com/Chris-Wolfgang/ETL-Test-Kit)
 
 ---
 


### PR DESCRIPTION
Stacked on #215. Adds `scorecard.yaml` — runs the OpenSSF Scorecard action weekly + on push to main + on branch-protection changes (not per-PR; it scores the *repo*, not a diff), publishes to the OpenSSF API, and uploads SARIF to the Security tab alongside CodeQL. Adds the Scorecard **badge** to README. Ported from D20-Dice.

## AC status
- ✅ Weekly schedule + push-to-main, SARIF to Code Scanning, README badge.
- ⏳ **Follow-up (needs first run):** documented score floor + baseline scan — the initial score isn't known until Scorecard runs once on `main`. I'll capture the baseline + floor after the first scheduled/dispatch run publishes a score.

Closes #142 when the vNext cycle merges to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)