### PR TITLE
chore: promote stranded 0.10.x public API to Shipped

### DIFF
--- a/src/Wolfgang.Etl.TestKit.Xunit/PublicAPI.Shipped.txt
+++ b/src/Wolfgang.Etl.TestKit.Xunit/PublicAPI.Shipped.txt
@@ -292,3 +292,12 @@ static Wolfgang.Etl.TestKit.Xunit.ProgressAssert.HasReports<T>(Wolfgang.Etl.Test
 static Wolfgang.Etl.TestKit.Xunit.ProgressAssert.IsMonotonicallyIncreasing<T, TKey>(Wolfgang.Etl.TestKit.Xunit.ProgressCapture<T>! capture, System.Func<T, TKey>! selector) -> void
 virtual Wolfgang.Etl.TestKit.Xunit.IdempotentLoaderContractTests<TSut, TItem>.GetCurrentItemCount(TSut sut) -> int
 virtual Wolfgang.Etl.TestKit.Xunit.IdempotentTransformerContractTests<TSut, TItem>.GetCurrentItemCount(TSut sut) -> int
+Wolfgang.Etl.TestKit.Xunit.SupportsDryRunContractTests<TSut>
+Wolfgang.Etl.TestKit.Xunit.SupportsDryRunContractTests<TSut>.SupportsDryRunContractTests() -> void
+Wolfgang.Etl.TestKit.Xunit.SupportsDryRunContractTests<TSut>.IsDryRun_can_be_set_back_to_false() -> void
+Wolfgang.Etl.TestKit.Xunit.SupportsDryRunContractTests<TSut>.IsDryRun_can_be_set_to_true() -> void
+Wolfgang.Etl.TestKit.Xunit.SupportsDryRunContractTests<TSut>.IsDryRun_defaults_to_false() -> void
+Wolfgang.Etl.TestKit.Xunit.SupportsDryRunContractTests<TSut>.When_IsDryRun_is_false_side_effect_occurs_Async() -> System.Threading.Tasks.Task!
+Wolfgang.Etl.TestKit.Xunit.SupportsDryRunContractTests<TSut>.When_IsDryRun_is_true_side_effect_is_skipped_Async() -> System.Threading.Tasks.Task!
+abstract Wolfgang.Etl.TestKit.Xunit.SupportsDryRunContractTests<TSut>.CreateSut() -> TSut
+abstract Wolfgang.Etl.TestKit.Xunit.SupportsDryRunContractTests<TSut>.RunAndReportSideEffectAsync(bool isDryRun) -> System.Threading.Tasks.Task<bool>!

--- a/src/Wolfgang.Etl.TestKit.Xunit/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.TestKit.Xunit/PublicAPI.Unshipped.txt
@@ -1,13 +1,4 @@
 #nullable enable
-Wolfgang.Etl.TestKit.Xunit.SupportsDryRunContractTests<TSut>
-Wolfgang.Etl.TestKit.Xunit.SupportsDryRunContractTests<TSut>.SupportsDryRunContractTests() -> void
-Wolfgang.Etl.TestKit.Xunit.SupportsDryRunContractTests<TSut>.IsDryRun_can_be_set_back_to_false() -> void
-Wolfgang.Etl.TestKit.Xunit.SupportsDryRunContractTests<TSut>.IsDryRun_can_be_set_to_true() -> void
-Wolfgang.Etl.TestKit.Xunit.SupportsDryRunContractTests<TSut>.IsDryRun_defaults_to_false() -> void
-Wolfgang.Etl.TestKit.Xunit.SupportsDryRunContractTests<TSut>.When_IsDryRun_is_false_side_effect_occurs_Async() -> System.Threading.Tasks.Task!
-Wolfgang.Etl.TestKit.Xunit.SupportsDryRunContractTests<TSut>.When_IsDryRun_is_true_side_effect_is_skipped_Async() -> System.Threading.Tasks.Task!
-abstract Wolfgang.Etl.TestKit.Xunit.SupportsDryRunContractTests<TSut>.CreateSut() -> TSut
-abstract Wolfgang.Etl.TestKit.Xunit.SupportsDryRunContractTests<TSut>.RunAndReportSideEffectAsync(bool isDryRun) -> System.Threading.Tasks.Task<bool>!
 Wolfgang.Etl.TestKit.Xunit.ErrorHandlingContractTests<TSut>
 Wolfgang.Etl.TestKit.Xunit.ErrorHandlingContractTests<TSut>.ErrorHandlingContractTests() -> void
 Wolfgang.Etl.TestKit.Xunit.ErrorHandlingContractTests<TSut>.Skip_policy_completes_the_run_Async() -> System.Threading.Tasks.Task!

--- a/src/Wolfgang.Etl.TestKit/PublicAPI.Shipped.txt
+++ b/src/Wolfgang.Etl.TestKit/PublicAPI.Shipped.txt
@@ -62,3 +62,5 @@ override Wolfgang.Etl.TestKit.TestTransformer<T>.CreateProgressReport() -> Wolfg
 override Wolfgang.Etl.TestKit.TestTransformer<T>.CreateProgressTimer(System.IProgress<Wolfgang.Etl.Abstractions.Report> progress) -> Wolfgang.Etl.Abstractions.IProgressTimer
 override Wolfgang.Etl.TestKit.TestTransformer<T>.Dispose(bool disposing) -> void
 override Wolfgang.Etl.TestKit.TestTransformer<T>.TransformWorkerAsync(System.Collections.Generic.IAsyncEnumerable<T> items, System.Threading.CancellationToken token) -> System.Collections.Generic.IAsyncEnumerable<T>
+Wolfgang.Etl.TestKit.TestLoader<T>.IsDryRun.get -> bool
+Wolfgang.Etl.TestKit.TestLoader<T>.IsDryRun.set -> void

--- a/src/Wolfgang.Etl.TestKit/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.TestKit/PublicAPI.Unshipped.txt
@@ -1,6 +1,4 @@
 #nullable enable
-Wolfgang.Etl.TestKit.TestLoader<T>.IsDryRun.get -> bool
-Wolfgang.Etl.TestKit.TestLoader<T>.IsDryRun.set -> void
 Wolfgang.Etl.TestKit.FaultyExtractor<T>.SkipErrors() -> Wolfgang.Etl.TestKit.FaultyExtractor<T>!
 Wolfgang.Etl.TestKit.FaultyExtractor<T>.HandleErrorsWith(System.Func<Wolfgang.Etl.Abstractions.ItemErrorContext!, Wolfgang.Etl.Abstractions.ItemErrorAction>! policy) -> Wolfgang.Etl.TestKit.FaultyExtractor<T>!
 Wolfgang.Etl.TestKit.FaultyExtractor<T>.CapturedErrors.get -> System.Collections.Generic.IReadOnlyList<Wolfgang.Etl.Abstractions.ItemErrorContext!>!


### PR DESCRIPTION
Stacked PR **3/4** for 0.11.0 (base: `docs/011-new-surface`).

The 0.10.x release never promoted these already-shipped entries out of `PublicAPI.Unshipped.txt`: `TestLoader<T>.IsDryRun` (core) and `SupportsDryRunContractTests<TSut>` (xunit). Moved to `PublicAPI.Shipped.txt` so Unshipped now holds only the unreleased 0.11 surface. No code change.