### PR TITLE
ci: 0.10.1 CI-infra bundle (protected + supporting files)

### DIFF
--- a/.github/license-audit/allowed-licenses.json
+++ b/.github/license-audit/allowed-licenses.json
@@ -1,0 +1,11 @@
+[
+  "MIT",
+  "Apache-2.0",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+  "MS-PL",
+  "0BSD",
+  "ISC",
+  "BSL-1.0",
+  "MPL-2.0"
+]

--- a/.github/license-audit/ignored-packages.json
+++ b/.github/license-audit/ignored-packages.json
@@ -1,0 +1,3 @@
+[
+  "SonarAnalyzer.CSharp"
+]

--- a/.github/license-audit/url-license-mappings.json
+++ b/.github/license-audit/url-license-mappings.json
@@ -1,0 +1,5 @@
+{
+  "http://go.microsoft.com/fwlink/?LinkId=329770": "MIT",
+  "https://github.com/dotnet/standard/blob/master/LICENSE.TXT": "MIT",
+  "https://raw.githubusercontent.com/xunit/xunit/master/license.txt": "Apache-2.0"
+}

--- a/.github/sourcelink/Directory.Build.props
+++ b/.github/sourcelink/Directory.Build.props
@@ -1,0 +1,9 @@
+<!--
+  Isolation stub. MSBuild imports only the NEAREST Directory.Build.props when
+  walking up, so this empty project stops the repo-root Directory.Build.props
+  (analyzers, BannedSymbols, TreatWarningsAsErrors, multi-TFM, PublicAPI, …)
+  from applying to the throwaway SourceLink step-into consumer. The consumer is
+  a debugging fixture, not shipped code, and must not inherit library policy.
+-->
+<Project>
+</Project>

--- a/.github/sourcelink/Directory.Build.targets
+++ b/.github/sourcelink/Directory.Build.targets
@@ -1,0 +1,3 @@
+<!-- Isolation stub — see Directory.Build.props in this folder. -->
+<Project>
+</Project>

