### PR TITLE
docs: scaffold migration-guide convention (#138)

### DIFF
--- a/docs/migrations/README.md
+++ b/docs/migrations/README.md
@@ -1,0 +1,12 @@
+# Migration guides
+
+Per-major-version upgrade guides live here, named `vX-to-vY.md`, created during
+release prep for any major bump (0.x → 1.0 with breaking changes, or 1.0 → 2.0)
+and linked from the corresponding GitHub Release notes. A guide covers both
+shipped packages (`Wolfgang.Etl.TestKit` and `Wolfgang.Etl.TestKit.Xunit`), which
+are released in lock-step.
+
+No major version has shipped yet — ETL-Test-Kit is in its `0.x` line — so only
+the [template](TEMPLATE-major-version-migration.md) exists. The convention is
+established now so the first major release can use it without inventing structure
+under time pressure.

--- a/docs/migrations/TEMPLATE-major-version-migration.md
+++ b/docs/migrations/TEMPLATE-major-version-migration.md
@@ -1,0 +1,47 @@
+# Migrating from vX to vY
+
+> Copy this template to `vX-to-vY.md` during release prep for a major version
+> bump, fill in each section, and link it from the GitHub Release notes. Delete
+> any section that does not apply (but prefer "None" over deletion so readers know
+> it was considered).
+
+## Summary
+
+One paragraph: who is affected, roughly how much work the upgrade is, and whether
+a compatibility shim exists.
+
+## Breaking-change inventory
+
+| API | Change | Replacement |
+| --- | --- | --- |
+| `OldType.OldMember` | removed / renamed / behaviour change | `NewType.NewMember` |
+
+## Before / after
+
+```csharp
+// Before (vX)
+```
+
+```csharp
+// After (vY)
+```
+
+Repeat per breaking change that needs a code edit.
+
+## Behavioural changes (no signature change)
+
+Changes that compile unchanged but behave differently at runtime (default-value
+changes, nullability flips, parsing-tolerance changes). These are the dangerous
+ones — call each out explicitly.
+
+## Deprecation timeline
+
+- **vX**: member marked `[Obsolete]` (warning).
+- **vY**: member removed.
+
+State when deprecated members were first warned about and when they were removed.
+
+## Verifying the upgrade
+
+How a consumer confirms the migration succeeded (build clean, tests green, ABI
+check via the release `api-compat` gate).


### PR DESCRIPTION
**Another corrected N/A.** I said "0.x, no majors" — but the AC explicitly wants the *convention scaffolded proactively*: *"A docs/migrations/ folder exists with at least a template file… Cheap to file proactively; expensive to retrofit."*

Adds `docs/migrations/` with:
- **`TEMPLATE-major-version-migration.md`** — breaking-change inventory table, before/after code, behavioural-changes section, deprecation timeline, and an "upgrade verification" step that references the api-compat gate (#125).
- **`README.md`** — the `vX-to-vY.md` naming convention, created during release prep, linked from the Release; notes both packages migrate in lock-step.

No major has shipped (0.x), so only the template exists — which is exactly the point. Ported from ETL-FixedWidth.

Closes #138 when the vNext cycle merges to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)