### PR TITLE
docs: add worked 'real consumer' sample (#116)

### DIFF
--- a/ETL-Test-Kit.slnx
+++ b/ETL-Test-Kit.slnx
@@ -36,6 +36,9 @@
     <Project Path="benchmarks/Wolfgang.Etl.TestKit.Benchmarks/Wolfgang.Etl.TestKit.Benchmarks.csproj" />
   </Folder>
   <Folder Name="/examples/" />
+  <Folder Name="/samples/">
+    <Project Path="samples/Wolfgang.Etl.TestKit.Sample/Wolfgang.Etl.TestKit.Sample.csproj" />
+  </Folder>
   <Folder Name="/src/">
     <Project Path="src/Wolfgang.Etl.TestKit/Wolfgang.Etl.TestKit.csproj" />
     <Project Path="src/Wolfgang.Etl.TestKit.Xunit/Wolfgang.Etl.TestKit.Xunit.csproj" />

--- a/samples/.editorconfig
+++ b/samples/.editorconfig
@@ -1,0 +1,30 @@
+# The sample is test-style code (an xUnit project demonstrating consumer usage),
+# so it gets the same analyzer relaxations the repo applies to tests/ — the root
+# .editorconfig's [tests/**] section and tests/.editorconfig do not match this
+# folder, so the relevant rules are re-declared here.
+
+[*.cs]
+
+# Underscore test-method naming (MethodUnderTest_when_condition_expected_result).
+dotnet_diagnostic.SA1300.severity = none
+dotnet_diagnostic.IDE1006.severity = none
+dotnet_diagnostic.CA1707.severity = none
+
+# ConfigureAwait not needed in test/sample code.
+dotnet_diagnostic.CA2007.severity = none
+dotnet_diagnostic.MA0004.severity = none
+dotnet_diagnostic.S3216.severity = none
+
+# Synchronous cancellation / blocking is fine in test/sample code.
+dotnet_diagnostic.CA1849.severity = none
+dotnet_diagnostic.AsyncFixer01.severity = none
+dotnet_diagnostic.AsyncFixer02.severity = none
+dotnet_diagnostic.VSTHRD103.severity = none
+dotnet_diagnostic.VSTHRD200.severity = none
+
+# Misc test-style relaxations.
+dotnet_diagnostic.IDE0058.severity = none
+dotnet_diagnostic.MA0011.severity = none
+dotnet_diagnostic.MA0048.severity = none
+dotnet_diagnostic.S2699.severity = none
+dotnet_diagnostic.S6562.severity = none

--- a/samples/Wolfgang.Etl.TestKit.Sample/PipelineWithDoublesExample.cs
+++ b/samples/Wolfgang.Etl.TestKit.Sample/PipelineWithDoublesExample.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Wolfgang.Etl.TestKit.Sample;
+
+/// <summary>
+/// The other use case: when you are testing something else (a pipeline, an
+/// orchestrator, error handling) and just need cheap, ready-made ETL components,
+/// use the kit's <em>doubles</em> as stand-ins — feed known data with
+/// <see cref="TestExtractor{T}"/>, capture output with <see cref="TestLoader{T}"/>,
+/// and inject failures with the <c>Faulty*</c> doubles.
+/// </summary>
+public sealed class PipelineWithDoublesExample
+{
+    private static readonly DateTimeOffset BaseTime =
+        new(2024, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+    private static IEnumerable<TemperatureReading> SampleReadings(int count) =>
+        Enumerable.Range(0, count)
+            .Select(i => new TemperatureReading(BaseTime.AddHours(i), 20.0 + i));
+
+    [Fact]
+    public async Task Capture_pipeline_output_with_TestLoader()
+    {
+        var readings = SampleReadings(3).ToList();
+
+        // TestExtractor feeds known data; TestLoader captures whatever the
+        // pipeline pushed so the test can assert on it.
+        using var extractor = new TestExtractor<TemperatureReading>(readings);
+        using var loader = new TestLoader<TemperatureReading>(collectItems: true);
+
+        await loader.LoadAsync(extractor.ExtractAsync());
+
+        Assert.Equal(readings, loader.GetCollectedItems());
+    }
+
+    [Fact]
+    public async Task Verify_error_handling_with_a_Faulty_double()
+    {
+        // FaultyExtractor throws on demand at a chosen position, so a consumer
+        // can prove their pipeline surfaces (or recovers from) mid-stream errors.
+        using var extractor = new FaultyExtractor<TemperatureReading>(SampleReadings(5))
+            .ThrowAt(2, new InvalidOperationException("sensor dropped out"));
+
+        var seen = new List<TemperatureReading>();
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+        {
+            await foreach (var reading in extractor.ExtractAsync())
+            {
+                seen.Add(reading);
+            }
+        });
+
+        Assert.Equal("sensor dropped out", ex.Message);
+        Assert.Equal(2, seen.Count); // two readings surfaced before the failure
+    }
+}

--- a/samples/Wolfgang.Etl.TestKit.Sample/README.md
+++ b/samples/Wolfgang.Etl.TestKit.Sample/README.md
@@ -1,0 +1,34 @@
+# Wolfgang.Etl.TestKit — worked sample
+
+A runnable "real consumer" sample (#116) showing the two ways you use the kit.
+Because it is a live xUnit project, everything here is compile- and
+behaviour-verified in CI — documentation that cannot silently rot.
+
+## 1. Verify your own ETL component with the contract tests
+
+[`WeatherStationExtractor`](WeatherStationExtractor.cs) is a hand-written custom
+extractor — the kind you'd write over a real sensor log, API, or file. It
+implements the `ExtractorBase<T, Report>` pattern in full: `ExtractWorkerAsync`
+with `SkipItemCount` / `MaximumItemCount` windowing, `CreateProgressReport`, and
+injectable progress-timer wiring.
+
+[`WeatherStationExtractorContractTests`](WeatherStationExtractorContractTests.cs)
+verifies it by subclassing `ExtractorBaseContractTests<…>` and filling in three
+factory methods (`CreateSut`, `CreateExpectedItems`, `CreateSutWithTimer`).
+Inheriting the base runs its entire suite — enumeration, cancellation, progress,
+skip/max, idempotency — against your extractor for free.
+
+## 2. Use the doubles as stand-ins in your own tests
+
+When you're testing something else and just need cheap ETL parts,
+[`PipelineWithDoublesExample`](PipelineWithDoublesExample.cs) shows:
+
+- `TestExtractor<T>` to feed known data and `TestLoader<T>` to capture output;
+- `FaultyExtractor<T>.ThrowAt(...)` to inject a mid-stream failure and prove your
+  pipeline surfaces (or recovers from) errors.
+
+## Run it
+
+```bash
+dotnet test samples/Wolfgang.Etl.TestKit.Sample
+```

--- a/samples/Wolfgang.Etl.TestKit.Sample/TemperatureReading.cs
+++ b/samples/Wolfgang.Etl.TestKit.Sample/TemperatureReading.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Wolfgang.Etl.TestKit.Sample;
+
+/// <summary>
+/// A record produced by the <see cref="WeatherStationExtractor"/> — a small
+/// realistic domain type for the sample. A <c>record</c> gives it the value
+/// equality the contract-test base classes rely on when comparing expected vs
+/// actual items.
+/// </summary>
+public sealed record TemperatureReading(DateTimeOffset Timestamp, double Celsius);

--- a/samples/Wolfgang.Etl.TestKit.Sample/WeatherStationExtractor.cs
+++ b/samples/Wolfgang.Etl.TestKit.Sample/WeatherStationExtractor.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+
+namespace Wolfgang.Etl.TestKit.Sample;
+
+/// <summary>
+/// A worked example of a <em>custom</em> extractor a consumer of this library
+/// might write: it reads <see cref="TemperatureReading"/> records from an
+/// in-memory source (standing in for a real sensor log / API / file). It is
+/// deliberately hand-written — NOT one of the kit's own doubles — to show the
+/// exact <see cref="ExtractorBase{TSource, TProgress}"/> pattern a consumer must
+/// implement, including <see cref="ExtractorBase{TSource, TProgress}.SkipItemCount"/> /
+/// <see cref="ExtractorBase{TSource, TProgress}.MaximumItemCount"/> windowing and
+/// injectable progress-timer wiring, so that
+/// <see cref="Xunit.ExtractorBaseContractTests{TSut, TItem, TProgress}"/> passes
+/// against it (see WeatherStationExtractorContractTests).
+/// </summary>
+public sealed class WeatherStationExtractor : ExtractorBase<TemperatureReading, Report>
+{
+    private readonly IEnumerable<TemperatureReading> _readings;
+
+    // Injected timer support: a consumer only needs this if they want their
+    // extractor to be verifiable with a deterministic ManualProgressTimer.
+    private readonly IProgressTimer? _progressTimer;
+    private bool _progressTimerWired;
+    private Action? _elapsedHandler;
+
+    /// <summary>Creates an extractor over the supplied readings.</summary>
+    public WeatherStationExtractor(IEnumerable<TemperatureReading> readings)
+    {
+        _readings = readings ?? throw new ArgumentNullException(nameof(readings));
+    }
+
+    /// <summary>
+    /// Creates an extractor over the supplied readings that reports progress
+    /// through the injected <paramref name="timer"/> — the seam the contract
+    /// tests drive with a deterministic timer.
+    /// </summary>
+    public WeatherStationExtractor(IEnumerable<TemperatureReading> readings, IProgressTimer timer)
+        : this(readings)
+    {
+        _progressTimer = timer ?? throw new ArgumentNullException(nameof(timer));
+    }
+
+    /// <inheritdoc/>
+    protected override Report CreateProgressReport() => new(CurrentItemCount);
+
+    /// <inheritdoc/>
+    protected override IProgressTimer CreateProgressTimer(IProgress<Report> progress)
+    {
+        if (_progressTimer is null)
+        {
+            return base.CreateProgressTimer(progress);
+        }
+
+        // Guard against re-wiring the handler if CreateProgressTimer is called
+        // more than once for the injected timer.
+        if (!_progressTimerWired)
+        {
+            _progressTimerWired = true;
+            _elapsedHandler = () => progress.Report(CreateProgressReport());
+            _progressTimer.Elapsed += _elapsedHandler;
+        }
+
+        return _progressTimer;
+    }
+
+    /// <inheritdoc/>
+    protected override async IAsyncEnumerable<TemperatureReading> ExtractWorkerAsync
+    (
+        [EnumeratorCancellation] CancellationToken token
+    )
+    {
+        token.ThrowIfCancellationRequested();
+
+        // Honour the async-iterator contract even though the source is synchronous.
+        await Task.Yield();
+
+        foreach (var reading in _readings)
+        {
+            token.ThrowIfCancellationRequested();
+
+            // SkipItemCount: drop the leading items the caller asked to skip.
+            if (CurrentSkippedItemCount < SkipItemCount)
+            {
+                IncrementCurrentSkippedItemCount();
+                continue;
+            }
+
+            // MaximumItemCount: stop once the cap is reached.
+            if (CurrentItemCount >= MaximumItemCount)
+            {
+                yield break;
+            }
+
+            // Count exactly once per yielded item.
+            IncrementCurrentItemCount();
+            yield return reading;
+        }
+    }
+
+    /// <inheritdoc/>
+    protected override void Dispose(bool disposing)
+    {
+        // The injected timer is owned by the caller, so only unsubscribe — never
+        // dispose it here.
+        if (disposing && _progressTimer is not null && _elapsedHandler is not null)
+        {
+            _progressTimer.Elapsed -= _elapsedHandler;
+            _elapsedHandler = null;
+        }
+
+        base.Dispose(disposing);
+    }
+}

--- a/samples/Wolfgang.Etl.TestKit.Sample/WeatherStationExtractorContractTests.cs
+++ b/samples/Wolfgang.Etl.TestKit.Sample/WeatherStationExtractorContractTests.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Wolfgang.Etl.Abstractions;
+using Wolfgang.Etl.TestKit.Xunit;
+
+namespace Wolfgang.Etl.TestKit.Sample;
+
+/// <summary>
+/// The headline use case for the kit: verify a hand-written custom extractor
+/// (<see cref="WeatherStationExtractor"/>) against the full extractor contract by
+/// subclassing <see cref="ExtractorBaseContractTests{TSut, TItem, TProgress}"/>
+/// and filling in three factory methods. Inheriting the base class runs its whole
+/// suite — enumeration, cancellation, progress, skip/max windowing, idempotency —
+/// against your extractor for free.
+/// </summary>
+public sealed class WeatherStationExtractorContractTests
+    : ExtractorBaseContractTests<WeatherStationExtractor, TemperatureReading, Report>
+{
+    private static readonly DateTimeOffset BaseTime =
+        new(2024, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+    // A deterministic reading generator so CreateSut and CreateExpectedItems agree.
+    private static IReadOnlyList<TemperatureReading> CreateReadings(int count) =>
+        Enumerable.Range(0, count)
+            .Select(i => new TemperatureReading(BaseTime.AddHours(i), 20.0 + i))
+            .ToList();
+
+    /// <inheritdoc/>
+    protected override WeatherStationExtractor CreateSut(int itemCount) =>
+        new WeatherStationExtractor(CreateReadings(itemCount));
+
+    /// <inheritdoc/>
+    protected override IReadOnlyList<TemperatureReading> CreateExpectedItems() =>
+        CreateReadings(5);
+
+    /// <inheritdoc/>
+    protected override WeatherStationExtractor CreateSutWithTimer(IProgressTimer timer) =>
+        new WeatherStationExtractor(CreateReadings(5), timer);
+}

--- a/samples/Wolfgang.Etl.TestKit.Sample/Wolfgang.Etl.TestKit.Sample.csproj
+++ b/samples/Wolfgang.Etl.TestKit.Sample/Wolfgang.Etl.TestKit.Sample.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    A worked "real consumer" sample (#116): a hand-written custom extractor with
+    its contract test, plus the doubles used as pipeline stand-ins. It is a
+    runnable xUnit project so the examples are compile- and behaviour-verified in
+    CI (documentation that cannot rot), not just prose. Not packed.
+  -->
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Etl.TestKit\Wolfgang.Etl.TestKit.csproj" />
+    <ProjectReference Include="..\..\src\Wolfgang.Etl.TestKit.Xunit\Wolfgang.Etl.TestKit.Xunit.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" NoWarn="NU1701">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Delivers the non-redundant part of #116 — the `samples/` real-usage project. A runnable xUnit project that documents the two ways consumers use the kit, **verified in CI so it can't rot**:

## 1. Verify your own ETL component with the contract tests
`WeatherStationExtractor` — a **hand-written custom extractor** (not one of the kit's doubles) implementing the full `ExtractorBase<T, Report>` pattern: `ExtractWorkerAsync` with `SkipItemCount`/`MaximumItemCount` windowing, `CreateProgressReport`, and injectable timer wiring. `WeatherStationExtractorContractTests` verifies it by subclassing `ExtractorBaseContractTests<…>` and filling in three factory methods — inheriting the **entire** contract suite for free.

## 2. Use the doubles as stand-ins
`PipelineWithDoublesExample` — `TestExtractor` feeds known data, `TestLoader` captures output, `FaultyExtractor.ThrowAt(...)` injects a mid-stream failure to test error handling.

## Verified
**38 tests pass** — the 36 inherited contract tests against the custom extractor (proving it's a correct, complete worked example) + 2 doubles examples. `samples/.editorconfig` re-declares the repo's test-style analyzer relaxations for this folder.

## Scope note
The issue's **shadow-perf-comparison workflow is intentionally omitted** — it's redundant with perf-regression (#144), the zero-alloc guard (#136), and the cross-platform differential (#128). This PR delivers the one non-redundant piece: the real-usage sample that synthetic XML-doc examples can't provide.

Closes #116 when the vNext cycle merges to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)