### PR TITLE
ci(release): migrate NuGet publish to Trusted Publishing / OIDC (#207)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -672,6 +672,9 @@ jobs:
     needs: [pack-and-validate, verify-docs-build]
     if: needs.pack-and-validate.outputs.has-packages == 'true'
     runs-on: windows-latest
+    permissions:
+      id-token: write   # required for OIDC token issuance to nuget.org
+      contents: read
     steps:
       - name: Setup .NET
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
@@ -691,22 +694,19 @@ jobs:
           name: nuget-packages
           path: ./packages
 
-      - name: Validate NuGet API key
-        shell: pwsh
-        env:
-          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-        run: |
-          if ([string]::IsNullOrEmpty($env:NUGET_API_KEY)) {
-            Write-Error "❌ NUGET_API_KEY secret not configured!"
-            Write-Host "Please add it in: Repository Settings → Secrets and variables → Actions → New repository secret"
-            exit 1
-          }
-          Write-Host "✅ NUGET_API_KEY is configured" -ForegroundColor Green
+      - name: NuGet login (OIDC → temporary API key)
+        # Trusted Publishing: exchange the workflow's GitHub OIDC token for an
+        # ephemeral (~1h) push key. No long-lived NUGET_API_KEY secret is used.
+        # Requires a Trusted Publishing policy for each package on nuget.org.
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1
+        id: nuget-login
+        with:
+          user: Chris-Wolfgang
 
       - name: Publish to NuGet
         shell: pwsh
         env:
-          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+          NUGET_API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
         run: |
           $packages = Get-ChildItem -Path './packages' -Filter '*.nupkg' -ErrorAction SilentlyContinue
           


### PR DESCRIPTION
Migrates `release.yaml` off `secrets.NUGET_API_KEY` and onto **NuGet Trusted Publishing (OIDC)** — the fleet-standard now on 9+ repos. Also **unblocks #140** (the SECURITY.md OIDC release-path appendix can now be written).

## The change (publish-nuget job)
- Adds `permissions: { id-token: write, contents: read }`.
- Replaces the "Validate NuGet API key" step with **`NuGet/login@8d19675… # v1`** (`id: nuget-login`, `user: Chris-Wolfgang`) — exchanges the GitHub OIDC token for an ephemeral (~1h) push key.
- Publish step now uses `--api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }}` (the ephemeral step output) instead of the repo secret.
- **No `secrets.NUGET_API_KEY` reference remains** anywhere in the file.

Canonical shape ported from Etl-DbClient's `release.yaml` on main.

## ⚠️ REQUIRED before the next release runs (manual, yours — I can't)
Configure a **Trusted Publishing policy on nuget.org for BOTH packages** first, or the OIDC publish fails:
- `Wolfgang.Etl.TestKit` and `Wolfgang.Etl.TestKit.Xunit` → package page → **Manage → Trusted Publishing → Add policy** → owner `Chris-Wolfgang`, repo `ETL-Test-Kit`, workflow `.github/workflows/release.yaml`.
- After this ships, the long-lived `NUGET_API_KEY` repo secret can be deleted.

## Protected file
`release.yaml` trips the `Detect .NET Projects` guard — handle via the protected-file split / admin-bypass at the `vNext → main` stage (it joins the other workflow changes already queued there).

Closes #207 when the vNext cycle merges to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)