### PR TITLE
ci: add Semgrep SAST beyond CodeQL (#117)

### DIFF
--- a/.github/workflows/semgrep.yaml
+++ b/.github/workflows/semgrep.yaml
@@ -1,0 +1,62 @@
+name: SAST (Semgrep)
+
+# Security-grade static analysis beyond CodeQL (#117).
+#
+# Semgrep runs a different engine and ruleset from CodeQL (pattern/dataflow
+# rules for C#, a general security-audit pack, and a secrets pack), so it
+# surfaces issues CodeQL's queries don't. Findings upload to Code Scanning
+# (Security tab) as an additional signal; report-only for now (`|| true`) so a
+# noisy new ruleset can't block merges — promote to a gate once the baseline is
+# clean.
+#
+# Uses the public Semgrep registry packs, which need no account/login (the free
+# Semgrep OSS tier — the "try the free tool first" path the issue calls for).
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: semgrep-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  semgrep:
+    name: Semgrep
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: '3.x'
+
+      - name: Install Semgrep
+        run: pip install semgrep
+
+      - name: Run Semgrep
+        run: |
+          semgrep scan \
+            --config p/csharp \
+            --config p/security-audit \
+            --config p/secrets \
+            --sarif --output semgrep.sarif \
+            --error || true
+
+      - name: Upload Semgrep SARIF
+        uses: github/codeql-action/upload-sarif@02c5e83432fe5497fd85b873b6c9f16a8578e1d9 # v3
+        with:
+          sarif_file: semgrep.sarif

--- a/.github/workflows/semgrep.yaml
+++ b/.github/workflows/semgrep.yaml
@@ -35,7 +35,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 
@@ -57,6 +57,6 @@ jobs:
             --error || true
 
       - name: Upload Semgrep SARIF
-        uses: github/codeql-action/upload-sarif@02c5e83432fe5497fd85b873b6c9f16a8578e1d9 # v3
+        uses: github/codeql-action/upload-sarif@e0647621c2984b5ed2f768cb892365bf2a616ad1 # v4
         with:
           sarif_file: semgrep.sarif


### PR DESCRIPTION
Stacked on #216. Adds `semgrep.yaml` — runs the **free public Semgrep registry packs** (`p/csharp`, `p/security-audit`, `p/secrets`) on PR + push. A different engine/ruleset from CodeQL, so it surfaces overlapping-but-distinct signals; uploads SARIF to Code Scanning (report-only for now, promote to gate once baseline clean). Ported from D20-Dice.

Note: #117 lists paid SAST tools (Snyk/Veracode/Fortier/...) but flags cost as the gating factor and "try the free tool first." Semgrep OSS is exactly that free tier and is the fleet-canonical choice — additive to CodeQL, zero account/budget needed. Adopting a paid tool later remains a project-level decision.

Closes #117 when the vNext cycle merges to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)