### PR TITLE
ci: add per-PR CycloneDX SBOM generation (#127)

### DIFF
--- a/.github/workflows/sbom.yaml
+++ b/.github/workflows/sbom.yaml
@@ -1,0 +1,66 @@
+name: SBOM
+
+# Supply-chain hardening — Software Bill of Materials (#127).
+#
+# Generates a CycloneDX SBOM of each shipped library's full dependency graph on
+# every PR and push, and uploads it as an artifact — so every build has a
+# machine-readable inventory of what it is composed of, and dependency changes
+# are visible at review time (release.yaml already emits SBOMs for the packed
+# artifacts; this is the per-PR complement).
+#
+# Scoped to the SBOM here; the other parts of #127 are deliberately out of this
+# workflow:
+#   - SLSA provenance attestation belongs on the release artifact (attest the
+#     packed .nupkg in release.yaml via actions/attest-build-provenance).
+#   - Package signing needs a signing certificate/key and is a separate,
+#     credential-bearing change.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sbom-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sbom:
+    name: Generate SBOM
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        proj:
+          - src/Wolfgang.Etl.TestKit/Wolfgang.Etl.TestKit.csproj
+          - src/Wolfgang.Etl.TestKit.Xunit/Wolfgang.Etl.TestKit.Xunit.csproj
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Install CycloneDX
+        run: dotnet tool install --global CycloneDX
+
+      - name: Restore
+        run: dotnet restore "${{ matrix.proj }}"
+
+      - name: Generate CycloneDX SBOM (JSON)
+        run: dotnet CycloneDX "${{ matrix.proj }}" --output sbom --json
+
+      - name: Upload SBOM
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: sbom-${{ strategy.job-index }}
+          path: sbom/


### PR DESCRIPTION
Stacked on #218. Adds `sbom.yaml` — generates a CycloneDX SBOM of each shipped project's dependency graph on PR + push, uploaded as an artifact (the per-PR complement to release.yaml's existing release-time SBOMs). Matrix'd over both packable projects; actions SHA-pinned to current major tags (#143). Verified locally (CycloneDX: 26 packages, bom.json). Ported from D20-Dice.

TestKit's release.yaml already emits release-time SBOMs, so #127 is mostly done; **SLSA provenance attestation + package signing** (the rest of #127) live in the protected release.yaml and are flagged as a separate follow-up.

Closes #127 when the vNext cycle merges to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)