### PR TITLE
ci: add build-reproducibility verification (#135)

### DIFF
--- a/.github/workflows/reproducible-build.yaml
+++ b/.github/workflows/reproducible-build.yaml
@@ -1,0 +1,87 @@
+name: Build Reproducibility
+
+# Deterministic-build verification (#135).
+#
+# The libraries build with Deterministic + ContinuousIntegrationBuild +
+# SourceLink, which should make the compiled assemblies byte-for-byte
+# reproducible regardless of the checkout path. This job proves it: check the
+# same commit out to two different directories, build each with
+# ContinuousIntegrationBuild=true (which normalises source paths to /_/), and
+# fail if the produced assemblies don't hash identically.
+#
+# This verifies path-independent reproducibility on a single runner (the
+# fleet-proven check). Cross-OS byte-identity (ubuntu vs windows) is a stronger
+# claim that is not reliably guaranteed for .pdb across SDK/OS and is tracked as
+# a follow-up in REPRODUCIBLE-BUILD.md.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: reproducible-build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  reproducible:
+    name: Reproducible build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout (copy A)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          path: a
+          persist-credentials: false
+
+      - name: Checkout (copy B)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          path: b
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Build copy A
+        run: |
+          for proj in \
+            src/Wolfgang.Etl.TestKit/Wolfgang.Etl.TestKit.csproj \
+            src/Wolfgang.Etl.TestKit.Xunit/Wolfgang.Etl.TestKit.Xunit.csproj; do
+            dotnet build "a/${proj}" -c Release -f net10.0 -p:ContinuousIntegrationBuild=true
+          done
+
+      - name: Build copy B
+        run: |
+          for proj in \
+            src/Wolfgang.Etl.TestKit/Wolfgang.Etl.TestKit.csproj \
+            src/Wolfgang.Etl.TestKit.Xunit/Wolfgang.Etl.TestKit.Xunit.csproj; do
+            dotnet build "b/${proj}" -c Release -f net10.0 -p:ContinuousIntegrationBuild=true
+          done
+
+      - name: Compare assembly hashes
+        run: |
+          status=0
+          for asm in \
+            src/Wolfgang.Etl.TestKit/bin/Release/net10.0/Wolfgang.Etl.TestKit.dll \
+            src/Wolfgang.Etl.TestKit.Xunit/bin/Release/net10.0/Wolfgang.Etl.TestKit.Xunit.dll; do
+            ha=$(sha256sum "a/${asm}" | cut -d' ' -f1)
+            hb=$(sha256sum "b/${asm}" | cut -d' ' -f1)
+            echo "${asm}"
+            echo "  A: $ha"
+            echo "  B: $hb"
+            if [ "$ha" != "$hb" ]; then
+              echo "::error::Build is not reproducible — ${asm} hashes differ."
+              status=1
+            else
+              echo "  ✅ reproducible"
+            fi
+          done
+          exit $status

--- a/.github/workflows/reproducible-build.yaml
+++ b/.github/workflows/reproducible-build.yaml
@@ -34,19 +34,19 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout (copy A)
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           path: a
           persist-credentials: false
 
       - name: Checkout (copy B)
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           path: b
           persist-credentials: false
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
         with:
           dotnet-version: '10.0.x'
 

--- a/REPRODUCIBLE-BUILD.md
+++ b/REPRODUCIBLE-BUILD.md
@@ -1,0 +1,50 @@
+# Reproducible builds
+
+Both shipped assemblies — `Wolfgang.Etl.TestKit` and `Wolfgang.Etl.TestKit.Xunit`
+— are built to be **byte-for-byte reproducible**: the same source commit produces
+the same compiled output regardless of *where* it is built.
+
+## What makes the build reproducible
+
+`Directory.Build.props` sets the compiler inputs that a reproducible build
+requires:
+
+- `<Deterministic>true</Deterministic>` — the compiler emits deterministic
+  output (no embedded timestamps, ordered metadata).
+- `<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>` (in CI) —
+  normalises embedded source paths to a deterministic `/_/` root via `PathMap`,
+  so the checkout directory does not leak into the assembly.
+- SourceLink — embeds the commit SHA rather than machine-local paths.
+
+## How it is verified
+
+[`.github/workflows/reproducible-build.yaml`](.github/workflows/reproducible-build.yaml)
+checks the same commit out to two independent directories, builds each with
+`-p:ContinuousIntegrationBuild=true`, and fails if the produced `.dll`s do not
+hash identically (`sha256sum`). This proves **path-independent** reproducibility
+on a single runner — the property that lets a third party rebuild and match.
+
+## How to verify it yourself
+
+```bash
+git clone https://github.com/Chris-Wolfgang/ETL-Test-Kit a
+git clone https://github.com/Chris-Wolfgang/ETL-Test-Kit b
+for d in a b; do
+  dotnet build "$d/src/Wolfgang.Etl.TestKit/Wolfgang.Etl.TestKit.csproj" \
+    -c Release -f net10.0 -p:ContinuousIntegrationBuild=true
+done
+sha256sum \
+  a/src/Wolfgang.Etl.TestKit/bin/Release/net10.0/Wolfgang.Etl.TestKit.dll \
+  b/src/Wolfgang.Etl.TestKit/bin/Release/net10.0/Wolfgang.Etl.TestKit.dll
+# The two hashes must be identical.
+```
+
+## Scope / follow-up
+
+The verification above covers path-independent reproducibility on a single OS —
+the fleet-proven guarantee. **Cross-OS** byte-identity (building on Ubuntu vs
+Windows and matching) is a stronger claim that is not yet asserted here: `.pdb`
+and some embedded metadata can differ across SDK patch levels and operating
+systems even with deterministic inputs. Extending the matrix to cross-OS
+comparison (with any required `.pdb`/metadata normalisation) is tracked as a
+follow-up to #135.


### PR DESCRIPTION
Stacked on #217. Adds `reproducible-build.yaml` — checks the commit out to two independent directories, builds **both** TestKit assemblies with `-p:ContinuousIntegrationBuild=true`, and fails if the `.dll` hashes differ. Proves **path-independent** reproducibility. Adds `REPRODUCIBLE-BUILD.md`. Ported from D20-Dice, extended to both packable projects.

## Scope note
- ✅ Same-runner path-independent byte-identity for both assemblies + doc.
- ⏳ Cross-OS byte-identity (ubuntu vs windows) deferred — .pdb/metadata can differ across SDK/OS; tracked as follow-up in REPRODUCIBLE-BUILD.md.
- CI is the definitive verification (faithful port of D20's green pattern, same deterministic Directory.Build.props, no source generator).

Closes #135 when the vNext cycle merges to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)