### PR TITLE
docs(security): add Release path & compromise scope appendix (#140)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,3 +21,15 @@ We will acknowledge your report within 48 hours and provide an estimated timelin
 
 Your help is greatly appreciated!
 Responsible disclosure of security vulnerabilities helps protect our entire community.
+
+## Release path & compromise scope
+
+Facts a maintainer would need at 2am if the release identity is compromised. Generic incident-response steps (rotating credentials, revoking OAuth apps, publishing advisories, unlisting NuGet packages) are not duplicated here — GitHub's and NuGet's own docs update faster than a checked-in runbook.
+
+- **Release path**: OIDC / NuGet Trusted Publishing via `NuGet/login@v1` in `.github/workflows/release.yaml`. The workflow mints an ephemeral push token per run via OIDC — the release path does not depend on a long-lived API key stored in GitHub secrets or on the NuGet account. During an incident, check the NuGet account for any long-lived API keys anyway (they can be created outside of CI) and delete anything you don't recognize.
+- **Fallback**: none. If Trusted Publishing is compromised, the incident is at the GitHub-account level (the OIDC identity is `Chris-Wolfgang/ETL-Test-Kit`).
+- **Owner**: @Chris-Wolfgang.
+- **Downstream consumers**: known Wolfgang.* dependents (test projects) include ETL-Xml, ETL-FixedWidth, Etl-DbClient, ETL-Json, and ETL-Transformers; unknown external consumers may also exist on nuget.org.
+- **Package coordinates for unlisting**: this repo ships two packages —
+  - `Wolfgang.Etl.TestKit` — https://www.nuget.org/packages/Wolfgang.Etl.TestKit/
+  - `Wolfgang.Etl.TestKit.Xunit` — https://www.nuget.org/packages/Wolfgang.Etl.TestKit.Xunit/


### PR DESCRIPTION
Now unblocked by #207/#239 (OIDC is the release path) **and** the Trusted Publishing policies you just created. Appends the canonical "Release path & compromise scope" section to `SECURITY.md` — the load-bearing per-repo facts a maintainer needs at 2am during an incident:

- **Release path**: OIDC / NuGet Trusted Publishing via `NuGet/login@v1` — no long-lived key on GitHub or NuGet.
- **Fallback**: none — a compromise is at the GitHub-account level (OIDC identity `Chris-Wolfgang/ETL-Test-Kit`).
- **Owner**: @Chris-Wolfgang.
- **Downstream consumers**: known Wolfgang.* dependents (ETL-Xml, ETL-FixedWidth, Etl-DbClient, ETL-Json, ETL-Transformers) + possible unknown external consumers.
- **Package coordinates for unlisting**: both `Wolfgang.Etl.TestKit` and `Wolfgang.Etl.TestKit.Xunit` with nuget.org URLs.

No `[fill in]` placeholders remain; generic incident-response steps intentionally not duplicated (GitHub/NuGet docs update faster). Docs-only — no version bump, not a protected file. Shape matches Etl-DbClient #240.

Closes #140 when the vNext cycle merges to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)