--- a/.github/sourcelink/README.md
+++ b/.github/sourcelink/README.md
@@ -1,0 +1,51 @@
+# SourceLink step-into verification
+
+Fixtures for [`sourcelink-stepinto.yaml`](../workflows/sourcelink-stepinto.yaml),
+which proves the *debugger* half of SourceLink end-to-end: that pressing **F11**
+in a consumer steps into the library's **real source** (resolved via the
+SourceLink map in the PDB), not a decompiled placeholder.
+
+This complements [`sourcelink.yaml`](../workflows/sourcelink.yaml) (PR #208), which
+proves every document in the PDB resolves to real GitHub content via
+`dotnet sourcelink test`. Together they cover the full chain F11 depends on and
+satisfy #133: SourceLink map in the PDB → source-file resolution → GitHub raw-URL
+fetch.
+
+## How it works
+
+1. Build [`consumer/`](consumer/) with `-c Debug -p:ContinuousIntegrationBuild=true`.
+   Its `ProjectReference` compiles the library with the **same SourceLink map a
+   released package ships** (deterministic `/_/…` source roots that map to GitHub
+   raw URLs), and Debug/non-optimized codegen so the step-into target isn't
+   reordered away.
+2. Run [`verify_stepinto.py`](verify_stepinto.py) — it drives
+   [netcoredbg](https://github.com/Samsung/netcoredbg) over its MI interface to
+   break in the consumer, step into `TestExtractor`'s constructor, and assert
+   the resulting frame is the library's SourceLink-mapped source file with symbols
+   loaded. If SourceLink or the sequence points were broken the step would land
+   with no source and the script exits non-zero.
+
+## Why a ProjectReference, not the packed NuGet
+
+netcoredbg is the only CI-scriptable .NET debugger, and it does **not** reliably
+pair a *package*-sourced assembly with its symbol-package (`.snupkg`) PDB — it
+reports `symbols-loaded=0` and cannot step into it (verified during development).
+A `ProjectReference` built with `ContinuousIntegrationBuild=true` produces a
+**byte-identical SourceLink PDB**, so the SourceLink map under test is the same
+one that ships; only the delivery path differs. The packed-package symbol/URL
+resolution is covered by `sourcelink.yaml` (PR #208).
+
+## Files
+
+- `consumer/StepIntoConsumer.csproj` / `Program.cs` — the fixture consumer. The
+  break line is marked `STEP_INTO_TARGET`.
+- `Directory.Build.props` / `.targets` — empty isolation stubs so the consumer
+  does **not** inherit the repo's analyzers / BannedSymbols / multi-TFM policy.
+- `verify_stepinto.py` — the debugger driver (exit 0 = step-into resolved real
+  source).
+
+## Scope
+
+Scheduled + manual, not a PR gate — debugger automation is heavier and slightly
+less deterministic than a unit test, and SourceLink's raw URLs resolve only
+against a pushed commit.

--- a/.github/sourcelink/consumer/Program.cs
+++ b/.github/sourcelink/consumer/Program.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+using Wolfgang.Etl.TestKit;
+
+// End-to-end SourceLink "step into" fixture. The debugger sets a breakpoint on
+// the line marked STEP_INTO_TARGET and issues a step-into (the F11 a consumer
+// would press). If SourceLink is intact the debugger resolves the library's real
+// source (from GitHub) at the constructor below, instead of a decompiled
+// placeholder. TestExtractor's constructor is a plain, non-async method, which
+// makes it a clean and stable step-into target.
+
+IEnumerable<int> items = new[] { 1, 2, 3 };
+var extractor = new TestExtractor<int>(items); // STEP_INTO_TARGET
+Console.WriteLine(extractor.GetType().FullName);

--- a/.github/sourcelink/consumer/StepIntoConsumer.csproj
+++ b/.github/sourcelink/consumer/StepIntoConsumer.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    A minimal consumer that steps into the library. It references the library
+    PROJECT (built with ContinuousIntegrationBuild=true so the PDB carries the
+    same SourceLink map a released package ships). A ProjectReference is used
+    rather than a PackageReference because netcoredbg — the only CI-scriptable
+    .NET debugger — does not reliably pair a package-sourced assembly with its
+    symbol package's PDB, so it cannot step into it. The SourceLink PDB under
+    test is identical either way; the packed-package symbol/URL resolution is
+    covered by sourcelink.yaml (#133 / PR #208).
+  -->
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <!-- Non-optimized so the step-into target is not reordered/inlined away. -->
+    <Optimize>false</Optimize>
+    <DebugType>portable</DebugType>
+    <!-- Set by the workflow to the repo's src project path. -->
+    <TestKitProject Condition="'$(TestKitProject)' == ''">../../../src/Wolfgang.Etl.TestKit/Wolfgang.Etl.TestKit.csproj</TestKitProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(TestKitProject)" />
+  </ItemGroup>
+
+</Project>

--- a/.github/sourcelink/verify_stepinto.py
+++ b/.github/sourcelink/verify_stepinto.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Drive netcoredbg to prove SourceLink "step into" (F11) works end-to-end.
+
+Sets a breakpoint in the consumer, runs to it, issues a step-into, and inspects
+the resulting stack frame. Succeeds (exit 0) only if the step landed in the
+expected library source file with the library's symbols loaded — i.e. a debugger
+resolves real library source, not a decompiled placeholder. If SourceLink or the
+symbol package were broken, the step would land with no source mapping and this
+fails.
+
+Usage:
+    verify_stepinto.py <netcoredbg> <consumer.dll> <Program.cs:LINE> <expected-src.cs>
+"""
+import subprocess
+import sys
+import re
+import threading
+import queue
+import time
+
+if len(sys.argv) != 5:
+    print(__doc__)
+    sys.exit(2)
+
+debugger, consumer_dll, break_spec, expected_src = sys.argv[1:5]
+
+proc = subprocess.Popen(
+    [debugger, "--interpreter=mi", "--", "dotnet", consumer_dll],
+    stdin=subprocess.PIPE,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.STDOUT,
+    text=True,
+    bufsize=1,
+)
+
+events: "queue.Queue[str]" = queue.Queue()
+
+
+def _reader():
+    for line in proc.stdout:
+        events.put(line.rstrip("\n"))
+    events.put(None)
+
+
+threading.Thread(target=_reader, daemon=True).start()
+
+
+def send(command):
+    print(">>>", command, flush=True)
+    proc.stdin.write(command + "\n")
+    proc.stdin.flush()
+
+
+def wait_for(needles, timeout=60):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            line = events.get(timeout=max(0.1, deadline - time.time()))
+        except queue.Empty:
+            return None
+        if line is None:
+            return None
+        print("dbg>", line, flush=True)
+        if any(n in line for n in needles):
+            return line
+    return None
+
+
+def fail(reason):
+    print("RESULT=FAIL reason=" + reason, flush=True)
+    try:
+        send("-gdb-exit")
+    except Exception:
+        pass
+    sys.exit(1)
+
+
+send("-break-insert " + break_spec)
+wait_for(["^done", "^error"], 15)
+send("-exec-run")
+
+# netcoredbg halts at the managed entry point first; continue to the breakpoint.
+stop = wait_for(["*stopped"], 60)
+if stop and 'reason="entry-point-hit"' in stop:
+    send("-exec-continue")
+    stop = wait_for(["*stopped"], 60)
+
+if not stop or "breakpoint-hit" not in stop:
+    fail("breakpoint-not-hit")
+
+# Step into (F11). Retry a couple of times in case the first step stays on the
+# call line before descending into the callee.
+resolved = None
+for _ in range(4):
+    send("-exec-step")
+    stop = wait_for(["*stopped"], 30)
+    if not stop:
+        break
+    match = re.search(r'frame=\{[^}]*?file="([^"]+)"[^}]*?fullname="([^"]+)"', stop)
+    if match and match.group(1).endswith(expected_src):
+        resolved = (match.group(1), match.group(2), stop)
+        break
+
+if not resolved:
+    fail("did-not-step-into-" + expected_src)
+
+send("-gdb-exit")
+
+source_file, fullname, stop = resolved
+line_match = re.search(r'line="(\d+)"', stop)
+print("RESOLVED_FILE=" + source_file, flush=True)
+print("RESOLVED_FULLNAME=" + fullname, flush=True)
+print("RESOLVED_LINE=" + (line_match.group(1) if line_match else "?"), flush=True)
+print("RESULT=PASS", flush=True)
+sys.exit(0)

--- a/.github/workflows/actions-audit.yaml
+++ b/.github/workflows/actions-audit.yaml
@@ -1,0 +1,89 @@
+name: Actions Audit
+
+# GitHub Actions workflow security/quality audit (#143).
+#
+#  - actionlint: static checker for workflow YAML + embedded shell (via
+#    shellcheck). Gates the build on findings — workflows should be lint-clean.
+#  - zizmor: security auditor for Actions (injection, unpinned actions,
+#    over-broad permissions, ...). Reports to the Security tab (SARIF) rather
+#    than hard-gating, since it is opinionated; promote to a gate once the
+#    baseline is clean.
+#
+# Installed via `go install` / `pip install` (pinned) rather than third-party
+# wrapper actions, to keep the supply chain small.
+
+on:
+  # Runs on every PR (not path-filtered) so the actionlint job can be a required
+  # status check — a path-filtered required check would hang PRs that don't touch
+  # .github/workflows/**. actionlint/zizmor are cheap (~20s) and idempotent.
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: actions-audit-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version: 'stable'
+
+      - name: Install actionlint
+        run: go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.7
+
+      - name: Run actionlint
+        env:
+          # Gate on shellcheck warning+ only. The info/style nits (SC2012 "use
+          # find not ls", SC2035 "use ./*glob*") in the canonical pr.yaml are
+          # not worth failing every PR over; warnings and errors still gate.
+          SHELLCHECK_OPTS: --severity=warning
+        run: actionlint -color
+
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: '3.x'
+
+      - name: Install zizmor
+        run: pip install zizmor
+
+      - name: Run zizmor
+        env:
+          GH_TOKEN: ${{ github.token }}
+        # Report-only for now: don't fail the job on findings, upload them to
+        # Code Scanning instead. Remove `|| true` to turn this into a gate.
+        run: zizmor --config .zizmor.yml --format sarif .github/workflows/ > zizmor.sarif || true
+
+      - name: Upload zizmor SARIF
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
+        with:
+          sarif_file: zizmor.sarif

--- a/.github/workflows/aot-smoke.yaml
+++ b/.github/workflows/aot-smoke.yaml
@@ -1,0 +1,53 @@
+name: AOT Smoke
+
+# Native-AOT publish-and-run smoke consumer (#132).
+#
+# Publishes a tiny console consumer with PublishAot and runs the native binary,
+# so the build fails if the library stops compiling or running under native AOT
+# (e.g. the async-enumerable pipeline path stops being trimmer-safe). This is the
+# *runtime* half of AOT verification: it exercises TestExtractor / TestTransformer
+# / TestLoader end-to-end in a trimmed, natively-compiled binary.
+#
+# windows-latest ships the MSVC "Desktop development with C++" workload that the
+# native linker requires, so no extra toolchain install is needed.
+#
+# Runs on every PR so AOT regressions block before merge.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: aot-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  aot-smoke:
+    name: "AOT publish + run"
+    runs-on: windows-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Publish (native AOT, win-x64)
+        run: dotnet publish aot-smoke/Wolfgang.Etl.TestKit.AotSmoke/Wolfgang.Etl.TestKit.AotSmoke.csproj -c Release -r win-x64
+
+      - name: Run native binary
+        shell: bash
+        run: |
+          EXE="aot-smoke/Wolfgang.Etl.TestKit.AotSmoke/bin/Release/net10.0/win-x64/publish/Wolfgang.Etl.TestKit.AotSmoke.exe"
+          echo "Running: $EXE"
+          "$EXE"

--- a/.github/workflows/build-all-versions.yaml
+++ b/.github/workflows/build-all-versions.yaml
@@ -25,13 +25,13 @@ jobs:
 
     steps:
       - name: Checkout repository (full history + all tags)
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0 # Full history so all tags are reachable
           persist-credentials: false
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v6
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
         with:
           dotnet-version: |
             5.0.x

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       with:
         persist-credentials: false
 
@@ -77,7 +77,7 @@ jobs:
 
     - name: Initialize CodeQL
       if: steps.check-csharp.outputs.has-csharp == 'true'
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
       with:
         languages: ${{ matrix.language }}
         # security-extended adds the broader security query pack on top of the
@@ -86,7 +86,7 @@ jobs:
 
     - name: Setup .NET
       if: steps.check-csharp.outputs.has-csharp == 'true'
-      uses: actions/setup-dotnet@v6
+      uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
       with:
         dotnet-version: '10.0.x'
 
@@ -159,7 +159,7 @@ jobs:
     - name: Perform CodeQL Analysis
       id: perform-codeql-analysis
       if: steps.check-csharp.outputs.has-csharp == 'true'
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
       with:
         category: "/language:${{matrix.language}}"
 

--- a/.github/workflows/concurrency.yaml
+++ b/.github/workflows/concurrency.yaml
@@ -1,0 +1,62 @@
+name: Concurrency (Coyote)
+
+# Systematic concurrency testing (#126) with Microsoft Coyote.
+#
+# The Tests.Concurrency project hands racy public scenarios (cancellation
+# mid-enumeration, Dispose racing an in-flight enumeration) to Coyote, which
+# explores hundreds of controlled thread interleavings of each and fails if any
+# schedule violates the invariant. Coyote must first REWRITE the assemblies so it
+# can control the Task schedule — the tests self-skip (COYOTE_REWRITTEN gate)
+# in the normal PR sweep, which runs them un-rewritten and can't control the
+# schedule. Scheduled + manual only: schedule exploration is heavier than a unit
+# test.
+#
+# NOTE: the issue's optional 24h soak with dotnet-counters requires a self-hosted
+# runner (GitHub-hosted runners cap job time well under 24h); it is intentionally
+# not implemented here.
+
+on:
+  schedule:
+    - cron: '0 4 * * 1'   # weekly, Monday 04:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: concurrency-coyote-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  coyote:
+    name: Coyote systematic exploration
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      PROJECT: tests/Wolfgang.Etl.TestKit.Tests.Concurrency
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Build concurrency project
+        run: dotnet build "$PROJECT/Wolfgang.Etl.TestKit.Tests.Concurrency.csproj" -c Release
+
+      - name: Install Coyote CLI
+        run: dotnet tool install --global Microsoft.Coyote.CLI --version 1.7.11
+
+      - name: Rewrite assemblies for schedule control
+        working-directory: ${{ env.PROJECT }}
+        run: coyote rewrite rewrite.coyote.json
+
+      - name: Run Coyote tests (rewritten)
+        working-directory: ${{ env.PROJECT }}
+        env:
+          COYOTE_REWRITTEN: '1'
+        run: dotnet test --no-build -c Release

--- a/.github/workflows/cross-platform-differential.yaml
+++ b/.github/workflows/cross-platform-differential.yaml
@@ -1,0 +1,125 @@
+name: Cross-Platform Differential
+
+# Cross-platform / multi-arch differential (#128).
+#
+# pr.yaml already runs the suite on Linux/Windows/macOS and requires it to *pass*
+# on each. This workflow verifies it passes the SAME WAY on each — including
+# ARM64, which pr.yaml does not cover. Each runner produces a normalized list of
+# "test name -> outcome"; the diff job fails if any platform's list diverges from
+# the linux-x64 reference (catching a test that passes on x64 but behaves
+# differently on arm64: culture sorts, line endings, timing, FS case).
+#
+# Both test projects are run into one trx directory; normalize-trx.py combines
+# every .trx it finds.
+
+on:
+  schedule:
+    - cron: '30 6 * * 1'   # weekly, Monday 06:30 UTC
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+      - vNext
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - '.github/workflows/cross-platform-differential.yaml'
+      - 'scripts/normalize-trx.py'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cross-platform-differential-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  run:
+    name: Test ${{ matrix.label }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { runner: ubuntu-latest,    label: linux-x64 }
+          - { runner: ubuntu-24.04-arm, label: linux-arm64 }
+          - { runner: macos-latest,     label: macos-arm64 }
+          - { runner: windows-latest,   label: windows-x64 }
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: '3.x'
+
+      # normalize-trx.py parses the .trx with defusedxml (hardened against XXE /
+      # entity expansion) rather than the stdlib xml module.
+      - name: Install defusedxml
+        run: python -m pip install --disable-pip-version-check defusedxml
+
+      - name: Run tests (net10.0)
+        shell: bash
+        # Do not fail here — a failing/diverging test must reach the diff job,
+        # where a *difference* between platforms is the real signal.
+        run: |
+          for proj in \
+            tests/Wolfgang.Etl.TestKit.Tests.Unit/Wolfgang.Etl.TestKit.Tests.Unit.csproj \
+            tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/Wolfgang.Etl.TestKit.Xunit.Tests.Unit.csproj; do
+            name="$(basename "$proj" .csproj)"
+            dotnet test "$proj" \
+              -c Release -f net10.0 \
+              --logger "trx;LogFileName=$name.trx" \
+              --results-directory trx || true
+          done
+
+      - name: Normalize outcomes
+        shell: bash
+        run: |
+          python scripts/normalize-trx.py trx "outcomes-${{ matrix.label }}.txt"
+
+      - name: Upload outcomes
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: outcomes-${{ matrix.label }}
+          path: outcomes-${{ matrix.label }}.txt
+
+  diff:
+    name: Diff outcomes across platforms
+    needs: run
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all outcomes
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: outcomes
+
+      - name: Compare against linux-x64
+        run: |
+          ref="outcomes/outcomes-linux-x64/outcomes-linux-x64.txt"
+          if [ ! -f "$ref" ]; then
+            echo "::error::reference outcomes (linux-x64) missing"
+            exit 1
+          fi
+          fail=0
+          for dir in outcomes/outcomes-*/; do
+            file=$(find "$dir" -name 'outcomes-*.txt' | head -n1)
+            label=$(basename "$dir" | sed 's/^outcomes-//')
+            if ! diff -u "$ref" "$file" > "diff-$label.txt"; then
+              echo "::error::Test outcomes on $label diverge from linux-x64:"
+              cat "diff-$label.txt"
+              fail=1
+            else
+              echo "✅ $label matches linux-x64"
+            fi
+          done
+          exit $fail

--- a/.github/workflows/docfx.yaml
+++ b/.github/workflows/docfx.yaml
@@ -60,7 +60,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0  # Full history needed to enumerate all v* tags
           persist-credentials: false
@@ -127,7 +127,7 @@ jobs:
           }
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v6
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
         with:
           dotnet-version: |
             5.0.x

--- a/.github/workflows/fuzz.yaml
+++ b/.github/workflows/fuzz.yaml
@@ -1,0 +1,82 @@
+name: Fuzz
+
+# Continuous fuzz sweep (#115). The unit-adjacent Tests.Fuzz project runs the
+# same CsCheck properties at ~1000 cases per PR (seconds); this scheduled
+# workflow runs them at a far higher case count to surface rare edge cases, and
+# auto-files an issue if a property is falsified. CsCheck prints a replayable
+# seed on failure, so the reported case can be pinned as a deterministic
+# regression in the unit suite.
+
+on:
+  schedule:
+    - cron: '0 5 * * 0'   # weekly, Sunday 05:00 UTC
+  workflow_dispatch:
+    inputs:
+      iterations:
+        description: 'Cases per property'
+        required: false
+        default: '1000000'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: fuzz-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  fuzz:
+    name: Property fuzz sweep
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      issues: write   # auto-file an issue when a property is falsified
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Run fuzz sweep
+        id: fuzz
+        env:
+          FUZZ_ITER: ${{ github.event.inputs.iterations || '1000000' }}
+        run: |
+          set -o pipefail
+          dotnet test tests/Wolfgang.Etl.TestKit.Tests.Fuzz/Wolfgang.Etl.TestKit.Tests.Fuzz.csproj \
+            -c Release --logger "console;verbosity=detailed" 2>&1 | tee fuzz-output.txt
+
+      - name: Upload fuzz log
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: fuzz-output
+          path: fuzz-output.txt
+          retention-days: 30
+
+      - name: File issue on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # CsCheck prints a replayable seed in the failure output; the issue body
+          # carries the log tail so the seed can be pinned as a regression.
+          {
+            echo "The scheduled fuzz sweep falsified a property."
+            echo ""
+            echo "Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+            echo ""
+            echo '```'
+            tail -c 4000 fuzz-output.txt || true
+            echo '```'
+          } > issue-body.txt
+          gh issue create \
+            --title "Fuzz sweep falsified a property ($(date -u +%Y-%m-%d))" \
+            --label bug \
+            --body-file issue-body.txt

--- a/.github/workflows/license-audit.yaml
+++ b/.github/workflows/license-audit.yaml
@@ -1,0 +1,82 @@
+name: License Audit
+
+# License audit of transitive dependencies (#137).
+#
+# Validates each shipped library's full (direct + transitive) dependency closure
+# against an allow-list of OSI-permissive licenses using the `nuget-license` tool,
+# and FAILS the build if any dependency's license is not allowed (e.g. a copyleft
+# or non-OSI license slipping in via a bump). Config lives in .github/license-audit/.
+# Also uploads the full inventory as a JSON artifact.
+#
+# Both packable projects are audited: Wolfgang.Etl.TestKit and
+# Wolfgang.Etl.TestKit.Xunit (the latter adds the xunit closure).
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: license-audit-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  license-audit:
+    name: License audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        proj:
+          - src/Wolfgang.Etl.TestKit/Wolfgang.Etl.TestKit.csproj
+          - src/Wolfgang.Etl.TestKit.Xunit/Wolfgang.Etl.TestKit.Xunit.csproj
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Install nuget-license
+        run: dotnet tool install --global nuget-license
+
+      - name: Restore (so transitive deps resolve)
+        run: dotnet restore "${{ matrix.proj }}"
+
+      # Gate: fail if any dependency's license is not in the allow-list.
+      #  - allowed-licenses.json     — OSI-permissive licenses we accept.
+      #  - url-license-mappings.json — maps a couple of Microsoft packages that expose a
+      #    license URL (not an SPDX expression) to their actual license (MIT).
+      #  - ignored-packages.json     — SonarAnalyzer.CSharp only: a build-time analyzer
+      #    (PrivateAssets=all, not shipped) under the non-OSI SONAR Source-Available
+      #    License, so it imposes no obligation on consumers of the package.
+      - name: Audit licenses (gate on allow-list)
+        run: |
+          nuget-license -i "${{ matrix.proj }}" -t \
+            -a .github/license-audit/allowed-licenses.json \
+            -ignore .github/license-audit/ignored-packages.json \
+            -mapping .github/license-audit/url-license-mappings.json \
+            -o Table
+
+      - name: License report (JSON artifact)
+        run: |
+          nuget-license -i "${{ matrix.proj }}" -t \
+            -a .github/license-audit/allowed-licenses.json \
+            -ignore .github/license-audit/ignored-packages.json \
+            -mapping .github/license-audit/url-license-mappings.json \
+            -o JsonPretty -fo licenses.json
+
+      - name: Upload license report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: license-report-${{ strategy.job-index }}
+          path: licenses.json

--- a/.github/workflows/perf-regression.yaml
+++ b/.github/workflows/perf-regression.yaml
@@ -1,40 +1,38 @@
-name: Benchmarks
+name: Perf Regression
 
-# Runs BenchmarkDotNet after a merge to main, then publishes the results to
-# the gh-pages branch under /dev/bench/ where benchmark-action/github-action-benchmark
-# renders an interactive line chart.
+# Per-PR performance-regression detection (#144).
 #
-# This workflow is decoupled from PR validation and release: it does NOT gate
-# merging or publishing — it just adds one data point per qualifying push.
+# Runs the BenchmarkDotNet suite on the PR and compares it against the baseline
+# published to gh-pages (dev/bench) by benchmarks.yaml. If a benchmark regresses
+# beyond the alert threshold, github-action-benchmark comments on the PR.
+#
+# Report-only for now: BenchmarkDotNet on shared CI runners is noisy, so this
+# does NOT fail the build (`fail-on-alert: false`) and does NOT update the
+# baseline (`auto-push: false`). Flip `fail-on-alert` to true — with a threshold
+# tuned to the observed noise — to turn it into a gate.
 
 on:
-  push:
-    branches: [main]
+  pull_request:
     paths:
       - 'src/**'
       - 'benchmarks/**'
-      - '.github/workflows/benchmarks.yaml'
   workflow_dispatch:
 
 permissions:
   contents: read
 
-# Serialize benchmark publishes so two pushes to main close together can't race
-# on the gh-pages branch. cancel-in-progress: false — every merge represents a
-# meaningful data point, so we queue rather than discard.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  group: perf-regression-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   benchmark:
-    name: Run BenchmarkDotNet & publish chart
+    name: Benchmark vs base
     runs-on: ubuntu-latest
-
+    timeout-minutes: 20
     permissions:
-      # Required to push the rendered chart + history to the gh-pages branch.
-      contents: write
-
+      contents: read
+      pull-requests: write   # post the regression alert comment
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -44,8 +42,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
         with:
-          dotnet-version: |
-            10.0.x
+          dotnet-version: '10.0.x'
 
       - name: Restore
         run: dotnet restore benchmarks/Wolfgang.Etl.TestKit.Benchmarks/Wolfgang.Etl.TestKit.Benchmarks.csproj
@@ -55,29 +52,18 @@ jobs:
 
       - name: Run benchmarks
         working-directory: benchmarks/Wolfgang.Etl.TestKit.Benchmarks
-        # ShortRun keeps total runtime small (~3-5 min). GitHub-hosted runners
-        # are noisy, so chart trends are reliable for allocations and double-digit
-        # time changes; smaller deltas are not.
         run: dotnet run -c Release --no-build -- --filter "*" --job short --memory --exporters json
 
       - name: Merge per-class BDN reports
         id: locate
         working-directory: benchmarks/Wolfgang.Etl.TestKit.Benchmarks
         run: |
-          # BDN's --exporters json writes one *-report-full-compressed.json per
-          # benchmark class. github-action-benchmark consumes a single file, so
-          # we combine the .Benchmarks arrays into one synthetic report.
-          # nullglob: empty match expands to nothing (instead of the literal
-          # pattern), so the explicit "no report found" branch can run before
-          # set -e + pipefail aborts the step.
           shopt -s nullglob
           reports=(BenchmarkDotNet.Artifacts/results/*-report-full-compressed.json)
           if [ ${#reports[@]} -eq 0 ]; then
             echo "::error::No BenchmarkDotNet JSON report found"
             exit 1
           fi
-          echo "Merging ${#reports[@]} report(s):"
-          printf '  %s\n' "${reports[@]}"
           jq -s '{
             Title: "BenchmarkDotNet combined report",
             HostEnvironmentInfo: .[0].HostEnvironmentInfo,
@@ -85,9 +71,7 @@ jobs:
           }' "${reports[@]}" > benchmarks-result.json
           echo "report=benchmarks/Wolfgang.Etl.TestKit.Benchmarks/benchmarks-result.json" >> "$GITHUB_OUTPUT"
 
-      - name: Publish chart to gh-pages
-        # Pinned to v1.22.1 commit per repo convention (third-party actions
-        # publishing to gh-pages are pinned by SHA, not mutable tag).
+      - name: Compare against gh-pages baseline
         uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba  # v1.22.1
         with:
           name: BenchmarkDotNet
@@ -95,9 +79,9 @@ jobs:
           output-file-path: ${{ steps.locate.outputs.report }}
           gh-pages-branch: gh-pages
           benchmark-data-dir-path: dev/bench
-          auto-push: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          # Don't fail the workflow if a metric regresses — this is a tracker,
-          # not a gate. Tighten later if the noise floor settles.
           alert-threshold: '200%'
+          comment-on-alert: true
           fail-on-alert: false
+          auto-push: false
+          save-data-file: false

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -376,16 +376,20 @@ jobs:
       # net5+ / netstandard / netcoreapp projects — no filter loop needed.
       # InspectCode then reads the built outputs (with `--no-build`).
       - name: Restore and build
+        env:
+          SLN: ${{ steps.select-solution.outputs.sln }}
         run: |
-          dotnet restore "${{ steps.select-solution.outputs.sln }}"
-          dotnet build "${{ steps.select-solution.outputs.sln }}" -c Release --no-restore
+          dotnet restore "$SLN"
+          dotnet build "$SLN" -c Release --no-restore
 
       - name: Install JetBrains.ReSharper.GlobalTools
         run: dotnet tool install -g JetBrains.ReSharper.GlobalTools
 
       - name: Run InspectCode
+        env:
+          SLN_INPUT: ${{ steps.select-solution.outputs.sln }}
         run: |
-          SLN="${{ steps.select-solution.outputs.sln }}"
+          SLN="$SLN_INPUT"
           echo "Inspecting: $SLN"
           jb inspectcode "$SLN" \
             --output=inspect.sarif \

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -42,7 +42,7 @@ jobs:
     if: github.repository != 'Chris-Wolfgang/repo-template'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/head
           persist-credentials: false
@@ -96,7 +96,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/head
           persist-credentials: false
@@ -239,7 +239,186 @@ jobs:
             echo "has-projects=false" >> "$GITHUB_OUTPUT"
             echo "ℹ️  No .NET project files found - skipping .NET build and test jobs"
           fi
+  # ============================================================================
+  # INSPECTCODE: JetBrains ReSharper InspectCode parallel to the test stages.
+  # Runs concurrently with Stage 1 / 2 / 3 (no `needs:` on a test job) so it
+  # doesn't extend wall-clock — typically 3–5 min vs the slowest stage.
+  # SARIF uploads to GitHub Code Scanning (Security tab + inline PR
+  # annotations). `error`-severity findings fail the job; `warning`-severity
+  # surfaces in Code Scanning but doesn't fail (gated by --severity=WARNING
+  # filter). Tune the noise floor via .DotSettings at the repo root.
+  # ============================================================================
+  inspectcode:
+    name: "ReSharper InspectCode"
+    # Runs on Windows so .NET Framework reference assemblies (System,
+    # System.Xml.Linq, etc.) resolve natively for any net462 / net472 / net48
+    # projects the solution includes. On ubuntu-latest InspectCode fails
+    # with 60+ MSB3245 assembly-resolution errors on Framework-target
+    # projects unless we install mono — Windows has them out of the box.
+    # The build + test stages parallel this on Linux/Windows/macOS, so the
+    # Windows load here is not additive to the wall-clock the way an extra
+    # test stage would be.
+    runs-on: windows-latest
+    # All step scripts below use bash syntax (process substitution, [[ ]],
+    # etc.) — pin the default shell so it works uniformly on windows-latest
+    # (which defaults to pwsh) and not accidentally on any future runner
+    # swap.
+    defaults:
+      run:
+        shell: bash
+    needs: detect-projects
+    if: github.repository != 'Chris-Wolfgang/repo-template' && needs.detect-projects.outputs.has-projects == 'true'
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      security-events: write   # required for upload-sarif
 
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/head
+          persist-credentials: false
+
+      # Same defense-in-depth pattern as detect-projects and the test stages:
+      # jobs don't share workspaces under pull_request_target, so each build/
+      # analyzer job re-fetches protected config from main after checkout.
+      # Without this, a malicious PR could ship a permissive .editorconfig /
+      # BannedSymbols.txt / .DotSettings that would silence InspectCode
+      # findings on the PR's own code.
+      - name: Fetch trusted configuration files from main branch
+        # Skip for Dependabot — its package-version bumps to protected files are
+        # legitimate and should not be overwritten by main's older versions.
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
+        run: |
+          echo "Fetching configuration files from main branch to prevent malicious overrides..."
+
+          git fetch origin main:main-branch
+
+          config_files=(
+            ".editorconfig"
+            "Directory.Build.props"
+            "Directory.Build.targets"
+            "BannedSymbols.txt"
+            "*.globalconfig"
+            "*.ruleset"
+            ".github/workflows/*.yml"
+            ".github/workflows/*.yaml"
+          )
+
+          for config_file in "${config_files[@]}"; do
+            if [[ "$config_file" == *"*"* ]]; then
+              # See Stage 1 for the process-substitution rationale (avoids a
+              # subshell that would swallow `exit 1` on failed copies).
+              while read -r file; do
+                if [ -n "$file" ]; then
+                  echo "  ✓ Copying $file from main branch"
+                  mkdir -p "$(dirname "$file")"
+                  if ! git show "main-branch:$file" > "$file"; then
+                    echo "::error::Failed to copy $file from main-branch — aborting to prevent silent fall-back to PR-supplied protected config."
+                    exit 1
+                  fi
+                fi
+              done < <(git ls-tree -r --name-only main-branch | { grep -E "${config_file//\*/.*}" || true; })
+            else
+              if git cat-file -e "main-branch:$config_file" 2>/dev/null; then
+                echo "  ✓ Copying $config_file from main branch"
+                if ! git show "main-branch:$config_file" > "$config_file"; then
+                  echo "::error::Failed to copy $config_file from main-branch — aborting to prevent silent fall-back to PR-supplied protected config."
+                  exit 1
+                fi
+              else
+                echo "  ℹ️  $config_file not found in main branch, skipping"
+              fi
+            fi
+          done
+
+          echo ""
+          echo "✅ Configuration files secured - using versions from main branch"
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
+        with:
+          # Match the test stages' SDK list so the solution's older-TFM projects
+          # (test projects target netcoreapp3.1 / net5.0-net7.0) restore and build
+          # here too — a 10.0-only SDK would fail or trip out-of-support-TFM
+          # warnings-as-errors on those projects.
+          dotnet-version: |
+            3.1.x
+            5.0.x
+            6.0.x
+            7.0.x
+            8.0.x
+            9.0.x
+            10.0.x
+
+      # Select the solution FIRST so restore, build, and InspectCode all target
+      # the SAME one — and so a missing/absent solution fails with the intended
+      # message rather than a generic dotnet error from an implicit build.
+      # Prefer .slnx (new format) then .sln.
+      - name: Select solution
+        id: select-solution
+        run: |
+          SLN=$(ls *.slnx 2>/dev/null | head -n1)
+          if [ -z "$SLN" ]; then
+            SLN=$(ls *.sln 2>/dev/null | head -n1)
+          fi
+          if [ -z "$SLN" ]; then
+            echo "::error::No .slnx or .sln found at repo root — InspectCode needs one to run."
+            exit 1
+          fi
+          echo "Selected solution: $SLN"
+          echo "sln=$SLN" >> "$GITHUB_OUTPUT"
+
+      # Restore + build the selected solution. On windows-latest .NET Framework
+      # 4.x reference assemblies are bundled, so net462 / net472 / net48 projects
+      # (e.g. examples/CSharp.DotNet462.Example) build natively alongside
+      # net5+ / netstandard / netcoreapp projects — no filter loop needed.
+      # InspectCode then reads the built outputs (with `--no-build`).
+      - name: Restore and build
+        run: |
+          dotnet restore "${{ steps.select-solution.outputs.sln }}"
+          dotnet build "${{ steps.select-solution.outputs.sln }}" -c Release --no-restore
+
+      - name: Install JetBrains.ReSharper.GlobalTools
+        run: dotnet tool install -g JetBrains.ReSharper.GlobalTools
+
+      - name: Run InspectCode
+        run: |
+          SLN="${{ steps.select-solution.outputs.sln }}"
+          echo "Inspecting: $SLN"
+          jb inspectcode "$SLN" \
+            --output=inspect.sarif \
+            --format=sarif \
+            --severity=WARNING \
+            --no-build
+
+      - name: Upload SARIF to Code Scanning
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
+        with:
+          sarif_file: inspect.sarif
+
+      - name: Gate on error-severity findings
+        # PowerShell (native on windows-latest) so we don't depend on jq
+        # being preinstalled. Parses the SARIF via ConvertFrom-Json and
+        # counts results at level=error. Warnings still upload (visible in
+        # Security → Code scanning) but don't gate merge — raise to `error`
+        # later when the noise floor is acceptable.
+        shell: pwsh
+        run: |
+          $sarif = Get-Content inspect.sarif -Raw | ConvertFrom-Json
+          $count = @(
+            foreach ($run in $sarif.runs) {
+              foreach ($result in $run.results) {
+                if ($result.level -eq 'error') { $result }
+              }
+            }
+          ).Count
+          if ($count -gt 0) {
+            Write-Host "::error::$count InspectCode error-severity finding(s) — see Security → Code scanning"
+            exit 1
+          }
+          Write-Host "✅ No error-severity InspectCode findings."
   # ============================================================================
   # STAGE 1: Linux - .NET Core/5+ Tests with Coverage Gate
   # ============================================================================
@@ -251,7 +430,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/head
           persist-credentials: false
@@ -338,7 +517,7 @@ jobs:
           sudo rm /etc/apt/sources.list.d/focal-security.list
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v6
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
         with:
           dotnet-version: |
             3.1.x
@@ -626,7 +805,7 @@ jobs:
 
       - name: Upload Linux coverage results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: coverage-linux
           path: |
@@ -634,7 +813,7 @@ jobs:
             CoverageReport/
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: build-output
           path: |
@@ -652,7 +831,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/head
           persist-credentials: false
@@ -720,7 +899,7 @@ jobs:
           Write-Host "✅ Configuration files secured - using versions from main branch"
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v6
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
         with:
           dotnet-version: |
             3.1.x
@@ -958,7 +1137,7 @@ jobs:
 
       - name: Upload Windows coverage results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: coverage-windows
           path: |
@@ -976,7 +1155,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/head
           persist-credentials: false
@@ -1048,7 +1227,7 @@ jobs:
           echo "✅ Configuration files secured - using versions from main branch"
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v6
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
         with:
           dotnet-version: |
             6.0.x
@@ -1313,7 +1492,7 @@ jobs:
 
       - name: Upload macOS coverage results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: coverage-macos
           path: |
@@ -1363,7 +1542,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/head
           persist-credentials: false
@@ -1468,7 +1647,7 @@ jobs:
 
       - name: Upload security scan results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: devskim-results
           path: devskim-results.txt

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
     if: github.repository != 'Chris-Wolfgang/repo-template'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 
@@ -85,7 +85,7 @@ jobs:
           }
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v6
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
         with:
           dotnet-version: |
             3.1.x
@@ -340,7 +340,7 @@ jobs:
 
       - name: Upload coverage report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: release-coverage
           path: CoverageReport/
@@ -354,12 +354,12 @@ jobs:
       has-packages: ${{ steps.check-packages.outputs.has-packages }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v6
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
         with:
           dotnet-version: |
             3.1.x
@@ -562,7 +562,7 @@ jobs:
 
 
       - name: Upload NuGet packages
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: nuget-packages
           path: ./nuget-packages/
@@ -581,7 +581,7 @@ jobs:
     if: github.repository != 'Chris-Wolfgang/repo-template'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 
@@ -598,7 +598,7 @@ jobs:
 
       - name: Setup .NET
         if: steps.check.outputs.found == 'true'
-        uses: actions/setup-dotnet@v6
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
         with:
           # Install the same SDK set as validate-release so dotnet build can
           # compile every TFM the solution targets (some test projects span
@@ -672,9 +672,12 @@ jobs:
     needs: [pack-and-validate, verify-docs-build]
     if: needs.pack-and-validate.outputs.has-packages == 'true'
     runs-on: windows-latest
+    permissions:
+      id-token: write   # required for OIDC token issuance to nuget.org
+      contents: read
     steps:
       - name: Setup .NET
-        uses: actions/setup-dotnet@v6
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
         with:
           dotnet-version: |
             3.1.x
@@ -686,27 +689,24 @@ jobs:
             10.0.x
 
       - name: Download packages
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: nuget-packages
           path: ./packages
 
-      - name: Validate NuGet API key
-        shell: pwsh
-        env:
-          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-        run: |
-          if ([string]::IsNullOrEmpty($env:NUGET_API_KEY)) {
-            Write-Error "❌ NUGET_API_KEY secret not configured!"
-            Write-Host "Please add it in: Repository Settings → Secrets and variables → Actions → New repository secret"
-            exit 1
-          }
-          Write-Host "✅ NUGET_API_KEY is configured" -ForegroundColor Green
+      - name: NuGet login (OIDC → temporary API key)
+        # Trusted Publishing: exchange the workflow's GitHub OIDC token for an
+        # ephemeral (~1h) push key. No long-lived NUGET_API_KEY secret is used.
+        # Requires a Trusted Publishing policy for each package on nuget.org.
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1
+        id: nuget-login
+        with:
+          user: Chris-Wolfgang
 
       - name: Publish to NuGet
         shell: pwsh
         env:
-          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+          NUGET_API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
         run: |
           $packages = Get-ChildItem -Path './packages' -Filter '*.nupkg' -ErrorAction SilentlyContinue
           
@@ -757,14 +757,35 @@ jobs:
     permissions:
       contents: write  # Required to upload assets to the GitHub Release
     steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
+        with:
+          dotnet-version: '10.0.x'
+
+      # Reproducible-build manifest (#145): the canonical SHA-256 of each shipped
+      # assembly, built with the same deterministic command consumers reproduce
+      # (docs/REPRODUCIBLE-BUILD.md). Attached to the release below.
+      - name: Generate reproducible-build manifest
+        # Pass the tag through the environment rather than interpolating the
+        # ${{ }} expression directly into the run block, so a crafted tag name
+        # can't inject shell (zizmor template-injection).
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: bash scripts/reproducible-manifest.sh "$RELEASE_TAG" reproducible-build-manifest.json
+
       - name: Download NuGet packages artifact
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: nuget-packages
           path: ./nuget-packages
 
       - name: Download coverage report artifact
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-coverage
           path: ./release-coverage
@@ -781,4 +802,5 @@ jobs:
             ./nuget-packages/*.snupkg
             ./nuget-packages/*.bom.json
             release-coverage.zip
+            reproducible-build-manifest.json
 

--- a/.github/workflows/reproducible-build.yaml
+++ b/.github/workflows/reproducible-build.yaml
@@ -1,0 +1,87 @@
+name: Build Reproducibility
+
+# Deterministic-build verification (#135).
+#
+# The libraries build with Deterministic + ContinuousIntegrationBuild +
+# SourceLink, which should make the compiled assemblies byte-for-byte
+# reproducible regardless of the checkout path. This job proves it: check the
+# same commit out to two different directories, build each with
+# ContinuousIntegrationBuild=true (which normalises source paths to /_/), and
+# fail if the produced assemblies don't hash identically.
+#
+# This verifies path-independent reproducibility on a single runner (the
+# fleet-proven check). Cross-OS byte-identity (ubuntu vs windows) is a stronger
+# claim that is not reliably guaranteed for .pdb across SDK/OS and is tracked as
+# a follow-up in REPRODUCIBLE-BUILD.md.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: reproducible-build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  reproducible:
+    name: Reproducible build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout (copy A)
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          path: a
+          persist-credentials: false
+
+      - name: Checkout (copy B)
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          path: b
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Build copy A
+        run: |
+          for proj in \
+            src/Wolfgang.Etl.TestKit/Wolfgang.Etl.TestKit.csproj \
+            src/Wolfgang.Etl.TestKit.Xunit/Wolfgang.Etl.TestKit.Xunit.csproj; do
+            dotnet build "a/${proj}" -c Release -f net10.0 -p:ContinuousIntegrationBuild=true
+          done
+
+      - name: Build copy B
+        run: |
+          for proj in \
+            src/Wolfgang.Etl.TestKit/Wolfgang.Etl.TestKit.csproj \
+            src/Wolfgang.Etl.TestKit.Xunit/Wolfgang.Etl.TestKit.Xunit.csproj; do
+            dotnet build "b/${proj}" -c Release -f net10.0 -p:ContinuousIntegrationBuild=true
+          done
+
+      - name: Compare assembly hashes
+        run: |
+          status=0
+          for asm in \
+            src/Wolfgang.Etl.TestKit/bin/Release/net10.0/Wolfgang.Etl.TestKit.dll \
+            src/Wolfgang.Etl.TestKit.Xunit/bin/Release/net10.0/Wolfgang.Etl.TestKit.Xunit.dll; do
+            ha=$(sha256sum "a/${asm}" | cut -d' ' -f1)
+            hb=$(sha256sum "b/${asm}" | cut -d' ' -f1)
+            echo "${asm}"
+            echo "  A: $ha"
+            echo "  B: $hb"
+            if [ "$ha" != "$hb" ]; then
+              echo "::error::Build is not reproducible — ${asm} hashes differ."
+              status=1
+            else
+              echo "  ✅ reproducible"
+            fi
+          done
+          exit $status

--- a/.github/workflows/sbom.yaml
+++ b/.github/workflows/sbom.yaml
@@ -1,0 +1,66 @@
+name: SBOM
+
+# Supply-chain hardening — Software Bill of Materials (#127).
+#
+# Generates a CycloneDX SBOM of each shipped library's full dependency graph on
+# every PR and push, and uploads it as an artifact — so every build has a
+# machine-readable inventory of what it is composed of, and dependency changes
+# are visible at review time (release.yaml already emits SBOMs for the packed
+# artifacts; this is the per-PR complement).
+#
+# Scoped to the SBOM here; the other parts of #127 are deliberately out of this
+# workflow:
+#   - SLSA provenance attestation belongs on the release artifact (attest the
+#     packed .nupkg in release.yaml via actions/attest-build-provenance).
+#   - Package signing needs a signing certificate/key and is a separate,
+#     credential-bearing change.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sbom-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sbom:
+    name: Generate SBOM
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        proj:
+          - src/Wolfgang.Etl.TestKit/Wolfgang.Etl.TestKit.csproj
+          - src/Wolfgang.Etl.TestKit.Xunit/Wolfgang.Etl.TestKit.Xunit.csproj
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Install CycloneDX
+        run: dotnet tool install --global CycloneDX
+
+      - name: Restore
+        run: dotnet restore "${{ matrix.proj }}"
+
+      - name: Generate CycloneDX SBOM (JSON)
+        run: dotnet CycloneDX "${{ matrix.proj }}" --output sbom --json
+
+      - name: Upload SBOM
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: sbom-${{ strategy.job-index }}
+          path: sbom/

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -1,0 +1,50 @@
+name: OSSF Scorecard
+
+# Automated security-posture scoring via the OpenSSF Scorecard (#142).
+#
+# Scorecard evaluates the repo against supply-chain / security best practices
+# (branch protection, pinned dependencies, token permissions, dangerous
+# workflow patterns, ...) and uploads findings to Code Scanning. Runs on a
+# weekly schedule and on branch-protection changes; not per-PR (it scores the
+# repository, not a diff).
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '31 6 * * 1'   # Mondays at 06:31 UTC
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions: read-all
+
+concurrency:
+  group: scorecard-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      security-events: write   # upload the SARIF results
+      id-token: write          # publish results to the OpenSSF API
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a  # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload SARIF to Code Scanning
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/semgrep.yaml
+++ b/.github/workflows/semgrep.yaml
@@ -1,0 +1,62 @@
+name: SAST (Semgrep)
+
+# Security-grade static analysis beyond CodeQL (#117).
+#
+# Semgrep runs a different engine and ruleset from CodeQL (pattern/dataflow
+# rules for C#, a general security-audit pack, and a secrets pack), so it
+# surfaces issues CodeQL's queries don't. Findings upload to Code Scanning
+# (Security tab) as an additional signal; report-only for now (`|| true`) so a
+# noisy new ruleset can't block merges — promote to a gate once the baseline is
+# clean.
+#
+# Uses the public Semgrep registry packs, which need no account/login (the free
+# Semgrep OSS tier — the "try the free tool first" path the issue calls for).
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: semgrep-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  semgrep:
+    name: Semgrep
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: '3.x'
+
+      - name: Install Semgrep
+        run: pip install semgrep
+
+      - name: Run Semgrep
+        run: |
+          semgrep scan \
+            --config p/csharp \
+            --config p/security-audit \
+            --config p/secrets \
+            --sarif --output semgrep.sarif \
+            --error || true
+
+      - name: Upload Semgrep SARIF
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
+        with:
+          sarif_file: semgrep.sarif

--- a/.github/workflows/sourcelink-stepinto.yaml
+++ b/.github/workflows/sourcelink-stepinto.yaml
@@ -1,0 +1,99 @@
+name: SourceLink Step-Into
+
+# End-to-end "F11 into library source" verification, one step beyond sourcelink.yaml.
+#
+# sourcelink.yaml (PR #208) proves every document in the PDB resolves to real
+# GitHub content via `dotnet sourcelink test`. This workflow proves the *debugger*
+# half: it builds a scratch consumer against the library (compiled with the same
+# ContinuousIntegrationBuild + SourceLink a release ships), then drives netcoredbg
+# to set a breakpoint in the consumer and STEP INTO (the F11 a consumer would
+# press) a library constructor — asserting the debugger lands in the library's
+# real source (symbols loaded, SourceLink-mapped source file) rather than a
+# decompiled placeholder. If the SourceLink map or sequence points were broken the
+# step would land with no source and this fails.
+#
+# Why a project reference, not the packed NuGet: netcoredbg (the only
+# CI-scriptable .NET debugger) does not reliably pair a *package*-sourced
+# assembly with its symbol-package PDB, so it cannot step into it. The PDB under
+# test is byte-identical either way; the packed-package symbol/URL resolution is
+# covered by sourcelink.yaml (PR #208). See .github/sourcelink/README.md.
+#
+# Together these two workflows satisfy #133 (SourceLink debug-step-into
+# verification). Scheduled + manual only (not a PR gate): debugger automation is
+# heavier and slightly less deterministic than a unit test, and SourceLink's raw
+# URLs resolve only against a pushed commit.
+
+on:
+  schedule:
+    - cron: '30 7 * * 1'   # Mondays 07:30 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sourcelink-stepinto-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  NETCOREDBG_VERSION: 3.1.2-1054
+  # Reduce tiered-JIT reordering so the step-into target stays stable.
+  DOTNET_TieredCompilation: '0'
+
+jobs:
+  step-into:
+    name: Debugger step-into (F11) resolves library source
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Detect src project
+        id: detect
+        run: |
+          if git ls-files 'src/**/*.csproj' 'src/*.csproj' | grep -q .; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No src/**/*.csproj found — skipping."
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup .NET
+        if: steps.detect.outputs.found == 'true'
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
+        with:
+          dotnet-version: '10.0.x'
+
+      # Build the fixture consumer. Its ProjectReference pulls in the library,
+      # compiled with ContinuousIntegrationBuild=true so the PDB carries the same
+      # SourceLink map a released package ships (Debug = non-optimized so the
+      # step-into target isn't reordered away).
+      - name: Build step-into consumer (SourceLink)
+        if: steps.detect.outputs.found == 'true'
+        run: |
+          dotnet build .github/sourcelink/consumer/StepIntoConsumer.csproj \
+            -c Debug \
+            -p:ContinuousIntegrationBuild=true
+
+      - name: Install netcoredbg
+        if: steps.detect.outputs.found == 'true'
+        run: |
+          url="https://github.com/Samsung/netcoredbg/releases/download/${NETCOREDBG_VERSION}/netcoredbg-linux-amd64.tar.gz"
+          curl -sSfL "$url" -o netcoredbg.tar.gz
+          tar -xzf netcoredbg.tar.gz
+          echo "NETCOREDBG=$PWD/netcoredbg/netcoredbg" >> "$GITHUB_ENV"
+
+      - name: Step into the library (F11) and assert real source resolves
+        if: steps.detect.outputs.found == 'true'
+        run: |
+          prog=".github/sourcelink/consumer/Program.cs"
+          line="$(grep -n 'STEP_INTO_TARGET' "$prog" | head -n1 | cut -d: -f1)"
+          echo "Breaking at Program.cs:$line"
+          python3 .github/sourcelink/verify_stepinto.py \
+            "$NETCOREDBG" \
+            ".github/sourcelink/consumer/bin/Debug/net10.0/StepIntoConsumer.dll" \
+            "Program.cs:$line" \
+            "TestExtractor.cs"

--- a/.github/workflows/sourcelink.yaml
+++ b/.github/workflows/sourcelink.yaml
@@ -1,0 +1,101 @@
+name: SourceLink
+
+# End-to-end SourceLink verification.
+#
+# Directory.Build.props enables Microsoft.SourceLink.GitHub + EmbedUntrackedSources
+# and the release packs .snupkg symbol packages. That embeds, into every PDB, a
+# map from each source document to its raw.githubusercontent.com URL at the build
+# commit. If a release mis-tags the commit or the SourceLink map is wrong, a
+# consumer's "step into library source" (F11) silently falls back to a decompiled
+# assembly — and nothing catches it today.
+#
+# `dotnet sourcelink test` closes that gap without needing a live debugger: for
+# every document referenced by the PDB it fetches the mapped GitHub URL and fails
+# unless the downloaded content's checksum matches the one embedded in the PDB.
+# That exercises the exact chain that step-into depends on — commit-SHA embedded
+# in the PDB + GitHub raw-URL resolution. Embedded (untracked) documents need no
+# URL and are verified in place. The PDB tested here is byte-identical to the one
+# shipped inside the .snupkg, so this covers the symbol-package path too.
+#
+# Runs on PRs so a SourceLink regression is caught before it can ship, using the
+# PR's pushed commit (whose raw URLs resolve on GitHub).
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sourcelink-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sourcelink:
+    name: Verify SourceLink
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Detect src projects
+        id: detect
+        run: |
+          if git ls-files 'src/**/*.csproj' 'src/*.csproj' | grep -q .; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No src/**/*.csproj found — skipping SourceLink verification."
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup .NET
+        if: steps.detect.outputs.found == 'true'
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
+        with:
+          dotnet-version: '10.0.x'
+
+      # Build each src project (not the whole solution — benchmarks/examples may
+      # target older TFMs only, so `-f net10.0` at the solution level would fail).
+      # ContinuousIntegrationBuild=true normalises source paths exactly as a
+      # release does, so the PDB embeds the same SourceLink map the shipped
+      # package carries.
+      - name: Build src projects (Release, net10.0)
+        if: steps.detect.outputs.found == 'true'
+        run: |
+          while IFS= read -r proj; do
+            echo "== build $proj =="
+            dotnet build "$proj" -c Release -f net10.0 -p:ContinuousIntegrationBuild=true
+          done < <(git ls-files 'src/**/*.csproj' 'src/*.csproj')
+
+      - name: Install sourcelink tool
+        if: steps.detect.outputs.found == 'true'
+        run: dotnet tool install --global sourcelink
+
+      - name: Verify SourceLink resolves for every PDB
+        if: steps.detect.outputs.found == 'true'
+        run: |
+          export PATH="$PATH:$HOME/.dotnet/tools"
+          shopt -s globstar nullglob
+          pdbs=(src/**/bin/Release/net10.0/*.pdb)
+          if [ ${#pdbs[@]} -eq 0 ]; then
+            echo "::error::No PDBs found under src/**/bin/Release/net10.0 — SourceLink cannot be verified."
+            exit 1
+          fi
+          failed=0
+          for pdb in "${pdbs[@]}"; do
+            echo "== sourcelink test $pdb =="
+            if ! sourcelink test "$pdb"; then
+              echo "::error::SourceLink verification failed for $pdb — a debugger would fall back to decompiled source."
+              failed=1
+            fi
+          done
+          if [ "$failed" -ne 0 ]; then
+            exit 1
+          fi
+          echo "✅ SourceLink resolves for all PDBs — step-into will fetch real source from GitHub."

--- a/.github/workflows/stryker.yaml
+++ b/.github/workflows/stryker.yaml
@@ -9,6 +9,11 @@
 # - workflow_dispatch: manual ad-hoc runs (e.g. while iterating on tests)
 # - schedule (weekly Sunday 06:00 UTC): catch quality regressions between
 #   releases without burning CI time on every PR (mutation testing is slow)
+# - pull_request (src/** or tests/** changes): the #124 enforcement gate. The
+#   per-project stryker-config.json pins target-framework:net10.0, so a PR runs
+#   a single-TFM mutation pass (~minutes) rather than the full matrix, and the
+#   config's `break` threshold fails the PR if the score regresses below floor.
+# - push to main: re-measure and publish the score to the gh-pages trend.
 #
 # Stryker discovers each test project's mutation targets via the standard
 # project-reference graph. Two configuration modes are supported:
@@ -23,6 +28,17 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 6 * * 0' # weekly Sunday 06:00 UTC
+  pull_request:
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - '.github/workflows/stryker.yaml'
+      - 'scripts/stryker-score.py'
+  push:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'tests/**'
 
 permissions:
   contents: read
@@ -43,7 +59,7 @@ jobs:
     timeout-minutes: 120
     steps:
       - name: Check out repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 
@@ -52,7 +68,7 @@ jobs:
         # through .NET 10.0). Stryker has to be able to build whichever
         # TFM each test project targets; pinning to a subset would
         # silently fail repos that target older runtimes.
-        uses: actions/setup-dotnet@v6
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
         with:
           dotnet-version: |
             3.1.x
@@ -102,8 +118,20 @@ jobs:
             $tests | ForEach-Object { Write-Host "  $($_.FullName)" }
             Write-Host ""
 
+            # Opt-in gating (#124): only run test projects that ship a
+            # stryker-config.json. A project without one has no documented
+            # score floor yet, so running it with Stryker defaults would be an
+            # ungated, all-TFM pass that is slow on every PR and can't fail the
+            # gate meaningfully. Add a stryker-config.json next to a test
+            # project to bring it under the gate.
+            $ran = 0
             foreach ($proj in $tests) {
               $dir = $proj.DirectoryName
+              if (-not (Test-Path (Join-Path $dir 'stryker-config.json'))) {
+                Write-Host "::notice::No stryker-config.json in $dir - skipping (add one to enable the mutation gate for this project)."
+                continue
+              }
+              $ran++
               Write-Host "::group::Stryker in $dir"
               Push-Location $dir
               try {
@@ -114,6 +142,11 @@ jobs:
               }
               Write-Host "::endgroup::"
             }
+
+            if ($ran -eq 0) {
+              Write-Host "::notice::No test project has a stryker-config.json - nothing to gate."
+              exit 0
+            }
           }
 
           if ($failed -gt 0) {
@@ -123,10 +156,58 @@ jobs:
 
       - name: Upload Stryker report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: stryker-report-${{ github.run_id }}
           path: |
             **/StrykerOutput/**
           if-no-files-found: ignore
           retention-days: 30
+
+  # Publish the mutation score to the gh-pages trend (#124), charted by the same
+  # benchmark-action pattern the BDN benchmark trend uses. Separate job so only
+  # it carries `contents: write`; the gate job above stays least-privilege. Runs
+  # only on trusted, non-PR events (a fork PR must never push to gh-pages) and
+  # only when the gate above passed (needs: stryker).
+  publish-trend:
+    name: Publish mutation-score trend
+    needs: stryker
+    if: github.event_name == 'push' || github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write   # push the score history to the gh-pages branch
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: '3.x'
+
+      - name: Download Stryker report
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: stryker-report-${{ github.run_id }}
+          path: stryker-report
+
+      - name: Extract mutation score
+        run: python scripts/stryker-score.py stryker-report stryker-score.json
+
+      - name: Publish score to gh-pages trend
+        uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1
+        with:
+          name: Mutation score
+          tool: 'customBiggerIsBetter'
+          output-file-path: stryker-score.json
+          gh-pages-branch: gh-pages
+          benchmark-data-dir-path: dev/stryker
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          # Bigger-is-better: alert if the score drops. Report-only (the PR gate
+          # above is the hard enforcement); this line just annotates the trend.
+          alert-threshold: '100%'
+          comment-on-alert: false
+          fail-on-alert: false

--- a/.zizmor.yml
+++ b/.zizmor.yml
@@ -1,0 +1,22 @@
+# zizmor configuration (#143 follow-up).
+#
+# NOTE: zizmor does NOT auto-discover this file — it must be passed explicitly
+# with `--config .zizmor.yml` on every invocation (see actions-audit.yaml).
+#
+# Every action in .github/workflows/** is pinned to a full commit SHA with a
+# `# vX` version comment (fleet SHA-pin convention). Enforce that: require a
+# hash pin for all actions, so a future tag-pin (`@v7`) or unpinned ref is
+# flagged by the `unpinned-uses` rule.
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        "*": hash-pin
+  dangerous-triggers:
+    # pr.yaml deliberately uses `pull_request_target` as a *gated* workflow: it
+    # runs from the trusted main branch, checks out PR code via refs/pull/*/head
+    # (never executing untrusted workflow YAML), and re-fetches analyzers/config
+    # from main so a malicious PR cannot disable checks. This is the canonical
+    # secure pattern, not the vulnerability the rule warns about.
+    ignore:
+      - pr.yaml

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -53,13 +53,13 @@
     </PackageReference>
     
     <!-- Meziantou - Comprehensive code quality -->
-    <PackageReference Include="Meziantou.Analyzer" Version="3.0.123">
+    <PackageReference Include="Meziantou.Analyzer" Version="3.0.125">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
 
     <!-- SonarAnalyzer - Industry-standard analysis -->
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.29.0.143774">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.30.0.144632">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -53,13 +53,13 @@
     </PackageReference>
     
     <!-- Meziantou - Comprehensive code quality -->
-    <PackageReference Include="Meziantou.Analyzer" Version="3.0.125">
+    <PackageReference Include="Meziantou.Analyzer" Version="3.0.123">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
 
     <!-- SonarAnalyzer - Industry-standard analysis -->
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.30.0.144632">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.29.0.143774">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/ETL-Test-Kit.slnx
+++ b/ETL-Test-Kit.slnx
@@ -36,11 +36,17 @@
     <Project Path="benchmarks/Wolfgang.Etl.TestKit.Benchmarks/Wolfgang.Etl.TestKit.Benchmarks.csproj" />
   </Folder>
   <Folder Name="/examples/" />
+  <Folder Name="/samples/">
+    <Project Path="samples/Wolfgang.Etl.TestKit.Sample/Wolfgang.Etl.TestKit.Sample.csproj" />
+  </Folder>
   <Folder Name="/src/">
     <Project Path="src/Wolfgang.Etl.TestKit/Wolfgang.Etl.TestKit.csproj" />
     <Project Path="src/Wolfgang.Etl.TestKit.Xunit/Wolfgang.Etl.TestKit.Xunit.csproj" />
   </Folder>
   <Folder Name="/tests/">
+    <Project Path="tests/Wolfgang.Etl.TestKit.Tests.Concurrency/Wolfgang.Etl.TestKit.Tests.Concurrency.csproj" />
+    <Project Path="tests/Wolfgang.Etl.TestKit.Tests.DocExamples/Wolfgang.Etl.TestKit.Tests.DocExamples.csproj" />
+    <Project Path="tests/Wolfgang.Etl.TestKit.Tests.Fuzz/Wolfgang.Etl.TestKit.Tests.Fuzz.csproj" />
     <Project Path="tests/Wolfgang.Etl.TestKit.Tests.Unit/Wolfgang.Etl.TestKit.Tests.Unit.csproj" />
     <Project Path="tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/Wolfgang.Etl.TestKit.Xunit.Tests.Unit.csproj" />
   </Folder>

--- a/aot-smoke/.editorconfig
+++ b/aot-smoke/.editorconfig
@@ -1,0 +1,14 @@
+# Isolation stub — companion to Directory.Build.props/.targets in this folder.
+#
+# .editorconfig is discovered by walking UP the directory tree, independently of
+# MSBuild's Directory.Build.props isolation, so without this the repo-root
+# .editorconfig's analyzer policy (CA2007 etc.) would still apply to the
+# throwaway AOT-smoke consumer. `root = true` stops that walk-up so the fixture
+# is fully exempt from repo lint — it is a publish-and-run smoke fixture, not
+# shipped code.
+root = true
+
+[*.cs]
+# The consumer is a console app with no synchronization context, so ConfigureAwait
+# is irrelevant; silence CA2007 explicitly in case SDK defaults ever enable it.
+dotnet_diagnostic.CA2007.severity = none

--- a/aot-smoke/Directory.Build.props
+++ b/aot-smoke/Directory.Build.props
@@ -1,0 +1,9 @@
+<!--
+  Isolation stub. MSBuild imports only the NEAREST Directory.Build.props when
+  walking up, so this empty project stops the repo-root Directory.Build.props
+  (analyzers, BannedSymbols, TreatWarningsAsErrors, CA2007, multi-TFM, PublicAPI,
+  …) from applying to the throwaway AOT-smoke consumer. The consumer is a
+  publish-and-run fixture, not shipped code, and must not inherit library policy.
+-->
+<Project>
+</Project>

--- a/aot-smoke/Directory.Build.targets
+++ b/aot-smoke/Directory.Build.targets
@@ -1,0 +1,3 @@
+<!-- Isolation stub — see Directory.Build.props in this folder. -->
+<Project>
+</Project>

--- a/aot-smoke/Wolfgang.Etl.TestKit.AotSmoke/Program.cs
+++ b/aot-smoke/Wolfgang.Etl.TestKit.AotSmoke/Program.cs
@@ -1,0 +1,60 @@
+// Native-AOT smoke consumer for Wolfgang.Etl.TestKit (#132).
+//
+// Exercises the public surface after native-AOT publish and returns a non-zero
+// exit code if any invariant is violated, so the CI job fails if the library
+// stops being AOT-safe at publish/run time. Kept deliberately simple — this is a
+// smoke test, not a behavioural test suite (those live in the unit-test project).
+
+using Wolfgang.Etl.TestKit;
+
+static int Fail(string message)
+{
+    Console.Error.WriteLine($"AOT smoke FAILED: {message}");
+    return 1;
+}
+
+// Extractor: yields the seeded items through the async-enumerable pipeline.
+var extractor = new TestExtractor<int>(new[] { 1, 2, 3 });
+var extracted = new List<int>();
+await foreach (var item in extractor.ExtractAsync())
+{
+    extracted.Add(item);
+}
+if (extracted.Count != 3)
+{
+    return Fail($"TestExtractor yielded {extracted.Count} items, expected 3");
+}
+
+// Transformer: pass-through over the extracted items.
+var transformer = new TestTransformer<int>();
+var transformed = new List<int>();
+await foreach (var item in transformer.TransformAsync(ToAsync(extracted)))
+{
+    transformed.Add(item);
+}
+if (transformed.Count != extracted.Count)
+{
+    return Fail($"TestTransformer yielded {transformed.Count} items, expected {extracted.Count}");
+}
+
+// Loader: collects everything the pipeline pushed.
+var loader = new TestLoader<int>(collectItems: true);
+await loader.LoadAsync(ToAsync(transformed));
+var collected = loader.GetCollectedItems();
+if (collected is null || collected.Count != transformed.Count)
+{
+    return Fail($"TestLoader collected {(collected is null ? "null" : collected.Count.ToString())} items, expected {transformed.Count}");
+}
+
+Console.WriteLine($"AOT smoke OK: extracted {extracted.Count}, transformed {transformed.Count}, loaded {collected.Count}");
+return 0;
+
+static async IAsyncEnumerable<int> ToAsync(IEnumerable<int> items)
+{
+    foreach (var item in items)
+    {
+        yield return item;
+    }
+
+    await Task.CompletedTask;
+}

--- a/aot-smoke/Wolfgang.Etl.TestKit.AotSmoke/Wolfgang.Etl.TestKit.AotSmoke.csproj
+++ b/aot-smoke/Wolfgang.Etl.TestKit.AotSmoke/Wolfgang.Etl.TestKit.AotSmoke.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Native-AOT smoke consumer for #132. A tiny console app that references the
+    library and exercises its public surface (TestExtractor / TestTransformer /
+    TestLoader), published with PublishAot and executed in CI (see
+    .github/workflows/aot-smoke.yaml). This gives a *runtime* AOT guarantee: it
+    fails if AOT publish or execution ever breaks — e.g. the async-enumerable
+    pipeline path stops being trimmer-safe. Not part of the solution / not packed.
+  -->
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <PublishAot>true</PublishAot>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>false</IsTestProject>
+    <!-- Invariant globalization keeps the AOT binary small and avoids ICU; the app only
+         emits ASCII diagnostics. -->
+    <InvariantGlobalization>true</InvariantGlobalization>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Etl.TestKit\Wolfgang.Etl.TestKit.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/.editorconfig
+++ b/samples/.editorconfig
@@ -1,0 +1,30 @@
+# The sample is test-style code (an xUnit project demonstrating consumer usage),
+# so it gets the same analyzer relaxations the repo applies to tests/ — the root
+# .editorconfig's [tests/**] section and tests/.editorconfig do not match this
+# folder, so the relevant rules are re-declared here.
+
+[*.cs]
+
+# Underscore test-method naming (MethodUnderTest_when_condition_expected_result).
+dotnet_diagnostic.SA1300.severity = none
+dotnet_diagnostic.IDE1006.severity = none
+dotnet_diagnostic.CA1707.severity = none
+
+# ConfigureAwait not needed in test/sample code.
+dotnet_diagnostic.CA2007.severity = none
+dotnet_diagnostic.MA0004.severity = none
+dotnet_diagnostic.S3216.severity = none
+
+# Synchronous cancellation / blocking is fine in test/sample code.
+dotnet_diagnostic.CA1849.severity = none
+dotnet_diagnostic.AsyncFixer01.severity = none
+dotnet_diagnostic.AsyncFixer02.severity = none
+dotnet_diagnostic.VSTHRD103.severity = none
+dotnet_diagnostic.VSTHRD200.severity = none
+
+# Misc test-style relaxations.
+dotnet_diagnostic.IDE0058.severity = none
+dotnet_diagnostic.MA0011.severity = none
+dotnet_diagnostic.MA0048.severity = none
+dotnet_diagnostic.S2699.severity = none
+dotnet_diagnostic.S6562.severity = none

--- a/samples/Wolfgang.Etl.TestKit.Sample/PipelineWithDoublesExample.cs
+++ b/samples/Wolfgang.Etl.TestKit.Sample/PipelineWithDoublesExample.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Wolfgang.Etl.TestKit.Sample;
+
+/// <summary>
+/// The other use case: when you are testing something else (a pipeline, an
+/// orchestrator, error handling) and just need cheap, ready-made ETL components,
+/// use the kit's <em>doubles</em> as stand-ins — feed known data with
+/// <see cref="TestExtractor{T}"/>, capture output with <see cref="TestLoader{T}"/>,
+/// and inject failures with the <c>Faulty*</c> doubles.
+/// </summary>
+public sealed class PipelineWithDoublesExample
+{
+    private static readonly DateTimeOffset BaseTime =
+        new(2024, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+    private static IEnumerable<TemperatureReading> SampleReadings(int count) =>
+        Enumerable.Range(0, count)
+            .Select(i => new TemperatureReading(BaseTime.AddHours(i), 20.0 + i));
+
+    [Fact]
+    public async Task Capture_pipeline_output_with_TestLoader()
+    {
+        var readings = SampleReadings(3).ToList();
+
+        // TestExtractor feeds known data; TestLoader captures whatever the
+        // pipeline pushed so the test can assert on it.
+        using var extractor = new TestExtractor<TemperatureReading>(readings);
+        using var loader = new TestLoader<TemperatureReading>(collectItems: true);
+
+        await loader.LoadAsync(extractor.ExtractAsync());
+
+        Assert.Equal(readings, loader.GetCollectedItems());
+    }
+
+    [Fact]
+    public async Task Verify_error_handling_with_a_Faulty_double()
+    {
+        // FaultyExtractor throws on demand at a chosen position, so a consumer
+        // can prove their pipeline surfaces (or recovers from) mid-stream errors.
+        using var extractor = new FaultyExtractor<TemperatureReading>(SampleReadings(5))
+            .ThrowAt(2, new InvalidOperationException("sensor dropped out"));
+
+        var seen = new List<TemperatureReading>();
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+        {
+            await foreach (var reading in extractor.ExtractAsync())
+            {
+                seen.Add(reading);
+            }
+        });
+
+        Assert.Equal("sensor dropped out", ex.Message);
+        Assert.Equal(2, seen.Count); // two readings surfaced before the failure
+    }
+}

--- a/samples/Wolfgang.Etl.TestKit.Sample/README.md
+++ b/samples/Wolfgang.Etl.TestKit.Sample/README.md
@@ -1,0 +1,34 @@
+# Wolfgang.Etl.TestKit — worked sample
+
+A runnable "real consumer" sample (#116) showing the two ways you use the kit.
+Because it is a live xUnit project, everything here is compile- and
+behaviour-verified in CI — documentation that cannot silently rot.
+
+## 1. Verify your own ETL component with the contract tests
+
+[`WeatherStationExtractor`](WeatherStationExtractor.cs) is a hand-written custom
+extractor — the kind you'd write over a real sensor log, API, or file. It
+implements the `ExtractorBase<T, Report>` pattern in full: `ExtractWorkerAsync`
+with `SkipItemCount` / `MaximumItemCount` windowing, `CreateProgressReport`, and
+injectable progress-timer wiring.
+
+[`WeatherStationExtractorContractTests`](WeatherStationExtractorContractTests.cs)
+verifies it by subclassing `ExtractorBaseContractTests<…>` and filling in three
+factory methods (`CreateSut`, `CreateExpectedItems`, `CreateSutWithTimer`).
+Inheriting the base runs its entire suite — enumeration, cancellation, progress,
+skip/max, idempotency — against your extractor for free.
+
+## 2. Use the doubles as stand-ins in your own tests
+
+When you're testing something else and just need cheap ETL parts,
+[`PipelineWithDoublesExample`](PipelineWithDoublesExample.cs) shows:
+
+- `TestExtractor<T>` to feed known data and `TestLoader<T>` to capture output;
+- `FaultyExtractor<T>.ThrowAt(...)` to inject a mid-stream failure and prove your
+  pipeline surfaces (or recovers from) errors.
+
+## Run it
+
+```bash
+dotnet test samples/Wolfgang.Etl.TestKit.Sample
+```

--- a/samples/Wolfgang.Etl.TestKit.Sample/TemperatureReading.cs
+++ b/samples/Wolfgang.Etl.TestKit.Sample/TemperatureReading.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Wolfgang.Etl.TestKit.Sample;
+
+/// <summary>
+/// A record produced by the <see cref="WeatherStationExtractor"/> — a small
+/// realistic domain type for the sample. A <c>record</c> gives it the value
+/// equality the contract-test base classes rely on when comparing expected vs
+/// actual items.
+/// </summary>
+public sealed record TemperatureReading(DateTimeOffset Timestamp, double Celsius);

--- a/samples/Wolfgang.Etl.TestKit.Sample/WeatherStationExtractor.cs
+++ b/samples/Wolfgang.Etl.TestKit.Sample/WeatherStationExtractor.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+
+namespace Wolfgang.Etl.TestKit.Sample;
+
+/// <summary>
+/// A worked example of a <em>custom</em> extractor a consumer of this library
+/// might write: it reads <see cref="TemperatureReading"/> records from an
+/// in-memory source (standing in for a real sensor log / API / file). It is
+/// deliberately hand-written — NOT one of the kit's own doubles — to show the
+/// exact <see cref="ExtractorBase{TSource, TProgress}"/> pattern a consumer must
+/// implement, including <see cref="ExtractorBase{TSource, TProgress}.SkipItemCount"/> /
+/// <see cref="ExtractorBase{TSource, TProgress}.MaximumItemCount"/> windowing and
+/// injectable progress-timer wiring, so that
+/// <see cref="Xunit.ExtractorBaseContractTests{TSut, TItem, TProgress}"/> passes
+/// against it (see WeatherStationExtractorContractTests).
+/// </summary>
+public sealed class WeatherStationExtractor : ExtractorBase<TemperatureReading, Report>
+{
+    private readonly IEnumerable<TemperatureReading> _readings;
+
+    // Injected timer support: a consumer only needs this if they want their
+    // extractor to be verifiable with a deterministic ManualProgressTimer.
+    private readonly IProgressTimer? _progressTimer;
+    private bool _progressTimerWired;
+    private Action? _elapsedHandler;
+
+    /// <summary>Creates an extractor over the supplied readings.</summary>
+    public WeatherStationExtractor(IEnumerable<TemperatureReading> readings)
+    {
+        _readings = readings ?? throw new ArgumentNullException(nameof(readings));
+    }
+
+    /// <summary>
+    /// Creates an extractor over the supplied readings that reports progress
+    /// through the injected <paramref name="timer"/> — the seam the contract
+    /// tests drive with a deterministic timer.
+    /// </summary>
+    public WeatherStationExtractor(IEnumerable<TemperatureReading> readings, IProgressTimer timer)
+        : this(readings)
+    {
+        _progressTimer = timer ?? throw new ArgumentNullException(nameof(timer));
+    }
+
+    /// <inheritdoc/>
+    protected override Report CreateProgressReport() => new(CurrentItemCount);
+
+    /// <inheritdoc/>
+    protected override IProgressTimer CreateProgressTimer(IProgress<Report> progress)
+    {
+        if (_progressTimer is null)
+        {
+            return base.CreateProgressTimer(progress);
+        }
+
+        // Guard against re-wiring the handler if CreateProgressTimer is called
+        // more than once for the injected timer.
+        if (!_progressTimerWired)
+        {
+            _progressTimerWired = true;
+            _elapsedHandler = () => progress.Report(CreateProgressReport());
+            _progressTimer.Elapsed += _elapsedHandler;
+        }
+
+        return _progressTimer;
+    }
+
+    /// <inheritdoc/>
+    protected override async IAsyncEnumerable<TemperatureReading> ExtractWorkerAsync
+    (
+        [EnumeratorCancellation] CancellationToken token
+    )
+    {
+        token.ThrowIfCancellationRequested();
+
+        // Honour the async-iterator contract even though the source is synchronous.
+        await Task.Yield();
+
+        foreach (var reading in _readings)
+        {
+            token.ThrowIfCancellationRequested();
+
+            // SkipItemCount: drop the leading items the caller asked to skip.
+            if (CurrentSkippedItemCount < SkipItemCount)
+            {
+                IncrementCurrentSkippedItemCount();
+                continue;
+            }
+
+            // MaximumItemCount: stop once the cap is reached.
+            if (CurrentItemCount >= MaximumItemCount)
+            {
+                yield break;
+            }
+
+            // Count exactly once per yielded item.
+            IncrementCurrentItemCount();
+            yield return reading;
+        }
+    }
+
+    /// <inheritdoc/>
+    protected override void Dispose(bool disposing)
+    {
+        // The injected timer is owned by the caller, so only unsubscribe — never
+        // dispose it here.
+        if (disposing && _progressTimer is not null && _elapsedHandler is not null)
+        {
+            _progressTimer.Elapsed -= _elapsedHandler;
+            _elapsedHandler = null;
+        }
+
+        base.Dispose(disposing);
+    }
+}

--- a/samples/Wolfgang.Etl.TestKit.Sample/WeatherStationExtractorContractTests.cs
+++ b/samples/Wolfgang.Etl.TestKit.Sample/WeatherStationExtractorContractTests.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Wolfgang.Etl.Abstractions;
+using Wolfgang.Etl.TestKit.Xunit;
+
+namespace Wolfgang.Etl.TestKit.Sample;
+
+/// <summary>
+/// The headline use case for the kit: verify a hand-written custom extractor
+/// (<see cref="WeatherStationExtractor"/>) against the full extractor contract by
+/// subclassing <see cref="ExtractorBaseContractTests{TSut, TItem, TProgress}"/>
+/// and filling in three factory methods. Inheriting the base class runs its whole
+/// suite — enumeration, cancellation, progress, skip/max windowing, idempotency —
+/// against your extractor for free.
+/// </summary>
+public sealed class WeatherStationExtractorContractTests
+    : ExtractorBaseContractTests<WeatherStationExtractor, TemperatureReading, Report>
+{
+    private static readonly DateTimeOffset BaseTime =
+        new(2024, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+    // A deterministic reading generator so CreateSut and CreateExpectedItems agree.
+    private static IReadOnlyList<TemperatureReading> CreateReadings(int count) =>
+        Enumerable.Range(0, count)
+            .Select(i => new TemperatureReading(BaseTime.AddHours(i), 20.0 + i))
+            .ToList();
+
+    /// <inheritdoc/>
+    protected override WeatherStationExtractor CreateSut(int itemCount) =>
+        new WeatherStationExtractor(CreateReadings(itemCount));
+
+    /// <inheritdoc/>
+    protected override IReadOnlyList<TemperatureReading> CreateExpectedItems() =>
+        CreateReadings(5);
+
+    /// <inheritdoc/>
+    protected override WeatherStationExtractor CreateSutWithTimer(IProgressTimer timer) =>
+        new WeatherStationExtractor(CreateReadings(5), timer);
+}

--- a/samples/Wolfgang.Etl.TestKit.Sample/Wolfgang.Etl.TestKit.Sample.csproj
+++ b/samples/Wolfgang.Etl.TestKit.Sample/Wolfgang.Etl.TestKit.Sample.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    A worked "real consumer" sample (#116): a hand-written custom extractor with
+    its contract test, plus the doubles used as pipeline stand-ins. It is a
+    runnable xUnit project so the examples are compile- and behaviour-verified in
+    CI (documentation that cannot rot), not just prose. Not packed.
+  -->
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Etl.TestKit\Wolfgang.Etl.TestKit.csproj" />
+    <ProjectReference Include="..\..\src\Wolfgang.Etl.TestKit.Xunit\Wolfgang.Etl.TestKit.Xunit.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" NoWarn="NU1701">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/scripts/normalize-trx.py
+++ b/scripts/normalize-trx.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Normalize VSTest .trx output to a sorted, platform-independent list of
+"test name<TAB>outcome" lines, for the cross-platform differential (#128).
+
+Usage: python scripts/normalize-trx.py <trx-dir> <output-file>
+
+Only the test name and outcome are emitted — durations, machine names, and
+timestamps are intentionally excluded so the list is identical across platforms
+when behaviour is identical.
+"""
+import glob
+import os
+import sys
+
+# Parse with defusedxml rather than the stdlib xml module: it is the documented
+# hardening against XXE / entity-expansion, and satisfies the static analysers
+# outright instead of relying on a suppression comment. It is a drop-in for the
+# ElementTree API used below.
+from defusedxml.ElementTree import parse as parse_xml  # nosemgrep
+
+NS = "{http://microsoft.com/schemas/VisualStudio/TeamTest/2010}"
+
+
+def main(trx_dir: str, out_file: str) -> None:
+    rows = []
+    for path in glob.glob(os.path.join(trx_dir, "**", "*.trx"), recursive=True):
+        tree = parse_xml(path)
+        for result in tree.iter(NS + "UnitTestResult"):
+            rows.append(f"{result.get('testName')}\t{result.get('outcome')}")
+
+    rows.sort()
+    with open(out_file, "w", encoding="utf-8", newline="\n") as handle:
+        handle.write("\n".join(rows))
+        handle.write("\n")
+
+    print(f"wrote {len(rows)} outcomes to {out_file}")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("usage: normalize-trx.py <trx-dir> <output-file>", file=sys.stderr)
+        sys.exit(2)
+    main(sys.argv[1], sys.argv[2])

--- a/scripts/reproducible-manifest.py
+++ b/scripts/reproducible-manifest.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Assemble reproducible-build-manifest.json (#145) from "assembly<TAB>sha256"
+lines on stdin plus build metadata.
+
+Usage: reproducible-manifest.py <version> <tfm> <sdk> <os> <output-file>
+"""
+import json
+import sys
+
+
+def main() -> None:
+    if len(sys.argv) != 6:
+        print("usage: reproducible-manifest.py <version> <tfm> <sdk> <os> <output-file>", file=sys.stderr)
+        sys.exit(2)
+
+    version, tfm, sdk, os_name, out_file = sys.argv[1:6]
+
+    assemblies = []
+    for line in sys.stdin.read().splitlines():
+        if not line.strip():
+            continue
+        name, sha = line.split("\t")
+        assemblies.append({"assembly": name, "sha256": sha})
+
+    manifest = {
+        "schema": "wolfgang.reproducible-build-manifest/v1",
+        "version": version,
+        "targetFramework": tfm,
+        "buildCommand": f"dotnet build <project> -c Release -f {tfm} -p:ContinuousIntegrationBuild=true",
+        "referenceEnvironment": {"os": os_name, "dotnetSdk": sdk},
+        "assemblies": sorted(assemblies, key=lambda a: a["assembly"]),
+    }
+
+    with open(out_file, "w", encoding="utf-8", newline="\n") as handle:
+        json.dump(manifest, handle, indent=2)
+        handle.write("\n")
+
+    print(f"Wrote {len(assemblies)} assembly hashes to {out_file}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/reproducible-manifest.sh
+++ b/scripts/reproducible-manifest.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Generate reproducible-build-manifest.json (#145): the canonical SHA-256 hashes
+# of each shipped assembly, built deterministically the same way a third party
+# would reproduce them (the command documented in docs/REPRODUCIBLE-BUILD.md).
+#
+# Usage: scripts/reproducible-manifest.sh <version> <output-file>
+#
+# The build uses -c Release -f net10.0 -p:ContinuousIntegrationBuild=true, which
+# normalises source paths (/_/) so the output is independent of the checkout
+# location — the same knobs reproducible-build.yaml (#135) verifies. The manifest
+# records the SDK version and OS it was produced on so a verifier can match the
+# reference environment.
+set -euo pipefail
+
+VERSION="${1:?usage: reproducible-manifest.sh <version> <output-file>}"
+OUT_FILE="${2:?usage: reproducible-manifest.sh <version> <output-file>}"
+
+PROJECTS=(
+  "src/Wolfgang.Etl.TestKit/Wolfgang.Etl.TestKit.csproj"
+  "src/Wolfgang.Etl.TestKit.Xunit/Wolfgang.Etl.TestKit.Xunit.csproj"
+)
+
+TFM="net10.0"
+SDK_VERSION="$(dotnet --version)"
+OS_NAME="$(uname -s)"
+
+# Collect "assembly<TAB>sha256" lines for each shipped assembly.
+hashes=""
+for proj in "${PROJECTS[@]}"; do
+  dotnet build "$proj" -c Release -f "$TFM" -p:ContinuousIntegrationBuild=true >/dev/null
+  dir="$(dirname "$proj")/bin/Release/$TFM"
+  asm="$dir/$(basename "$(dirname "$proj")").dll"
+  sha="$(sha256sum "$asm" | cut -d' ' -f1)"
+  hashes+="$(basename "$asm")	$sha"$'\n'
+done
+
+# Assemble the JSON (scripts/reproducible-manifest.py avoids a jq dependency and
+# keeps the piped hashes on stdin — a heredoc-inlined script would collide with
+# the interpreter's own stdin).
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+printf '%s' "$hashes" \
+  | python3 "$script_dir/reproducible-manifest.py" "$VERSION" "$TFM" "$SDK_VERSION" "$OS_NAME" "$OUT_FILE"

--- a/scripts/stryker-score.py
+++ b/scripts/stryker-score.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Compute the Stryker mutation score from mutation-report.json files and emit a
+github-action-benchmark `customBiggerIsBetter` payload for the gh-pages trend (#124).
+
+Aggregates every mutation-report.json under the given root (a repo may have more
+than one test project's report), applying Stryker's own score formula:
+
+    score = (Killed + Timeout) / (Killed + Timeout + Survived + NoCoverage) * 100
+
+Ignored / CompileError mutants are excluded from the denominator, exactly as
+Stryker does when it prints "The final mutation score".
+
+Usage: python scripts/stryker-score.py <search-root> <output-json>
+"""
+import glob
+import json
+import os
+import sys
+from collections import Counter
+
+DETECTED = ("Killed", "Timeout")
+UNDETECTED = ("Survived", "NoCoverage")
+
+
+def compute(root: str) -> float:
+    counts: Counter = Counter()
+    reports = glob.glob(os.path.join(root, "**", "mutation-report.json"), recursive=True)
+    if not reports:
+        raise SystemExit(f"No mutation-report.json found under {root!r}")
+    for path in reports:
+        with open(path, encoding="utf-8") as handle:
+            data = json.load(handle)
+        for file_data in data.get("files", {}).values():
+            for mutant in file_data.get("mutants", []):
+                counts[mutant["status"]] += 1
+
+    detected = sum(counts[s] for s in DETECTED)
+    denom = detected + sum(counts[s] for s in UNDETECTED)
+    score = round(100 * detected / denom, 2) if denom else 0.0
+    print(f"Mutation status counts: {dict(counts)}")
+    print(f"Mutation score: {score}% (from {len(reports)} report(s))")
+    return score
+
+
+def main(root: str, out_file: str) -> None:
+    score = compute(root)
+    payload = [{"name": "Mutation score", "unit": "%", "value": score}]
+    with open(out_file, "w", encoding="utf-8", newline="\n") as handle:
+        json.dump(payload, handle, indent=2)
+        handle.write("\n")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("usage: stryker-score.py <search-root> <output-json>", file=sys.stderr)
+        sys.exit(2)
+    main(sys.argv[1], sys.argv[2])

--- a/tests/Wolfgang.Etl.TestKit.Tests.Concurrency/ConcurrencyTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Concurrency/ConcurrencyTests.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Coyote;
+using Microsoft.Coyote.SystematicTesting;
+using Wolfgang.Etl.TestKit;
+using Xunit;
+
+namespace Wolfgang.Etl.TestKit.Tests.Concurrency;
+
+/// <summary>
+/// Systematic concurrency tests (#126) using Microsoft Coyote. Each test hands a
+/// racy scenario to Coyote's <see cref="TestingEngine"/>, which replays it under
+/// many controlled thread interleavings and fails if any schedule violates the
+/// invariant — surfacing races that a single-run test would miss because it only
+/// ever observes one schedule.
+/// </summary>
+/// <remarks>
+/// The scenarios use only the public API and exercise the concurrency the doubles
+/// must tolerate (the exact shapes called out in the issue): a cancellation token
+/// cancelled while an enumeration is in flight, and a <c>Dispose</c> racing an
+/// in-flight enumeration. For Coyote to control the Task schedule, this assembly
+/// is rewritten by <c>coyote rewrite</c> in the concurrency workflow; run
+/// un-rewritten it still executes but explores far fewer schedules.
+/// </remarks>
+public sealed class ConcurrencyTests
+{
+    private const int Iterations = 500;
+
+    [Fact]
+    public void Cancellation_during_enumeration_is_race_safe()
+    {
+        RunSystematic(CancellationScenario);
+    }
+
+    [Fact]
+    public void Dispose_racing_enumeration_is_race_safe()
+    {
+        RunSystematic(DisposeDuringEnumerationScenario);
+    }
+
+    // A cancellation arriving concurrently with enumeration must surface as a
+    // clean OperationCanceledException (or simply complete) — never a torn state,
+    // an unexpected exception type, or a hang.
+    private static async Task CancellationScenario()
+    {
+        using var cts = new CancellationTokenSource();
+        var extractor = new TestExtractor<int>(Enumerable.Range(0, 8));
+
+        var enumerate = Task.Run(async () =>
+        {
+            try
+            {
+                await foreach (var _ in extractor.ExtractAsync(cts.Token))
+                {
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // Expected — cancellation is the point.
+            }
+        });
+
+        var cancel = Task.Run(() => cts.Cancel());
+
+        await Task.WhenAll(enumerate, cancel);
+        extractor.Dispose();
+    }
+
+    // Disposing the extractor while an enumeration is in flight must not throw an
+    // unexpected exception or deadlock, regardless of interleaving. If dispose
+    // wins the race an ObjectDisposedException is a legitimate outcome.
+    private static async Task DisposeDuringEnumerationScenario()
+    {
+        var extractor = new TestExtractor<int>(Enumerable.Range(0, 8));
+
+        var enumerate = Task.Run(async () =>
+        {
+            try
+            {
+                await foreach (var _ in extractor.ExtractAsync())
+                {
+                }
+            }
+            catch (ObjectDisposedException)
+            {
+                // Legitimate if dispose won the race.
+            }
+        });
+
+        var dispose = Task.Run(() => extractor.Dispose());
+
+        await Task.WhenAll(enumerate, dispose);
+    }
+
+    private static void RunSystematic(Func<Task> scenario)
+    {
+        // These tests require the assembly to be rewritten by `coyote rewrite`
+        // (the concurrency workflow does this before running them). Run
+        // un-rewritten — e.g. in the normal PR test sweep, which discovers every
+        // project under tests/ — Coyote cannot control the Task schedule and
+        // reports false deadlocks. The workflow sets COYOTE_REWRITTEN=1 after
+        // rewriting; without it, skip so the normal sweep stays green.
+        if (!string.Equals(Environment.GetEnvironmentVariable("COYOTE_REWRITTEN"), "1", StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        var configuration = Configuration.Create()
+            .WithTestingIterations(Iterations)
+            .WithMaxSchedulingSteps(500);
+
+        using var engine = TestingEngine.Create(configuration, scenario);
+        engine.Run();
+
+        var report = engine.TestReport;
+        Assert.True
+        (
+            report.NumOfFoundBugs == 0,
+            report.NumOfFoundBugs == 0
+                ? string.Empty
+                : "Coyote found a concurrency bug: " + report.BugReports.FirstOrDefault()
+        );
+    }
+}

--- a/tests/Wolfgang.Etl.TestKit.Tests.Concurrency/Wolfgang.Etl.TestKit.Tests.Concurrency.csproj
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Concurrency/Wolfgang.Etl.TestKit.Tests.Concurrency.csproj
@@ -1,0 +1,35 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Systematic concurrency testing (#126) with Microsoft Coyote. Coyote explores
+    thousands of thread interleavings of the racy public scenarios (cancellation
+    arriving mid-enumeration, the progress timer firing while the worker
+    unsubscribes on completion/dispose) that a normal single-run test observes
+    only one schedule of. A single modern TFM — this explores schedules, not
+    per-TFM runtime behaviour. The assembly is rewritten by `coyote rewrite`
+    (see rewrite.coyote.json) so Coyote controls Task scheduling.
+  -->
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Etl.TestKit\Wolfgang.Etl.TestKit.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Coyote.Test" Version="1.7.11" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" NoWarn="NU1701">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <!-- Analyzer PackageReferences are centralized in Directory.Build.props -->
+
+</Project>

--- a/tests/Wolfgang.Etl.TestKit.Tests.Concurrency/rewrite.coyote.json
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Concurrency/rewrite.coyote.json
@@ -1,0 +1,7 @@
+{
+  "AssembliesPath": "bin/Release/net10.0",
+  "Assemblies": [
+    "Wolfgang.Etl.TestKit.Tests.Concurrency.dll",
+    "Wolfgang.Etl.TestKit.dll"
+  ]
+}

--- a/tests/Wolfgang.Etl.TestKit.Tests.DocExamples/DocExampleCompilationTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.DocExamples/DocExampleCompilationTests.cs
@@ -1,0 +1,335 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace Wolfgang.Etl.TestKit.Tests.DocExamples;
+
+/// <summary>
+/// Compiles every <c>&lt;example&gt;&lt;code&gt;</c> block found in the two shipped
+/// projects' XML documentation against the current public API, so a snippet that
+/// outlives the API it demonstrates (a renamed or removed member) fails the build.
+/// </summary>
+/// <remarks>
+/// TestKit's examples come in three shapes: statement snippets (constructing a
+/// <c>TestExtractor</c>), full type declarations (a consumer's contract-test
+/// subclass), and bare member snippets (a single <c>override</c>). A single
+/// wrapping cannot host all three, so each snippet is compiled in three contexts
+/// — top level, as a class member, and as an async-method body — and is accepted
+/// if <em>any</em> context compiles cleanly. Errors that merely reflect an
+/// undefined illustrative placeholder (<c>MyExtractor</c>, <c>db</c>, <c>source</c>)
+/// or the structural artifacts of extracting a member out of its base type are
+/// tolerated. What is NOT tolerated is an error against a symbol the library
+/// actually owns — the documentation rot this test exists to catch.
+/// </remarks>
+public sealed class DocExampleCompilationTests
+{
+    // Errors that indicate the snippet references a symbol which does not exist
+    // in the illustrative context (an undefined placeholder), as opposed to a
+    // broken reference to the library's own API.
+    private static readonly HashSet<string> PlaceholderErrorCodes = new(StringComparer.Ordinal)
+    {
+        "CS0246", // type or namespace could not be found (e.g. `MyExtractor`, `MyRecord`)
+        "CS0103", // name does not exist in the current context (e.g. `db`, `sourceData`)
+        "CS0234", // type/namespace does not exist in a placeholder namespace
+        "CS0305", // wrong number of type arguments on an undefined generic placeholder
+    };
+
+    // Errors that cascade from an undefined placeholder: once a lambda parameter
+    // or argument has an error type (because its type is a placeholder), overload
+    // resolution and type inference can no longer succeed. Tolerated ONLY when the
+    // snippet also produced a hard placeholder error above.
+    private static readonly HashSet<string> PlaceholderCascadeCodes = new(StringComparer.Ordinal)
+    {
+        "CS0121", // ambiguous call (overload can't be picked without the lambda's real return type)
+        "CS0411", // type arguments cannot be inferred
+        "CS1503", // argument type conversion
+        "CS1660", // cannot convert lambda to the expected type
+        "CS1661", // lambda parameter count/signature mismatch
+        "CS1662", // cannot convert lambda (return type)
+        "CS1929", // receiver has no matching (extension) method
+        "CS0119", // placeholder name used as a value where a type is expected
+    };
+
+    // Structural artifacts of extracting a snippet out of its surrounding context,
+    // which are not documentation rot: an `override` member lifted away from its
+    // base type has nothing to override (CS0115), and a snippet that shows two
+    // alternatives back-to-back reuses a variable name (CS0128). These are
+    // tolerated in whichever wrapping is otherwise cleanest.
+    private static readonly HashSet<string> StructuralArtifactCodes = new(StringComparer.Ordinal)
+    {
+        "CS0115", // no suitable method found to override
+        "CS0128", // a local variable is already defined (two-alternatives snippet)
+        "CS0106", // modifier not valid for this item (e.g. `protected` at an unexpected level)
+    };
+
+    private static readonly string[] HarnessUsings =
+    {
+        "System",
+        "System.Collections.Generic",
+        "System.Linq",
+        "System.Threading",
+        "System.Threading.Tasks",
+        "Wolfgang.Etl.Abstractions",
+        "Wolfgang.Etl.TestKit",
+        "Wolfgang.Etl.TestKit.Xunit",
+        "Xunit",
+    };
+
+    [Fact]
+    public async Task Xml_doc_examples_compile_against_the_current_public_api()
+    {
+        var sourceRoot = FindSourceRoot();
+        var failures = new List<string>();
+        var examplesChecked = 0;
+
+        foreach (var file in Directory.EnumerateFiles(sourceRoot, "*.cs", SearchOption.AllDirectories))
+        {
+            if (IsGeneratedOrBuildOutput(file))
+            {
+                continue;
+            }
+
+            var source = await File.ReadAllTextAsync(file).ConfigureAwait(false);
+
+            foreach (var (line, code) in ExtractExampleCode(source))
+            {
+                if (ContainsElision(code))
+                {
+                    continue;
+                }
+
+                examplesChecked++;
+
+                var rot = BestEffortRot(code);
+                if (rot.Count > 0)
+                {
+                    failures.Add(FormatFailure(file, line, code, rot));
+                }
+            }
+        }
+
+        Assert.True
+        (
+            examplesChecked > 0,
+            $"No <example><code> blocks were found under '{sourceRoot}'. The extractor is probably broken."
+        );
+
+        Assert.True
+        (
+            failures.Count == 0,
+            $"{failures.Count} XML-doc example(s) no longer compile against the current public API:"
+            + Environment.NewLine + Environment.NewLine
+            + string.Join(Environment.NewLine + Environment.NewLine, failures)
+        );
+    }
+
+    // Compile the snippet in three contexts and return the smallest set of
+    // real-rot diagnostics across them — a snippet is only rot if it fails to
+    // compile cleanly in EVERY context it could plausibly belong to.
+    private static IReadOnlyList<Diagnostic> BestEffortRot(string snippet)
+    {
+        var usings = string.Concat(HarnessUsings.Select(u => $"using {u};" + Environment.NewLine));
+
+        var candidates = new[]
+        {
+            // Top level: hosts type declarations and (as top-level statements) plain
+            // statement snippets, including `await` / `await foreach`.
+            usings + snippet + Environment.NewLine,
+
+            // Class member: hosts a bare member snippet (e.g. a single `override`).
+            usings + "internal class DocExampleHarness" + Environment.NewLine
+                   + "{" + Environment.NewLine + snippet + Environment.NewLine + "}" + Environment.NewLine,
+
+            // Async method body: hosts statement snippets that need a method scope.
+            usings + "internal class DocExampleHarness" + Environment.NewLine + "{" + Environment.NewLine
+                   + "    private async global::System.Threading.Tasks.Task RunAsync()" + Environment.NewLine
+                   + "    {" + Environment.NewLine + snippet + Environment.NewLine + "    }" + Environment.NewLine
+                   + "}" + Environment.NewLine,
+        };
+
+        IReadOnlyList<Diagnostic>? best = null;
+        foreach (var program in candidates)
+        {
+            var rot = RotDiagnostics(program);
+            if (rot.Count == 0)
+            {
+                return rot;
+            }
+
+            if (best is null || rot.Count < best.Count)
+            {
+                best = rot;
+            }
+        }
+
+        return best ?? Array.Empty<Diagnostic>();
+    }
+
+    private static IReadOnlyList<Diagnostic> RotDiagnostics(string program)
+    {
+        var tree = CSharpSyntaxTree.ParseText
+        (
+            program,
+            new CSharpParseOptions(LanguageVersion.Latest, DocumentationMode.None)
+        );
+
+        var compilation = CSharpCompilation.Create
+        (
+            "DocExamples",
+            new[] { tree },
+            ReferenceAssemblies(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+        );
+
+        var errors = compilation.GetDiagnostics()
+            .Where(d => d.Severity == DiagnosticSeverity.Error)
+            .ToList();
+
+        var hasPlaceholder = errors.Any(d => PlaceholderErrorCodes.Contains(d.Id));
+
+        return errors
+            .Where(d => !PlaceholderErrorCodes.Contains(d.Id)
+                     && !StructuralArtifactCodes.Contains(d.Id)
+                     && !(hasPlaceholder && PlaceholderCascadeCodes.Contains(d.Id)))
+            .ToList();
+    }
+
+    private static IReadOnlyList<MetadataReference> ReferenceAssemblies()
+    {
+        // The runtime's trusted-platform-assemblies list includes the framework
+        // plus every assembly this test resolves — which, via the two project
+        // references, includes both TestKit assemblies and their dependencies.
+        var platformAssemblies =
+            (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? string.Empty)
+            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries);
+
+        return platformAssemblies
+            .Where(p => p.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+            .Select(p => (MetadataReference)MetadataReference.CreateFromFile(p))
+            .ToList();
+    }
+
+    private static IEnumerable<(int Line, string Code)> ExtractExampleCode(string source)
+    {
+        var tree = CSharpSyntaxTree.ParseText
+        (
+            source,
+            new CSharpParseOptions(LanguageVersion.Latest, DocumentationMode.Parse)
+        );
+
+        var docComments = tree.GetRoot()
+            .DescendantTrivia(descendIntoTrivia: true)
+            .Where(t => t.IsKind(SyntaxKind.SingleLineDocumentationCommentTrivia))
+            .Select(t => t.GetStructure())
+            .OfType<DocumentationCommentTriviaSyntax>();
+
+        foreach (var doc in docComments)
+        {
+            var codeElements = doc.DescendantNodes()
+                .OfType<XmlElementSyntax>()
+                .Where(e => string.Equals(e.StartTag.Name.LocalName.Text, "example", StringComparison.Ordinal))
+                .SelectMany(e => e.DescendantNodes().OfType<XmlElementSyntax>())
+                .Where(e => string.Equals(e.StartTag.Name.LocalName.Text, "code", StringComparison.Ordinal));
+
+            foreach (var code in codeElements)
+            {
+                var cleaned = CleanDocText(code.Content.ToFullString());
+                if (!string.IsNullOrWhiteSpace(cleaned))
+                {
+                    var line = code.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
+                    yield return (line, cleaned);
+                }
+            }
+        }
+    }
+
+    private static string CleanDocText(string raw)
+    {
+        var builder = new StringBuilder();
+
+        foreach (var rawLine in raw.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n'))
+        {
+            var line = rawLine.TrimStart();
+
+            if (line.StartsWith("///", StringComparison.Ordinal))
+            {
+                line = line.Substring(3);
+            }
+
+            // Drop exactly one leading space (the `/// ` separator) but keep the
+            // snippet's own indentation intact.
+            if (line.StartsWith(" ", StringComparison.Ordinal))
+            {
+                line = line.Substring(1);
+            }
+
+            builder.Append(line).Append('\n');
+        }
+
+        return WebUtility.HtmlDecode(builder.ToString()).Trim('\n');
+    }
+
+    // Doc examples elide bodies and continuations with `...`, which is not valid
+    // C#. Those snippets can't be compiled meaningfully, so they are skipped.
+    private static bool ContainsElision(string code) =>
+        code.Contains("...", StringComparison.Ordinal);
+
+    private static bool IsGeneratedOrBuildOutput(string path)
+    {
+        var normalized = path.Replace('\\', '/');
+        return normalized.Contains("/bin/", StringComparison.OrdinalIgnoreCase)
+            || normalized.Contains("/obj/", StringComparison.OrdinalIgnoreCase)
+            || path.EndsWith(".g.cs", StringComparison.OrdinalIgnoreCase)
+            || path.EndsWith(".Designer.cs", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string FindSourceRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+
+        while (directory is not null)
+        {
+            var candidate = Path.Combine(directory.FullName, "src");
+            if (Directory.Exists(Path.Combine(candidate, "Wolfgang.Etl.TestKit")))
+            {
+                return candidate;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new DirectoryNotFoundException
+        (
+            "Could not locate the 'src' root by walking up from " + AppContext.BaseDirectory
+        );
+    }
+
+    private static string FormatFailure(string file, int line, string code, IEnumerable<Diagnostic> diagnostics)
+    {
+        var indentedCode = string.Join
+        (
+            Environment.NewLine,
+            code.Replace("\r\n", "\n", StringComparison.Ordinal)
+                .Split('\n')
+                .Select(l => "      " + l)
+        );
+
+        var diagnosticText = string.Join
+        (
+            Environment.NewLine,
+            diagnostics.Select(d => "    -> " + d.Id + ": " + d.GetMessage())
+        );
+
+        return Path.GetFileName(file) + " (example at line " + line + "):" + Environment.NewLine
+            + indentedCode + Environment.NewLine
+            + diagnosticText;
+    }
+}

--- a/tests/Wolfgang.Etl.TestKit.Tests.DocExamples/Wolfgang.Etl.TestKit.Tests.DocExamples.csproj
+++ b/tests/Wolfgang.Etl.TestKit.Tests.DocExamples/Wolfgang.Etl.TestKit.Tests.DocExamples.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Meta-test: compiles every XML-doc <example><code> block across both shipped
+    projects against the current public API to catch documentation rot. Single
+    modern TFM — it is not part of the shipped multi-TFM matrix; it only needs to
+    run once per CI. References both src projects so the examples (double usage
+    AND contract-base subclassing) resolve against real symbols.
+  -->
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Etl.TestKit\Wolfgang.Etl.TestKit.csproj" />
+    <ProjectReference Include="..\..\src\Wolfgang.Etl.TestKit.Xunit\Wolfgang.Etl.TestKit.Xunit.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" NoWarn="NU1701">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/tests/Wolfgang.Etl.TestKit.Tests.Fuzz/TestKitFuzzTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Fuzz/TestKitFuzzTests.cs
@@ -1,0 +1,124 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using CsCheck;
+using Wolfgang.Etl.TestKit;
+using Xunit;
+
+namespace Wolfgang.Etl.TestKit.Tests.Fuzz;
+
+/// <summary>
+/// Property-based fuzz tests (#115) over the doubles' public surface using
+/// CsCheck. The invariants exercised:
+/// <list type="bullet">
+///   <item><description>Identity — the extractor / transformer / loader move an
+///   arbitrary item sequence through unchanged (round-trip).</description></item>
+///   <item><description>Windowing — <c>SkipItemCount</c> / <c>MaximumItemCount</c>
+///   yield exactly <c>Skip(s).Take(m)</c> for arbitrary <c>s</c>/<c>m</c>,
+///   including the boundaries (<c>s</c> past the end, <c>s + m</c> past the end)
+///   where off-by-one / negative-width bugs hide.</description></item>
+/// </list>
+/// The case count is <c>FUZZ_ITER</c> (default 1000 per PR run); the scheduled
+/// fuzz.yaml sets it far higher. On failure CsCheck shrinks to a minimal input
+/// and prints a replayable seed.
+/// </summary>
+public class TestKitFuzzTests
+{
+    private static long Iterations =>
+        long.TryParse(System.Environment.GetEnvironmentVariable("FUZZ_ITER"), out var n) && n > 0
+            ? n
+            : 1000;
+
+    private static readonly Gen<List<int>> Items = Gen.Int.List[0, 40];
+
+    // Arbitrary items plus an arbitrary skip/max, deliberately allowed to exceed
+    // the item count so the clamping boundaries are exercised. Max is >= 1 (0 is a
+    // distinct "unlimited vs none" semantic tested separately in the unit suite).
+    private static readonly Gen<(List<int> Items, int Skip, int Max)> Windowed =
+        Gen.Select(Items, Gen.Int[0, 45], Gen.Int[1, 45], (items, skip, max) => (items, skip, max));
+
+    [Fact]
+    public void Extractor_yields_input_unchanged()
+    {
+        Items.Sample(
+            items =>
+            {
+                using var extractor = new TestExtractor<int>(items);
+                Assert.Equal(items, Drain(extractor.ExtractAsync(CancellationToken.None)));
+            },
+            iter: Iterations);
+    }
+
+    [Fact]
+    public void Transformer_yields_input_unchanged()
+    {
+        Items.Sample(
+            items =>
+            {
+                using var transformer = new TestTransformer<int>();
+                Assert.Equal(items, Drain(transformer.TransformAsync(ToAsync(items), CancellationToken.None)));
+            },
+            iter: Iterations);
+    }
+
+    [Fact]
+    public void Loader_collects_input_unchanged()
+    {
+        Items.Sample(
+            items =>
+            {
+                using var loader = new TestLoader<int>(collectItems: true);
+                loader.LoadAsync(ToAsync(items), CancellationToken.None).GetAwaiter().GetResult();
+                Assert.Equal(items, loader.GetCollectedItems());
+            },
+            iter: Iterations);
+    }
+
+    [Fact]
+    public void Extractor_windows_by_skip_then_max()
+    {
+        Windowed.Sample(
+            t =>
+            {
+                using var extractor = new TestExtractor<int>(t.Items)
+                {
+                    SkipItemCount = t.Skip,
+                    MaximumItemCount = t.Max,
+                };
+
+                var expected = t.Items.Skip(t.Skip).Take(t.Max).ToList();
+                Assert.Equal(expected, Drain(extractor.ExtractAsync(CancellationToken.None)));
+            },
+            iter: Iterations);
+    }
+
+    // CsCheck.Sample is synchronous, so the async pipeline is drained by blocking.
+    private static List<T> Drain<T>(IAsyncEnumerable<T> source)
+    {
+        var results = new List<T>();
+        var enumerator = source.GetAsyncEnumerator(CancellationToken.None);
+        try
+        {
+            while (enumerator.MoveNextAsync().AsTask().GetAwaiter().GetResult())
+            {
+                results.Add(enumerator.Current);
+            }
+        }
+        finally
+        {
+            enumerator.DisposeAsync().AsTask().GetAwaiter().GetResult();
+        }
+
+        return results;
+    }
+
+    private static async IAsyncEnumerable<int> ToAsync(IEnumerable<int> items)
+    {
+        foreach (var item in items)
+        {
+            yield return item;
+        }
+
+        await System.Threading.Tasks.Task.CompletedTask;
+    }
+}

--- a/tests/Wolfgang.Etl.TestKit.Tests.Fuzz/Wolfgang.Etl.TestKit.Tests.Fuzz.csproj
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Fuzz/Wolfgang.Etl.TestKit.Tests.Fuzz.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <!-- Fuzz explores input space, not per-TFM runtime behaviour, so a single
+         modern TFM keeps the suite fast. CsCheck itself targets netstandard2.0. -->
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <Version>0.1.0</Version>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Etl.TestKit\Wolfgang.Etl.TestKit.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CsCheck" Version="4.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" NoWarn="NU1701">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <!-- Analyzer PackageReferences are centralized in Directory.Build.props -->
+
+</Project>

--- a/tests/Wolfgang.Etl.TestKit.Tests.Unit/stryker-config.json
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Unit/stryker-config.json
@@ -1,0 +1,13 @@
+{
+  "stryker-config": {
+    "project": "Wolfgang.Etl.TestKit.csproj",
+    "target-framework": "net10.0",
+    "reporters": ["progress", "json", "html"],
+    "thresholds": {
+      "high": 90,
+      "low": 70,
+      "break": 70
+    },
+    "mutation-level": "Standard"
+  }
+}


### PR DESCRIPTION
## Purpose

Land the 0.10.1 thorough-review cycle's **CI-infrastructure** files on `main` ahead of the release PR (#246), so #246's `Detect .NET Projects` guard clears and Stage 1/2/3 run before merge.

This is the **admin-bypass** half of a protected-file split (same pattern as ETL-Abstractions #306). The guard will FAIL on this PR by design — it modifies protected files. Please merge with admin bypass.

## Contents (56 files)

**Protected** (the delta that trips #246's guard):
- 21 `.github/workflows/*` (calibrated on vNext)
- `.zizmor.yml`, root `Directory.Build.props`
- `aot-smoke/` + `.github/sourcelink/` `Directory.Build.props`/`.targets`
- `aot-smoke/.editorconfig`, `samples/.editorconfig`

**Supporting non-protected** (so `main` stays buildable/consistent):
- `scripts/` (normalize-trx, reproducible-manifest .sh/.py, stryker-score)
- `aot-smoke/` consumer project, `.github/sourcelink/` consumer + verify + README, `.github/license-audit/*.json`
- `samples/Wolfgang.Etl.TestKit.Sample/` project
- new `tests/…Tests.{Concurrency,Fuzz,DocExamples}/` projects + `Tests.Unit/stryker-config.json`
- `ETL-Test-Kit.slnx` (keeps the solution consistent with the added projects)

## Not here (stays in #246)
`src/**` (version bump + Abstractions ref), `CHANGELOG.md`, `README.md`, `SECURITY.md`, `docs/**`, `docfx_project/docfx.json`, and the Unit-test `.cs` additions — none protected.

## After merge
Merge `main` → `vNext` so #246's protected diff drops; its guard then passes and Stage 1/2/3 run before the release merge.