### PR TITLE
docs,ci: consumer-side reproducible-build verification (#145)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -771,7 +771,12 @@ jobs:
       # assembly, built with the same deterministic command consumers reproduce
       # (docs/REPRODUCIBLE-BUILD.md). Attached to the release below.
       - name: Generate reproducible-build manifest
-        run: bash scripts/reproducible-manifest.sh "${{ github.event.release.tag_name }}" reproducible-build-manifest.json
+        # Pass the tag through the environment rather than interpolating the
+        # ${{ }} expression directly into the run block, so a crafted tag name
+        # can't inject shell (zizmor template-injection).
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: bash scripts/reproducible-manifest.sh "$RELEASE_TAG" reproducible-build-manifest.json
 
       - name: Download NuGet packages artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -757,6 +757,22 @@ jobs:
     permissions:
       contents: write  # Required to upload assets to the GitHub Release
     steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
+        with:
+          dotnet-version: '10.0.x'
+
+      # Reproducible-build manifest (#145): the canonical SHA-256 of each shipped
+      # assembly, built with the same deterministic command consumers reproduce
+      # (docs/REPRODUCIBLE-BUILD.md). Attached to the release below.
+      - name: Generate reproducible-build manifest
+        run: bash scripts/reproducible-manifest.sh "${{ github.event.release.tag_name }}" reproducible-build-manifest.json
+
       - name: Download NuGet packages artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -781,4 +797,5 @@ jobs:
             ./nuget-packages/*.snupkg
             ./nuget-packages/*.bom.json
             release-coverage.zip
+            reproducible-build-manifest.json
 

--- a/README.md
+++ b/README.md
@@ -354,6 +354,16 @@ docfx build --serve
 
 ---
 
+## 🔐 Verify the build
+
+Every release is built deterministically, and each GitHub Release attaches a
+`reproducible-build-manifest.json` with the SHA-256 of every shipped assembly.
+You can independently rebuild from the tag and confirm the hashes match — see
+[docs/REPRODUCIBLE-BUILD.md](docs/REPRODUCIBLE-BUILD.md) for the step-by-step
+procedure and how to publish a third-party attestation.
+
+---
+
 ## 🤝 Contributing
 
 Contributions are welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for:

--- a/docs/REPRODUCIBLE-BUILD.md
+++ b/docs/REPRODUCIBLE-BUILD.md
@@ -1,0 +1,91 @@
+# Verifying the build is reproducible
+
+Every release of `Wolfgang.Etl.TestKit` and `Wolfgang.Etl.TestKit.Xunit` is built
+deterministically: the same source at the same tag produces byte-identical
+assemblies, independent of who builds it or where. This page lets **you** confirm
+that independently, so "our builds are reproducible" is a checkable claim rather
+than a promise.
+
+CI already proves *same-environment* reproducibility on every push
+([`reproducible-build.yaml`](../.github/workflows/reproducible-build.yaml), #135):
+it builds the library twice and asserts the assembly hashes match. This document
+is the *consumer-side* flip — how a third party reproduces and attests to it.
+
+## What is published
+
+Each GitHub Release attaches a **`reproducible-build-manifest.json`** listing the
+SHA-256 of every shipped assembly, plus the reference environment (OS and .NET SDK
+version) and the exact build command used to produce them. Example:
+
+```json
+{
+  "schema": "wolfgang.reproducible-build-manifest/v1",
+  "version": "v0.11.0",
+  "targetFramework": "net10.0",
+  "buildCommand": "dotnet build <project> -c Release -f net10.0 -p:ContinuousIntegrationBuild=true",
+  "referenceEnvironment": { "os": "Linux", "dotnetSdk": "10.0.110" },
+  "assemblies": [
+    { "assembly": "Wolfgang.Etl.TestKit.dll", "sha256": "…" },
+    { "assembly": "Wolfgang.Etl.TestKit.Xunit.dll", "sha256": "…" }
+  ]
+}
+```
+
+## Reproduce it yourself
+
+1. **Match the reference environment.** Use the same OS family and .NET SDK
+   version named in the release's manifest (`referenceEnvironment`).
+   `ContinuousIntegrationBuild=true` normalises source paths, so the *checkout
+   location* does not matter — but the compiler version does, so match the SDK.
+
+2. **Clone at the exact tag:**
+
+   ```bash
+   git clone --branch <tag> --depth 1 https://github.com/Chris-Wolfgang/ETL-Test-Kit
+   cd ETL-Test-Kit
+   ```
+
+3. **Build each library with the documented command** (the manifest's
+   `buildCommand`):
+
+   ```bash
+   dotnet build src/Wolfgang.Etl.TestKit/Wolfgang.Etl.TestKit.csproj \
+     -c Release -f net10.0 -p:ContinuousIntegrationBuild=true
+   dotnet build src/Wolfgang.Etl.TestKit.Xunit/Wolfgang.Etl.TestKit.Xunit.csproj \
+     -c Release -f net10.0 -p:ContinuousIntegrationBuild=true
+   ```
+
+4. **Hash your output and compare** against the manifest:
+
+   ```bash
+   sha256sum \
+     src/Wolfgang.Etl.TestKit/bin/Release/net10.0/Wolfgang.Etl.TestKit.dll \
+     src/Wolfgang.Etl.TestKit.Xunit/bin/Release/net10.0/Wolfgang.Etl.TestKit.Xunit.dll
+   ```
+
+   Each hash must equal the corresponding `sha256` in
+   `reproducible-build-manifest.json`. The repo's own generator
+   ([`scripts/reproducible-manifest.sh`](../scripts/reproducible-manifest.sh))
+   runs exactly these steps, so you can also regenerate the whole manifest and
+   `diff` it against the published one.
+
+## If a hash does not match
+
+A mismatch means either the environments differ (most commonly a different SDK
+patch version) or the artifact was tampered with. Please
+[open an issue](https://github.com/Chris-Wolfgang/ETL-Test-Kit/issues/new) titled
+"Reproducible-build mismatch for `<tag>`" including:
+
+- the release tag,
+- your OS and `dotnet --version`,
+- your computed hashes vs the manifest's,
+- the exact commands you ran.
+
+## Publishing a third-party attestation
+
+Independent verification is most useful when it is *public*. If you reproduced a
+release successfully, you can publish an attestation following the
+[Reproducible Builds project](https://reproducible-builds.org/) conventions (or a
+service such as [vouchsafe.io](https://vouchsafe.io/)): sign a statement naming the
+tag, the manifest hash, and your environment, and link it back on the mismatch/
+verification issue so others can find corroborating rebuilds.

--- a/scripts/reproducible-manifest.py
+++ b/scripts/reproducible-manifest.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Assemble reproducible-build-manifest.json (#145) from "assembly<TAB>sha256"
+lines on stdin plus build metadata.
+
+Usage: reproducible-manifest.py <version> <tfm> <sdk> <os> <output-file>
+"""
+import json
+import sys
+
+
+def main() -> None:
+    if len(sys.argv) != 6:
+        print("usage: reproducible-manifest.py <version> <tfm> <sdk> <os> <output-file>", file=sys.stderr)
+        sys.exit(2)
+
+    version, tfm, sdk, os_name, out_file = sys.argv[1:6]
+
+    assemblies = []
+    for line in sys.stdin.read().splitlines():
+        if not line.strip():
+            continue
+        name, sha = line.split("\t")
+        assemblies.append({"assembly": name, "sha256": sha})
+
+    manifest = {
+        "schema": "wolfgang.reproducible-build-manifest/v1",
+        "version": version,
+        "targetFramework": tfm,
+        "buildCommand": f"dotnet build <project> -c Release -f {tfm} -p:ContinuousIntegrationBuild=true",
+        "referenceEnvironment": {"os": os_name, "dotnetSdk": sdk},
+        "assemblies": sorted(assemblies, key=lambda a: a["assembly"]),
+    }
+
+    with open(out_file, "w", encoding="utf-8", newline="\n") as handle:
+        json.dump(manifest, handle, indent=2)
+        handle.write("\n")
+
+    print(f"Wrote {len(assemblies)} assembly hashes to {out_file}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/reproducible-manifest.sh
+++ b/scripts/reproducible-manifest.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Generate reproducible-build-manifest.json (#145): the canonical SHA-256 hashes
+# of each shipped assembly, built deterministically the same way a third party
+# would reproduce them (the command documented in docs/REPRODUCIBLE-BUILD.md).
+#
+# Usage: scripts/reproducible-manifest.sh <version> <output-file>
+#
+# The build uses -c Release -f net10.0 -p:ContinuousIntegrationBuild=true, which
+# normalises source paths (/_/) so the output is independent of the checkout
+# location — the same knobs reproducible-build.yaml (#135) verifies. The manifest
+# records the SDK version and OS it was produced on so a verifier can match the
+# reference environment.
+set -euo pipefail
+
+VERSION="${1:?usage: reproducible-manifest.sh <version> <output-file>}"
+OUT_FILE="${2:?usage: reproducible-manifest.sh <version> <output-file>}"
+
+PROJECTS=(
+  "src/Wolfgang.Etl.TestKit/Wolfgang.Etl.TestKit.csproj"
+  "src/Wolfgang.Etl.TestKit.Xunit/Wolfgang.Etl.TestKit.Xunit.csproj"
+)
+
+TFM="net10.0"
+SDK_VERSION="$(dotnet --version)"
+OS_NAME="$(uname -s)"
+
+# Collect "assembly<TAB>sha256" lines for each shipped assembly.
+hashes=""
+for proj in "${PROJECTS[@]}"; do
+  dotnet build "$proj" -c Release -f "$TFM" -p:ContinuousIntegrationBuild=true >/dev/null
+  dir="$(dirname "$proj")/bin/Release/$TFM"
+  asm="$dir/$(basename "$(dirname "$proj")").dll"
+  sha="$(sha256sum "$asm" | cut -d' ' -f1)"
+  hashes+="$(basename "$asm")	$sha"$'\n'
+done
+
+# Assemble the JSON (scripts/reproducible-manifest.py avoids a jq dependency and
+# keeps the piped hashes on stdin — a heredoc-inlined script would collide with
+# the interpreter's own stdin).
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+printf '%s' "$hashes" \
+  | python3 "$script_dir/reproducible-manifest.py" "$VERSION" "$TFM" "$SDK_VERSION" "$OS_NAME" "$OUT_FILE"


### PR DESCRIPTION
Makes the deterministic-build claim from #135 **independently verifiable** — the consumer-side flip.

## What's added
- **`docs/REPRODUCIBLE-BUILD.md`** — the full procedure: match the reference environment, clone at the tag, rebuild with the documented `-p:ContinuousIntegrationBuild=true` command, `sha256sum` and compare against the published manifest, file a discrepancy, and publish a third-party attestation (Reproducible Builds project / vouchsafe.io).
- **`scripts/reproducible-manifest.{sh,py}`** — build each shipped assembly deterministically and emit `reproducible-build-manifest.json` (per-assembly SHA-256 + reference OS/SDK + the exact build command). The `.py` is split out so the piped hashes stay on stdin (a heredoc-inlined script collides with the interpreter's own stdin).
- **`release.yaml`** — the `update-release-artifacts` job now generates the manifest (on ubuntu/net10.0, matching #135's deterministic build — *not* the Windows packing build, so the hashes are what a third party reproduces) and **attaches it to the GitHub Release**.
- **README** — a "Verify the build" section linking the procedure.

## Verified locally
The generator builds both projects with the CI flag and emits valid 64-char SHA-256 hashes for both assemblies, sorted, well-formed JSON. (Same-environment reproducibility itself is already gated by #135.)

## Design note
The manifest is generated with the **deterministic** build command (ubuntu, `ContinuousIntegrationBuild=true`) rather than the release's Windows pack build, because that's the environment the doc tells third parties to reproduce — cross-OS byte-identity isn't guaranteed, so the manifest records the reference OS + SDK to match.

Closes #145 when the vNext cycle merges to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)