### PR TITLE
feat: Report.TotalItemCount for collection-backed extractor doubles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,9 @@ public API only — no breaking change.
 
 - Built against `Wolfgang.Etl.Abstractions` 0.17.0 → **0.18.0**.
 - The doubles' `CreateProgressReport()` now surfaces the base's `StartedAt`/`Elapsed` timing
-  (Abstractions 0.14.0) in the `Report`, so `ItemsPerSecond` is computed for reported progress.
+  (Abstractions 0.14.0) in the `Report`, so `ItemsPerSecond` is computed for reported progress;
+  the extractor doubles also set `TotalItemCount` from a materialized collection source so
+  `PercentComplete`/`EstimatedRemaining` compute.
 
 ## [0.10.1] - 2026-07-24
 

--- a/src/Wolfgang.Etl.TestKit/FaultyExtractor.cs
+++ b/src/Wolfgang.Etl.TestKit/FaultyExtractor.cs
@@ -353,7 +353,15 @@ public class FaultyExtractor<T> : ExtractorBase<T, Report>
 
     /// <inheritdoc/>
     protected override Report CreateProgressReport() =>
-        new(CurrentItemCount) { StartedAt = StartedAt, Elapsed = Elapsed };
+        new(CurrentItemCount)
+        {
+            StartedAt = StartedAt,
+            Elapsed = Elapsed,
+
+            // When the source is a materialized collection its size is a cheap, known
+            // total, so PercentComplete / EstimatedRemaining can be computed.
+            TotalItemCount = (_items as ICollection<T>)?.Count,
+        };
 
 
 

--- a/src/Wolfgang.Etl.TestKit/TestExtractor.cs
+++ b/src/Wolfgang.Etl.TestKit/TestExtractor.cs
@@ -515,7 +515,16 @@ public class TestExtractor<T> : ExtractorBase<T, Report>
 
     /// <inheritdoc/>
     protected override Report CreateProgressReport() =>
-        new(CurrentItemCount) { StartedAt = StartedAt, Elapsed = Elapsed };
+        new(CurrentItemCount)
+        {
+            StartedAt = StartedAt,
+            Elapsed = Elapsed,
+
+            // When the source is a materialized collection its size is a cheap, known
+            // total, so PercentComplete / EstimatedRemaining can be computed. An
+            // enumerator- or factory-backed source has no known total (stays null).
+            TotalItemCount = (_enumerable as ICollection<T>)?.Count,
+        };
 
 
 

--- a/tests/Wolfgang.Etl.TestKit.Tests.Unit/DoubleReportTimingTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Unit/DoubleReportTimingTests.cs
@@ -50,11 +50,38 @@ public class DoubleReportTimingTests
         Assert.True(report.ItemsPerSecond >= 0);
     }
 
+    [Fact]
+    public async Task CreateProgressReport_for_a_collection_source_surfaces_TotalItemCount()
+    {
+        var sut = new ExposedTestExtractor<int>(new List<int> { 1, 2, 3, 4, 5 });
+
+        await sut.ExtractAsync().ToListAsync();
+        var report = sut.GetProgressReport();
+
+        Assert.Equal(5, report.TotalItemCount);
+        Assert.Equal(100d, report.PercentComplete!.Value);
+    }
+
+    [Fact]
+    public void CreateProgressReport_for_an_enumerator_source_has_no_TotalItemCount()
+    {
+        var sut = new ExposedTestExtractor<int>(Enumerable.Range(1, 3).GetEnumerator());
+
+        var report = sut.GetProgressReport();
+
+        Assert.Null(report.TotalItemCount);
+    }
+
     private sealed class ExposedTestExtractor<T> : TestExtractor<T>
         where T : notnull
     {
         public ExposedTestExtractor(IEnumerable<T> items)
             : base(items)
+        {
+        }
+
+        public ExposedTestExtractor(IEnumerator<T> enumerator)
+            : base(enumerator)
         {
         }
 


### PR DESCRIPTION
Stacked PR **4/4** for 0.11.0 (base: `chore/promote-publicapi-shipped`).

`TestExtractor<T>` and `FaultyExtractor<T>` set `Report.TotalItemCount` from a materialized `ICollection<T>` source, so `PercentComplete`/`EstimatedRemaining` compute for reported progress. Enumerator/factory sources have no known total (stays null). No new public API surface (inside `CreateProgressReport`). +2 tests.