### PR TITLE
Release 0.11.0 — Abstractions 0.18.1 adoption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,15 @@ public API only — no breaking change.
 - `DisposableStageContractTests<TSut>` — an opt-in xUnit contract-test base verifying a stage
   throws `ObjectDisposedException` after `Dispose()`/`DisposeAsync()` (the 0.17 use-after-dispose
   guard) and that disposing twice is a harmless no-op.
+- Counter contract tests on `ExtractorBaseContractTests`, `LoaderBaseContractTests`, and
+  `TransformerBaseContractTests`: `CurrentItemCount` / `CurrentSkippedItemCount` /
+  `CurrentErrorItemCount` default-to-zero and skip-count-tracking assertions, inherited free by
+  every downstream contract-test class (#248).
+- "No over-read" contract tests (#49) on all three base classes: a stage must stop pulling from
+  its source once `MaximumItemCount` is reached (≤ M+1 reads) or the run is cancelled, and a
+  pre-cancelled token must read nothing. Extractors opt in by overriding the new
+  `CreateSutOverSource` factory (a no-op by default for extractors whose source is not an
+  injectable sequence).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [0.11.0] - 2026-07-26
+
+Adopts the `Wolfgang.Etl.Abstractions` 0.18.0 per-item **error hook** in the test doubles
+and adds contract-test bases covering the error hook and the disposability guarantees, plus
+surfaces the base classes' timing instrumentation in the doubles' progress reports. New
+public API only — no breaking change.
+
+### Added
+
+- **Error hook (Abstractions 0.18.0).** `FaultyExtractor<T>`, `FaultyLoader<T>`, and
+  `FaultyTransformer<T>` gain `SkipErrors()`, `HandleErrorsWith(policy)`, and `CapturedErrors`:
+  an injected `ThrowAt` fault is routed through the base `HandleItemError` hook, so it is
+  discarded and counted as an error (`CurrentErrorItemCount`) and the run continues on
+  `ItemErrorAction.Skip`, or re-thrown on `Abort`. With no policy configured a fault still
+  propagates (fail-fast), unchanged.
+- `ErrorHandlingContractTests<TSut>` + `ErrorHandlingOutcome` — an opt-in xUnit contract-test
+  base verifying a stage's error hook: a `Skip` policy completes the run and counts the failure
+  as an error kept *distinct* from the intentional-skip count; an `Abort` policy re-throws and
+  counts no error.
+- `DisposableStageContractTests<TSut>` — an opt-in xUnit contract-test base verifying a stage
+  throws `ObjectDisposedException` after `Dispose()`/`DisposeAsync()` (the 0.17 use-after-dispose
+  guard) and that disposing twice is a harmless no-op.
+
+### Changed
+
+- Built against `Wolfgang.Etl.Abstractions` 0.17.0 → **0.18.0**.
+- The doubles' `CreateProgressReport()` now surfaces the base's `StartedAt`/`Elapsed` timing
+  (Abstractions 0.14.0) in the `Report`, so `ItemsPerSecond` is computed for reported progress.
+
 ## [0.10.1] - 2026-07-24
 
 Maintenance release: the deferred "thorough-review" hardening tier plus the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,9 @@ public API only — no breaking change.
 
 - Built against `Wolfgang.Etl.Abstractions` 0.17.0 → **0.18.0**.
 - The doubles' `CreateProgressReport()` now surfaces the base's `StartedAt`/`Elapsed` timing
-  (Abstractions 0.14.0) in the `Report`, so `ItemsPerSecond` is computed for reported progress.
+  (Abstractions 0.14.0) in the `Report`, so `ItemsPerSecond` is computed for reported progress;
+  the extractor doubles also set `TotalItemCount` from a materialized collection source so
+  `PercentComplete`/`EstimatedRemaining` compute.
 
 ## [0.10.1] - 2026-07-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,11 +53,23 @@ public API only — no breaking change.
 
 ### Changed
 
-- Built against `Wolfgang.Etl.Abstractions` 0.17.0 → **0.18.0**.
+- Built against `Wolfgang.Etl.Abstractions` 0.17.0 → **0.18.1**.
+- The doubles build their progress `Report` via the new
+  `Report(int, DateTimeOffset?, TimeSpan, int?)` constructor (Abstractions 0.18.1) instead of
+  the object-initializer form, so setting the timing/total values is safe cross-assembly on
+  every target framework (see Fixed).
 - The doubles' `CreateProgressReport()` now surfaces the base's `StartedAt`/`Elapsed` timing
   (Abstractions 0.14.0) in the `Report`, so `ItemsPerSecond` is computed for reported progress;
   the extractor doubles also set `TotalItemCount` from a materialized collection source so
   `PercentComplete`/`EstimatedRemaining` compute.
+
+### Fixed
+
+- Surfacing `Report` timing from the doubles no longer throws `MissingMethodException` on
+  **.NET 6 / .NET 7**. The doubles' `netstandard2.0` assembly (which those runtimes load) set the
+  `Report` timing via the object-initializer (`init`) form, whose `IsExternalInit` modreq did not
+  match the modern Abstractions assembly resolved at runtime. The doubles now use the plain
+  `Report` timing constructor added in Abstractions 0.18.1, which is safe across every framework.
 
 ## [0.10.1] - 2026-07-24
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,33 @@ var loader = new FaultyLoader<string>(collectItems: true)
     .DuplicateAt(1);
 ```
 
+### Core — skipping bad items with the error hook
+
+Built on the `Wolfgang.Etl.Abstractions` 0.18 per-item error hook, the `Faulty*` doubles can route an injected fault through the base `HandleItemError` policy instead of only failing fast. Call `SkipErrors()` (or `HandleErrorsWith(policy)` for a per-item decision) so the bad item is discarded and counted as an error (`CurrentErrorItemCount`) while the run continues; `CapturedErrors` records each `ItemErrorContext`:
+
+```csharp
+using System;
+using Wolfgang.Etl.Abstractions;
+using Wolfgang.Etl.TestKit;
+
+var source = new[] { "alpha", "bravo", "charlie", "delta" };
+
+// Skip every failed item and keep going:
+var extractor = new FaultyExtractor<string>(source)
+    .ThrowAt(1, new FormatException("bad row"))
+    .SkipErrors();
+
+// Or decide per item — skip parse errors, abort on anything else:
+var picky = new FaultyExtractor<string>(source)
+    .ThrowAt(1, new FormatException("bad row"))
+    .HandleErrorsWith(ctx => ctx.Exception is FormatException
+        ? ItemErrorAction.Skip
+        : ItemErrorAction.Abort);
+
+// After the run: extractor.CurrentErrorItemCount == 1, and extractor.CapturedErrors
+// holds the ItemErrorContext for the discarded item.
+```
+
 ### xUnit — capturing and asserting on progress
 
 `ProgressCapture<T>` is an `IProgress<T>` that records every report; pass it straight to any progress-aware overload, then assert with `ProgressAssert`:
@@ -174,6 +201,55 @@ public sealed class MyExtractorIdempotencyTests
 ```
 
 `IdempotentLoaderContractTests<TSut, TItem>` adds a `TryGetLoadedItems(TSut sut)` factory (return `null` if the loader does not expose its loaded items), and `IdempotentTransformerContractTests<TSut, TItem>` follows the extractor shape with `CreateExpectedItems()`.
+
+### xUnit — verifying error handling
+
+If your stage opts into the 0.18 error hook, derive from `ErrorHandlingContractTests<TSut>` and implement one harness method that runs a scenario with a single failing item under a given policy. The base verifies that `Skip` completes the run and counts the failure as an error kept *distinct* from the intentional-skip count, while `Abort` re-throws and counts no error:
+
+```csharp
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+using Wolfgang.Etl.TestKit.Xunit;
+
+public sealed class MyExtractorErrorHandlingTests
+    : ErrorHandlingContractTests<MyExtractor>
+{
+    protected override async Task<ErrorHandlingOutcome> RunSingleFaultScenarioAsync(ItemErrorAction policy)
+    {
+        var sut = new MyExtractor(SourceWithOneBadRow()) { ErrorPolicy = policy };
+        var aborted = false;
+        try { await foreach (var _ in sut.ExtractAsync()) { } }
+        catch { aborted = true; }
+        return new ErrorHandlingOutcome(aborted, sut.CurrentItemCount, sut.CurrentErrorItemCount, sut.CurrentSkippedItemCount);
+    }
+}
+```
+
+### xUnit — verifying disposal
+
+Derive from `DisposableStageContractTests<TSut>` to verify the 0.14/0.17 dispose guarantees — that a public operation throws `ObjectDisposedException` after `Dispose()`/`DisposeAsync()`, and that disposing twice is a harmless no-op:
+
+```csharp
+using System.Threading.Tasks;
+using Wolfgang.Etl.TestKit.Xunit;
+
+public sealed class MyExtractorDisposableTests
+    : DisposableStageContractTests<MyExtractor>
+{
+    protected override MyExtractor CreateSut() => new MyExtractor(source);
+
+    protected override async Task<bool> InvokeReportsObjectDisposedAsync(bool disposeFirst, bool useAsyncDispose)
+    {
+        var sut = CreateSut();
+        if (disposeFirst)
+        {
+            if (useAsyncDispose) await sut.DisposeAsync(); else sut.Dispose();
+        }
+        try { await foreach (var _ in sut.ExtractAsync()) { } return false; }
+        catch (System.ObjectDisposedException) { return true; }
+    }
+}
+```
 
 ### xUnit add-on — contract-testing your own ETL types
 
@@ -233,9 +309,11 @@ public sealed class MyLoaderContractTests
 | **`ManualProgressTimer`** | An `IProgressTimer` whose `Fire()` method triggers progress callbacks synchronously, so progress tests are deterministic |
 | **`SynchronousProgress<T>`** | An `IProgress<T>` that invokes its callback synchronously for predictable progress assertions |
 | **`TestExtractor<T>` factory ctors** | Build a `TestExtractor<T>` from a `Func<T>` or `Func<int, T>` factory (with an optional item count) instead of materializing a collection up front |
-| **`FaultyExtractor<T>` / `FaultyLoader<T>` / `FaultyTransformer<T>`** | Fault-injection doubles with fluent `ThrowAt`, `ThrowAfterCompletion`, and `DuplicateAt` knobs for exercising error and retry paths |
+| **`FaultyExtractor<T>` / `FaultyLoader<T>` / `FaultyTransformer<T>`** | Fault-injection doubles with fluent `ThrowAt`, `ThrowAfterCompletion`, and `DuplicateAt` knobs, plus `SkipErrors()` / `HandleErrorsWith(policy)` / `CapturedErrors` to drive the Abstractions 0.18 per-item error hook |
 | **`ProgressCapture<T>` + `ProgressAssert`** | `ProgressCapture<T>` is an `IProgress<T>` that records every report; `ProgressAssert` provides xUnit assertions (`HasReports`, `HasExactly`, `FinalReportSatisfies`, `IsMonotonicallyIncreasing`, …) over a capture |
 | **`Idempotent*ContractTests`** | Opt-in `IdempotentExtractorContractTests<,,>`, `IdempotentLoaderContractTests<,>`, and `IdempotentTransformerContractTests<,>` bases that verify a component produces identical results across repeated runs |
+| **`ErrorHandlingContractTests<TSut>`** | Opt-in base verifying a stage's 0.18 error hook — `Skip` continues and counts the failure as an error (distinct from the intentional-skip count); `Abort` re-throws |
+| **`DisposableStageContractTests<TSut>`** | Opt-in base verifying the 0.14/0.17 dispose guarantees — use-after-dispose throws `ObjectDisposedException`, and double-dispose is a no-op |
 | **Multi-TFM support** | net462, net481, netstandard2.0, net8.0, net10.0 |
 
 ---

--- a/samples/Wolfgang.Etl.TestKit.Sample/PipelineWithDoublesExample.cs
+++ b/samples/Wolfgang.Etl.TestKit.Sample/PipelineWithDoublesExample.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
 using Xunit;
 
 namespace Wolfgang.Etl.TestKit.Sample;
@@ -57,5 +58,50 @@ public sealed class PipelineWithDoublesExample
 
         Assert.Equal("sensor dropped out", ex.Message);
         Assert.Equal(2, seen.Count); // two readings surfaced before the failure
+    }
+
+    [Fact]
+    public async Task Compose_extract_transform_load_with_EtlPipeline()
+    {
+        var readings = SampleReadings(3).ToList();
+
+        // Compose the doubles with the Abstractions 0.16 fluent pipeline: a source
+        // (TestExtractor), a stage (TestTransformer, pass-through here), and a sink
+        // (TestLoader) that captures the result for the assertion.
+        using var extractor   = new TestExtractor<TemperatureReading>(readings);
+        using var transformer = new TestTransformer<TemperatureReading>();
+        using var loader      = new TestLoader<TemperatureReading>(collectItems: true);
+
+        await EtlPipeline
+            .Create()
+            .From(extractor)
+            .Through(transformer)
+            .To(loader)
+            .RunAsync();
+
+        Assert.Equal(readings, loader.GetCollectedItems());
+    }
+
+    [Fact]
+    public async Task Skip_bad_items_in_a_pipeline_with_the_error_hook()
+    {
+        // A Faulty* double with SkipErrors() exercises the Abstractions 0.18 error hook
+        // inside a real pipeline: the bad item is discarded and counted as an error,
+        // and the run completes, so the loader still receives the survivors.
+        using var extractor   = new TestExtractor<TemperatureReading>(SampleReadings(5));
+        using var transformer = new FaultyTransformer<TemperatureReading>()
+            .ThrowAt(2, new InvalidOperationException("bad reading"))
+            .SkipErrors();
+        using var loader      = new TestLoader<TemperatureReading>(collectItems: true);
+
+        await EtlPipeline
+            .Create()
+            .From(extractor)
+            .Through(transformer)
+            .To(loader)
+            .RunAsync();
+
+        Assert.Equal(4, loader.GetCollectedItems()!.Count); // one bad reading skipped
+        Assert.Equal(1, transformer.CurrentErrorItemCount);
     }
 }

--- a/src/Wolfgang.Etl.TestKit.Xunit/DisposableStageContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/DisposableStageContractTests.cs
@@ -1,0 +1,155 @@
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Wolfgang.Etl.TestKit.Xunit;
+
+/// <summary>
+/// Abstract base class providing xUnit contract tests for the disposability guarantees the ETL
+/// base classes gained in <c>Wolfgang.Etl.Abstractions</c> 0.14.0 (<see cref="IDisposable"/> /
+/// <see cref="IAsyncDisposable"/>) and 0.17.0 (using a disposed stage throws
+/// <see cref="ObjectDisposedException"/>).
+/// </summary>
+/// <typeparam name="TSut">
+/// The stage type under test. Must be an <see cref="IDisposable"/> and
+/// <see cref="IAsyncDisposable"/> — every <c>ExtractorBase</c>/<c>LoaderBase</c>/
+/// <c>TransformerBase</c> is.
+/// </typeparam>
+/// <remarks>
+/// <para>
+/// Inherit from this class to verify that your stage honours the dispose contract: that its
+/// public operation throws <see cref="ObjectDisposedException"/> once the stage has been
+/// disposed (via either <see cref="IDisposable.Dispose"/> or
+/// <see cref="IAsyncDisposable.DisposeAsync"/>), and that disposing twice is a harmless no-op.
+/// </para>
+/// <para>
+/// Implement <see cref="CreateSut"/> to construct a fresh stage (used by the idempotent-dispose
+/// tests), and <see cref="InvokeReportsObjectDisposedAsync"/> to construct a stage, optionally
+/// dispose it, drive one public operation to completion, and report whether it threw
+/// <see cref="ObjectDisposedException"/>. The operation lives in the derived class — rather than
+/// receiving the stage as a parameter — so the contract stays stage-agnostic without forcing
+/// null-argument validation on the override.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// public class MyExtractorDisposableTests
+///     : DisposableStageContractTests&lt;MyExtractor&gt;
+/// {
+///     protected override MyExtractor CreateSut() => new MyExtractor(source);
+///
+///     protected override async Task&lt;bool&gt; InvokeReportsObjectDisposedAsync(bool disposeFirst, bool useAsyncDispose)
+///     {
+///         var sut = CreateSut();
+///         if (disposeFirst)
+///         {
+///             if (useAsyncDispose) await sut.DisposeAsync(); else sut.Dispose();
+///         }
+///         try { await foreach (var _ in sut.ExtractAsync()) { } return false; }
+///         catch (System.ObjectDisposedException) { return true; }
+///     }
+/// }
+/// </code>
+/// </example>
+public abstract class DisposableStageContractTests<TSut>
+    where TSut : class, IDisposable, IAsyncDisposable
+{
+    // ------------------------------------------------------------------
+    // Factory / harness methods
+    // ------------------------------------------------------------------
+
+    /// <summary>
+    /// Creates a fresh, undisposed stage under test. Used by the idempotent-dispose tests.
+    /// </summary>
+    protected abstract TSut CreateSut();
+
+    /// <summary>
+    /// Creates a fresh stage, optionally disposes it, drives one public operation to completion,
+    /// and reports whether the operation threw <see cref="ObjectDisposedException"/>.
+    /// </summary>
+    /// <param name="disposeFirst">
+    /// When <see langword="true"/>, dispose the stage before invoking the operation.
+    /// </param>
+    /// <param name="useAsyncDispose">
+    /// When disposing, use <see cref="IAsyncDisposable.DisposeAsync"/> if <see langword="true"/>,
+    /// otherwise <see cref="IDisposable.Dispose"/>. Ignored when <paramref name="disposeFirst"/>
+    /// is <see langword="false"/>.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> if the operation threw <see cref="ObjectDisposedException"/>;
+    /// otherwise <see langword="false"/>.
+    /// </returns>
+    protected abstract Task<bool> InvokeReportsObjectDisposedAsync(bool disposeFirst, bool useAsyncDispose);
+
+
+
+    // ------------------------------------------------------------------
+    // Dispose contract
+    // ------------------------------------------------------------------
+
+    /// <summary>
+    /// Control case: verifies the public operation does <em>not</em> throw
+    /// <see cref="ObjectDisposedException"/> on an undisposed stage, so the after-dispose tests
+    /// are not passing vacuously.
+    /// </summary>
+    [Fact]
+    public async Task Public_operation_before_dispose_does_not_throw_ObjectDisposedException_Async()
+    {
+        Assert.False
+        (
+            await InvokeReportsObjectDisposedAsync(disposeFirst: false, useAsyncDispose: false).ConfigureAwait(false),
+            "Expected no ObjectDisposedException before the stage is disposed."
+        );
+    }
+
+    /// <summary>
+    /// Verifies the public operation throws <see cref="ObjectDisposedException"/> after
+    /// <see cref="IDisposable.Dispose"/>.
+    /// </summary>
+    [Fact]
+    public async Task Public_operation_after_Dispose_throws_ObjectDisposedException_Async()
+    {
+        Assert.True
+        (
+            await InvokeReportsObjectDisposedAsync(disposeFirst: true, useAsyncDispose: false).ConfigureAwait(false),
+            "Expected ObjectDisposedException after Dispose()."
+        );
+    }
+
+    /// <summary>
+    /// Verifies the public operation throws <see cref="ObjectDisposedException"/> after
+    /// <see cref="IAsyncDisposable.DisposeAsync"/>.
+    /// </summary>
+    [Fact]
+    public async Task Public_operation_after_DisposeAsync_throws_ObjectDisposedException_Async()
+    {
+        Assert.True
+        (
+            await InvokeReportsObjectDisposedAsync(disposeFirst: true, useAsyncDispose: true).ConfigureAwait(false),
+            "Expected ObjectDisposedException after DisposeAsync()."
+        );
+    }
+
+    /// <summary>
+    /// Verifies that calling <see cref="IDisposable.Dispose"/> twice is a harmless no-op.
+    /// </summary>
+    [Fact]
+    public void Dispose_is_idempotent()
+    {
+        var sut = CreateSut();
+        sut.Dispose();
+        sut.Dispose();
+    }
+
+    /// <summary>
+    /// Verifies that calling <see cref="IAsyncDisposable.DisposeAsync"/> twice is a harmless
+    /// no-op.
+    /// </summary>
+    [Fact]
+    public async Task DisposeAsync_is_idempotent_Async()
+    {
+        var sut = CreateSut();
+        await sut.DisposeAsync().ConfigureAwait(false);
+        await sut.DisposeAsync().ConfigureAwait(false);
+    }
+}

--- a/src/Wolfgang.Etl.TestKit.Xunit/ErrorHandlingContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/ErrorHandlingContractTests.cs
@@ -1,0 +1,153 @@
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+using Xunit;
+
+namespace Wolfgang.Etl.TestKit.Xunit;
+
+/// <summary>
+/// Abstract base class providing xUnit contract tests for a stage that opts into the
+/// per-item error hook introduced in <c>Wolfgang.Etl.Abstractions</c> 0.18.0
+/// (<c>OnItemError</c> / <c>HandleItemError</c> / <c>CurrentErrorItemCount</c>,
+/// <see cref="ItemErrorAction"/>, <see cref="ItemErrorContext"/>).
+/// </summary>
+/// <typeparam name="TSut">The stage type under test.</typeparam>
+/// <remarks>
+/// <para>
+/// Inherit from this class to verify that your stage honours the error-hook contract: that a
+/// policy of <see cref="ItemErrorAction.Skip"/> discards the failed item and lets the run
+/// continue while counting it as an <em>error</em>, and that a policy of
+/// <see cref="ItemErrorAction.Abort"/> (the default) re-throws. The hook is opt-in — the base
+/// classes do not catch a worker's per-item failure — so this contract is the guarantee that an
+/// opted-in stage skips-and-continues correctly and never absorbs a failure into its intentional
+/// skip budget.
+/// </para>
+/// <para>
+/// The base is stage-agnostic: implement <see cref="RunSingleFaultScenarioAsync"/> to create
+/// your stage configured with the supplied policy over a scenario that contains
+/// <em>exactly one failing item</em> plus at least one item that succeeds, drive it to
+/// completion (catching the re-thrown failure when the policy aborts), and report the resulting
+/// counters via an <see cref="ErrorHandlingOutcome"/>.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// public class MyExtractorErrorHandlingTests
+///     : ErrorHandlingContractTests&lt;MyExtractor&gt;
+/// {
+///     protected override async Task&lt;ErrorHandlingOutcome&gt; RunSingleFaultScenarioAsync(ItemErrorAction policy)
+///     {
+///         var sut = new MyExtractor(SourceWithOneBadRow()) { ErrorPolicy = policy };
+///         var aborted = false;
+///         try { await foreach (var _ in sut.ExtractAsync()) { } }
+///         catch { aborted = true; }
+///         return new ErrorHandlingOutcome(aborted, sut.CurrentItemCount, sut.CurrentErrorItemCount, sut.CurrentSkippedItemCount);
+///     }
+/// }
+/// </code>
+/// </example>
+public abstract class ErrorHandlingContractTests<TSut>
+    where TSut : notnull
+{
+    // ------------------------------------------------------------------
+    // Factory / harness method
+    // ------------------------------------------------------------------
+
+    /// <summary>
+    /// Creates the stage under test configured with the supplied error <paramref name="policy"/>
+    /// over a scenario containing <em>exactly one failing item</em> and at least one item that
+    /// succeeds, drives it to completion (catching the re-thrown failure if the policy aborts),
+    /// and reports the resulting counters.
+    /// </summary>
+    /// <param name="policy">
+    /// The action the stage's error policy returns for the failing item —
+    /// <see cref="ItemErrorAction.Skip"/> or <see cref="ItemErrorAction.Abort"/>.
+    /// </param>
+    /// <returns>The observable outcome of the run.</returns>
+    protected abstract Task<ErrorHandlingOutcome> RunSingleFaultScenarioAsync(ItemErrorAction policy);
+
+
+
+    // ------------------------------------------------------------------
+    // Skip policy contract
+    // ------------------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that a <see cref="ItemErrorAction.Skip"/> policy lets the run complete rather
+    /// than re-throwing the failing item's exception.
+    /// </summary>
+    [Fact]
+    public async Task Skip_policy_completes_the_run_Async()
+    {
+        var outcome = await RunSingleFaultScenarioAsync(ItemErrorAction.Skip).ConfigureAwait(false);
+
+        Assert.False(outcome.Aborted, "Expected a Skip policy to complete the run, not abort.");
+    }
+
+    /// <summary>
+    /// Verifies that a <see cref="ItemErrorAction.Skip"/> policy counts the failed item as an
+    /// error (<c>CurrentErrorItemCount</c>), so the failure is never silent.
+    /// </summary>
+    [Fact]
+    public async Task Skip_policy_counts_the_failure_as_an_error_Async()
+    {
+        var outcome = await RunSingleFaultScenarioAsync(ItemErrorAction.Skip).ConfigureAwait(false);
+
+        Assert.Equal(1, outcome.ErrorItemCount);
+    }
+
+    /// <summary>
+    /// Verifies that a <see cref="ItemErrorAction.Skip"/> policy does <em>not</em> fold the
+    /// failure into <c>CurrentSkippedItemCount</c> — the 0.18 guarantee that an error-skip is
+    /// distinct from an intentional skip.
+    /// </summary>
+    [Fact]
+    public async Task Skip_policy_does_not_count_the_failure_as_an_intentional_skip_Async()
+    {
+        var outcome = await RunSingleFaultScenarioAsync(ItemErrorAction.Skip).ConfigureAwait(false);
+
+        Assert.Equal(0, outcome.SkippedItemCount);
+    }
+
+    /// <summary>
+    /// Verifies that a <see cref="ItemErrorAction.Skip"/> policy still processes the items that
+    /// do not fail — the run is not vacuously "completed" by producing nothing.
+    /// </summary>
+    [Fact]
+    public async Task Skip_policy_processes_the_surviving_items_Async()
+    {
+        var outcome = await RunSingleFaultScenarioAsync(ItemErrorAction.Skip).ConfigureAwait(false);
+
+        Assert.True(outcome.ItemCount > 0, "Expected the surviving items to be processed after a skipped failure.");
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // Abort policy contract
+    // ------------------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that an <see cref="ItemErrorAction.Abort"/> policy re-throws the failing item's
+    /// exception, aborting the run (the default fail-fast behaviour).
+    /// </summary>
+    [Fact]
+    public async Task Abort_policy_rethrows_and_aborts_Async()
+    {
+        var outcome = await RunSingleFaultScenarioAsync(ItemErrorAction.Abort).ConfigureAwait(false);
+
+        Assert.True(outcome.Aborted, "Expected an Abort policy to re-throw and abort the run.");
+    }
+
+    /// <summary>
+    /// Verifies that an <see cref="ItemErrorAction.Abort"/> policy does <em>not</em> increment
+    /// <c>CurrentErrorItemCount</c> — the error counter tracks discarded (skipped) failures, not
+    /// aborting ones.
+    /// </summary>
+    [Fact]
+    public async Task Abort_policy_does_not_count_an_error_Async()
+    {
+        var outcome = await RunSingleFaultScenarioAsync(ItemErrorAction.Abort).ConfigureAwait(false);
+
+        Assert.Equal(0, outcome.ErrorItemCount);
+    }
+}

--- a/src/Wolfgang.Etl.TestKit.Xunit/ErrorHandlingOutcome.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/ErrorHandlingOutcome.cs
@@ -1,0 +1,38 @@
+namespace Wolfgang.Etl.TestKit.Xunit;
+
+/// <summary>
+/// The observable outcome of running a stage over a scenario containing exactly one failing
+/// item, used by <see cref="ErrorHandlingContractTests{TSut}"/>.
+/// </summary>
+public sealed class ErrorHandlingOutcome
+{
+    /// <summary>
+    /// Initialises a new <see cref="ErrorHandlingOutcome"/>.
+    /// </summary>
+    /// <param name="aborted">
+    /// <see langword="true"/> if the run re-threw the item's failure (aborted); otherwise
+    /// <see langword="false"/> (the run completed).
+    /// </param>
+    /// <param name="itemCount">The stage's <c>CurrentItemCount</c> after the run.</param>
+    /// <param name="errorItemCount">The stage's <c>CurrentErrorItemCount</c> after the run.</param>
+    /// <param name="skippedItemCount">The stage's <c>CurrentSkippedItemCount</c> after the run.</param>
+    public ErrorHandlingOutcome(bool aborted, int itemCount, int errorItemCount, int skippedItemCount)
+    {
+        Aborted          = aborted;
+        ItemCount        = itemCount;
+        ErrorItemCount   = errorItemCount;
+        SkippedItemCount = skippedItemCount;
+    }
+
+    /// <summary>Whether the run re-threw the failing item's exception (aborted the run).</summary>
+    public bool Aborted { get; }
+
+    /// <summary>The stage's <c>CurrentItemCount</c> (successfully processed items) after the run.</summary>
+    public int ItemCount { get; }
+
+    /// <summary>The stage's <c>CurrentErrorItemCount</c> (error-discarded items) after the run.</summary>
+    public int ErrorItemCount { get; }
+
+    /// <summary>The stage's <c>CurrentSkippedItemCount</c> (intentionally skipped items) after the run.</summary>
+    public int SkippedItemCount { get; }
+}

--- a/src/Wolfgang.Etl.TestKit.Xunit/ExtractorBaseContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/ExtractorBaseContractTests.cs
@@ -813,4 +813,115 @@ public abstract class ExtractorBaseContractTests<TSut, TItem, TProgress>
 
         Assert.Equal(2, sut.CurrentSkippedItemCount);
     }
+
+    /// <summary>
+    /// Verifies that <c>CurrentErrorItemCount</c> is zero on a freshly created extractor, before
+    /// any item has failed (Abstractions 0.18.0 error hook).
+    /// </summary>
+    [Fact]
+    public void CurrentErrorItemCount_defaults_to_zero()
+    {
+        var sut = CreateSut();
+
+        Assert.Equal(0, sut.CurrentErrorItemCount);
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // No over-read (issue #49)
+    // ------------------------------------------------------------------
+
+    /// <summary>
+    /// Override to enable the "no over-read" tests for an extractor that reads from an
+    /// injectable in-memory sequence. Return an extractor that draws its items from
+    /// <paramref name="source"/>, or <see langword="null"/> (the default) to skip those tests —
+    /// appropriate for an extractor whose source is a connection or handle that cannot be a
+    /// caller-supplied sequence.
+    /// </summary>
+    /// <param name="source">The sequence the returned extractor must read from.</param>
+    protected virtual TSut? CreateSutOverSource(IEnumerable<TItem> source) => default;
+
+    /// <summary>
+    /// Verifies that once <c>MaximumItemCount</c> is reached the extractor stops pulling from its
+    /// source rather than draining it — at most M+1 reads (the +1 discovers the limit). Skipped
+    /// unless <see cref="CreateSutOverSource"/> is overridden.
+    /// </summary>
+    [Fact]
+    public async Task ExtractAsync_does_not_over_read_past_MaximumItemCount_Async()
+    {
+        var counter = new PullCounter();
+        var sut = CreateSutOverSource(counter.CountSync(CreateExpectedItems()));
+        if (sut is null)
+        {
+            return;
+        }
+
+        sut.MaximumItemCount = 3;
+
+        await sut.ExtractAsync().ToListAsync().ConfigureAwait(false);
+
+        Assert.True(counter.Count <= 4, $"Expected at most 4 upstream reads, saw {counter.Count}.");
+    }
+
+    // Cancel() runs synchronously to cancel mid-enumeration; CancelAsync is net8.0+ only and
+    // this base targets net462+.
+#pragma warning disable CA1849, VSTHRD103
+    /// <summary>
+    /// Verifies that cancelling mid-enumeration stops the extractor pulling from its source at
+    /// the next check. Skipped unless <see cref="CreateSutOverSource"/> is overridden.
+    /// </summary>
+    [Fact]
+    public async Task ExtractAsync_stops_reading_on_cancellation_Async()
+    {
+        using var cts = new CancellationTokenSource();
+        var counter = new PullCounter();
+        var sut = CreateSutOverSource(counter.CountSync(CreateExpectedItems()));
+        if (sut is null)
+        {
+            return;
+        }
+
+        var seen = 0;
+
+        try
+        {
+            await foreach (var _ in sut.ExtractAsync(cts.Token).ConfigureAwait(false))
+            {
+                if (++seen == 3)
+                {
+                    cts.Cancel();
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+        }
+
+        Assert.True(counter.Count <= 4, $"Expected at most 4 upstream reads, saw {counter.Count}.");
+    }
+#pragma warning restore CA1849, VSTHRD103
+
+    /// <summary>
+    /// Verifies that a pre-cancelled token short-circuits the extractor before it pulls any item
+    /// from its source. Skipped unless <see cref="CreateSutOverSource"/> is overridden.
+    /// </summary>
+    [Fact]
+    public async Task ExtractAsync_with_a_pre_cancelled_token_reads_nothing_Async()
+    {
+        var token = new CancellationToken(canceled: true);
+        var counter = new PullCounter();
+        var sut = CreateSutOverSource(counter.CountSync(CreateExpectedItems()));
+        if (sut is null)
+        {
+            return;
+        }
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>
+        (
+            () => sut.ExtractAsync(token).ToListAsync(token).AsTask()
+        ).ConfigureAwait(false);
+
+        Assert.Equal(0, counter.Count);
+    }
 }

--- a/src/Wolfgang.Etl.TestKit.Xunit/ExtractorBaseContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/ExtractorBaseContractTests.cs
@@ -771,4 +771,46 @@ public abstract class ExtractorBaseContractTests<TSut, TItem, TProgress>
         Assert.Equal(expected[1], actual[0]);
         Assert.Equal(1, sut.CurrentSkippedItemCount);
     }
+
+    /// <summary>
+    /// Verifies that <c>CurrentItemCount</c> is zero on a freshly created extractor, before any
+    /// extraction has run.
+    /// </summary>
+    [Fact]
+    public void CurrentItemCount_defaults_to_zero()
+    {
+        var sut = CreateSut();
+
+        Assert.Equal(0, sut.CurrentItemCount);
+    }
+
+    /// <summary>
+    /// Verifies that <c>CurrentSkippedItemCount</c> is zero on a freshly created extractor, before
+    /// any extraction has run.
+    /// </summary>
+    [Fact]
+    public void CurrentSkippedItemCount_defaults_to_zero()
+    {
+        var sut = CreateSut();
+
+        Assert.Equal(0, sut.CurrentSkippedItemCount);
+    }
+
+    /// <summary>
+    /// Verifies that <c>CurrentSkippedItemCount</c> reflects the exact number of items skipped by
+    /// <c>SkipItemCount</c> after a run.
+    /// </summary>
+    [Fact]
+    public async Task ExtractAsync_CurrentSkippedItemCount_reflects_the_number_of_items_skipped_Async()
+    {
+        var sut = CreateSut();
+        var expected = CreateExpectedItems();
+        Assert.True(expected.Count >= 3, "CreateExpectedItems() must return at least 3 items.");
+
+        sut.SkipItemCount = 2;
+
+        await sut.ExtractAsync().ToListAsync().ConfigureAwait(false);
+
+        Assert.Equal(2, sut.CurrentSkippedItemCount);
+    }
 }

--- a/src/Wolfgang.Etl.TestKit.Xunit/LoaderBaseContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/LoaderBaseContractTests.cs
@@ -835,4 +835,46 @@ public abstract class LoaderBaseContractTests<TSut, TItem, TProgress>
         Assert.Equal(expected.Count - 1, sut.CurrentItemCount);
         Assert.Equal(1, sut.CurrentSkippedItemCount);
     }
+
+    /// <summary>
+    /// Verifies that <c>CurrentItemCount</c> is zero on a freshly created loader, before any load
+    /// has run.
+    /// </summary>
+    [Fact]
+    public void CurrentItemCount_defaults_to_zero()
+    {
+        var sut = CreateSut();
+
+        Assert.Equal(0, sut.CurrentItemCount);
+    }
+
+    /// <summary>
+    /// Verifies that <c>CurrentSkippedItemCount</c> is zero on a freshly created loader, before any
+    /// load has run.
+    /// </summary>
+    [Fact]
+    public void CurrentSkippedItemCount_defaults_to_zero()
+    {
+        var sut = CreateSut();
+
+        Assert.Equal(0, sut.CurrentSkippedItemCount);
+    }
+
+    /// <summary>
+    /// Verifies that <c>CurrentSkippedItemCount</c> reflects the exact number of items skipped by
+    /// <c>SkipItemCount</c> after a run.
+    /// </summary>
+    [Fact]
+    public async Task LoadAsync_CurrentSkippedItemCount_reflects_the_number_of_items_skipped_Async()
+    {
+        var sut = CreateSut();
+        var expected = CreateSourceItems();
+        Assert.True(expected.Count >= 3, "CreateSourceItems() must return at least 3 items.");
+
+        sut.SkipItemCount = 2;
+
+        await sut.LoadAsync(CreateInputItemsAsync()).ConfigureAwait(false);
+
+        Assert.Equal(2, sut.CurrentSkippedItemCount);
+    }
 }

--- a/src/Wolfgang.Etl.TestKit.Xunit/LoaderBaseContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/LoaderBaseContractTests.cs
@@ -877,4 +877,89 @@ public abstract class LoaderBaseContractTests<TSut, TItem, TProgress>
 
         Assert.Equal(2, sut.CurrentSkippedItemCount);
     }
+
+    /// <summary>
+    /// Verifies that <c>CurrentErrorItemCount</c> is zero on a freshly created loader, before any
+    /// item has failed (Abstractions 0.18.0 error hook).
+    /// </summary>
+    [Fact]
+    public void CurrentErrorItemCount_defaults_to_zero()
+    {
+        var sut = CreateSut();
+
+        Assert.Equal(0, sut.CurrentErrorItemCount);
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // No over-read (issue #49)
+    // ------------------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that once <c>MaximumItemCount</c> is reached the loader stops pulling from its
+    /// source rather than draining it — at most M+1 reads (the +1 discovers the limit).
+    /// </summary>
+    [Fact]
+    public async Task LoadAsync_does_not_over_read_past_MaximumItemCount_Async()
+    {
+        var sut = CreateSut();
+        sut.MaximumItemCount = 3;
+        var counter = new PullCounter();
+
+        await sut.LoadAsync(counter.CountAsync(CreateInputItemsAsync())).ConfigureAwait(false);
+
+        Assert.True(counter.Count <= 4, $"Expected at most 4 upstream reads, saw {counter.Count}.");
+    }
+
+    // Cancel() runs synchronously to cancel mid-enumeration; CancelAsync is net8.0+ only and
+    // this base targets net462+.
+#pragma warning disable CA1849, VSTHRD103
+    /// <summary>
+    /// Verifies that cancelling mid-run stops the loader pulling from its source at the next
+    /// check, rather than draining the already-available items.
+    /// </summary>
+    [Fact]
+    public async Task LoadAsync_stops_reading_on_cancellation_Async()
+    {
+        var sut = CreateSut();
+        using var cts = new CancellationTokenSource();
+        var counter = new PullCounter();
+        var source = counter.CountAsync
+        (
+            CreateInputItemsAsync(),
+            onPull: () => { if (counter.Count == 3) { cts.Cancel(); } },
+            token: cts.Token
+        );
+
+        try
+        {
+            await sut.LoadAsync(source, cts.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+        }
+
+        Assert.True(counter.Count <= 4, $"Expected at most 4 upstream reads, saw {counter.Count}.");
+    }
+#pragma warning restore CA1849, VSTHRD103
+
+    /// <summary>
+    /// Verifies that a pre-cancelled token short-circuits the loader before it pulls any item
+    /// from its source.
+    /// </summary>
+    [Fact]
+    public async Task LoadAsync_with_a_pre_cancelled_token_reads_nothing_Async()
+    {
+        var sut = CreateSut();
+        var token = new CancellationToken(canceled: true);
+        var counter = new PullCounter();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>
+        (
+            () => sut.LoadAsync(counter.CountAsync(CreateInputItemsAsync(), token: token), token)
+        ).ConfigureAwait(false);
+
+        Assert.Equal(0, counter.Count);
+    }
 }

--- a/src/Wolfgang.Etl.TestKit.Xunit/PublicAPI.Shipped.txt
+++ b/src/Wolfgang.Etl.TestKit.Xunit/PublicAPI.Shipped.txt
@@ -292,3 +292,12 @@ static Wolfgang.Etl.TestKit.Xunit.ProgressAssert.HasReports<T>(Wolfgang.Etl.Test
 static Wolfgang.Etl.TestKit.Xunit.ProgressAssert.IsMonotonicallyIncreasing<T, TKey>(Wolfgang.Etl.TestKit.Xunit.ProgressCapture<T>! capture, System.Func<T, TKey>! selector) -> void
 virtual Wolfgang.Etl.TestKit.Xunit.IdempotentLoaderContractTests<TSut, TItem>.GetCurrentItemCount(TSut sut) -> int
 virtual Wolfgang.Etl.TestKit.Xunit.IdempotentTransformerContractTests<TSut, TItem>.GetCurrentItemCount(TSut sut) -> int
+Wolfgang.Etl.TestKit.Xunit.SupportsDryRunContractTests<TSut>
+Wolfgang.Etl.TestKit.Xunit.SupportsDryRunContractTests<TSut>.SupportsDryRunContractTests() -> void
+Wolfgang.Etl.TestKit.Xunit.SupportsDryRunContractTests<TSut>.IsDryRun_can_be_set_back_to_false() -> void
+Wolfgang.Etl.TestKit.Xunit.SupportsDryRunContractTests<TSut>.IsDryRun_can_be_set_to_true() -> void
+Wolfgang.Etl.TestKit.Xunit.SupportsDryRunContractTests<TSut>.IsDryRun_defaults_to_false() -> void
+Wolfgang.Etl.TestKit.Xunit.SupportsDryRunContractTests<TSut>.When_IsDryRun_is_false_side_effect_occurs_Async() -> System.Threading.Tasks.Task!
+Wolfgang.Etl.TestKit.Xunit.SupportsDryRunContractTests<TSut>.When_IsDryRun_is_true_side_effect_is_skipped_Async() -> System.Threading.Tasks.Task!
+abstract Wolfgang.Etl.TestKit.Xunit.SupportsDryRunContractTests<TSut>.CreateSut() -> TSut
+abstract Wolfgang.Etl.TestKit.Xunit.SupportsDryRunContractTests<TSut>.RunAndReportSideEffectAsync(bool isDryRun) -> System.Threading.Tasks.Task<bool>!

--- a/src/Wolfgang.Etl.TestKit.Xunit/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.TestKit.Xunit/PublicAPI.Unshipped.txt
@@ -32,3 +32,16 @@ Wolfgang.Etl.TestKit.Xunit.LoaderBaseContractTests<TSut, TItem, TProgress>.LoadA
 Wolfgang.Etl.TestKit.Xunit.TransformerBaseContractTests<TSut, TItem, TProgress>.CurrentItemCount_defaults_to_zero() -> void
 Wolfgang.Etl.TestKit.Xunit.TransformerBaseContractTests<TSut, TItem, TProgress>.CurrentSkippedItemCount_defaults_to_zero() -> void
 Wolfgang.Etl.TestKit.Xunit.TransformerBaseContractTests<TSut, TItem, TProgress>.TransformAsync_CurrentSkippedItemCount_reflects_the_number_of_items_skipped_Async() -> System.Threading.Tasks.Task!
+Wolfgang.Etl.TestKit.Xunit.ExtractorBaseContractTests<TSut, TItem, TProgress>.CurrentErrorItemCount_defaults_to_zero() -> void
+virtual Wolfgang.Etl.TestKit.Xunit.ExtractorBaseContractTests<TSut, TItem, TProgress>.CreateSutOverSource(System.Collections.Generic.IEnumerable<TItem>! source) -> TSut?
+Wolfgang.Etl.TestKit.Xunit.ExtractorBaseContractTests<TSut, TItem, TProgress>.ExtractAsync_does_not_over_read_past_MaximumItemCount_Async() -> System.Threading.Tasks.Task!
+Wolfgang.Etl.TestKit.Xunit.ExtractorBaseContractTests<TSut, TItem, TProgress>.ExtractAsync_stops_reading_on_cancellation_Async() -> System.Threading.Tasks.Task!
+Wolfgang.Etl.TestKit.Xunit.ExtractorBaseContractTests<TSut, TItem, TProgress>.ExtractAsync_with_a_pre_cancelled_token_reads_nothing_Async() -> System.Threading.Tasks.Task!
+Wolfgang.Etl.TestKit.Xunit.LoaderBaseContractTests<TSut, TItem, TProgress>.CurrentErrorItemCount_defaults_to_zero() -> void
+Wolfgang.Etl.TestKit.Xunit.LoaderBaseContractTests<TSut, TItem, TProgress>.LoadAsync_does_not_over_read_past_MaximumItemCount_Async() -> System.Threading.Tasks.Task!
+Wolfgang.Etl.TestKit.Xunit.LoaderBaseContractTests<TSut, TItem, TProgress>.LoadAsync_stops_reading_on_cancellation_Async() -> System.Threading.Tasks.Task!
+Wolfgang.Etl.TestKit.Xunit.LoaderBaseContractTests<TSut, TItem, TProgress>.LoadAsync_with_a_pre_cancelled_token_reads_nothing_Async() -> System.Threading.Tasks.Task!
+Wolfgang.Etl.TestKit.Xunit.TransformerBaseContractTests<TSut, TItem, TProgress>.CurrentErrorItemCount_defaults_to_zero() -> void
+Wolfgang.Etl.TestKit.Xunit.TransformerBaseContractTests<TSut, TItem, TProgress>.TransformAsync_does_not_over_read_past_MaximumItemCount_Async() -> System.Threading.Tasks.Task!
+Wolfgang.Etl.TestKit.Xunit.TransformerBaseContractTests<TSut, TItem, TProgress>.TransformAsync_stops_reading_on_cancellation_Async() -> System.Threading.Tasks.Task!
+Wolfgang.Etl.TestKit.Xunit.TransformerBaseContractTests<TSut, TItem, TProgress>.TransformAsync_with_a_pre_cancelled_token_reads_nothing_Async() -> System.Threading.Tasks.Task!

--- a/src/Wolfgang.Etl.TestKit.Xunit/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.TestKit.Xunit/PublicAPI.Unshipped.txt
@@ -1,13 +1,4 @@
 #nullable enable
-Wolfgang.Etl.TestKit.Xunit.SupportsDryRunContractTests<TSut>
-Wolfgang.Etl.TestKit.Xunit.SupportsDryRunContractTests<TSut>.SupportsDryRunContractTests() -> void
-Wolfgang.Etl.TestKit.Xunit.SupportsDryRunContractTests<TSut>.IsDryRun_can_be_set_back_to_false() -> void
-Wolfgang.Etl.TestKit.Xunit.SupportsDryRunContractTests<TSut>.IsDryRun_can_be_set_to_true() -> void
-Wolfgang.Etl.TestKit.Xunit.SupportsDryRunContractTests<TSut>.IsDryRun_defaults_to_false() -> void
-Wolfgang.Etl.TestKit.Xunit.SupportsDryRunContractTests<TSut>.When_IsDryRun_is_false_side_effect_occurs_Async() -> System.Threading.Tasks.Task!
-Wolfgang.Etl.TestKit.Xunit.SupportsDryRunContractTests<TSut>.When_IsDryRun_is_true_side_effect_is_skipped_Async() -> System.Threading.Tasks.Task!
-abstract Wolfgang.Etl.TestKit.Xunit.SupportsDryRunContractTests<TSut>.CreateSut() -> TSut
-abstract Wolfgang.Etl.TestKit.Xunit.SupportsDryRunContractTests<TSut>.RunAndReportSideEffectAsync(bool isDryRun) -> System.Threading.Tasks.Task<bool>!
 Wolfgang.Etl.TestKit.Xunit.ErrorHandlingContractTests<TSut>
 Wolfgang.Etl.TestKit.Xunit.ErrorHandlingContractTests<TSut>.ErrorHandlingContractTests() -> void
 Wolfgang.Etl.TestKit.Xunit.ErrorHandlingContractTests<TSut>.Skip_policy_completes_the_run_Async() -> System.Threading.Tasks.Task!

--- a/src/Wolfgang.Etl.TestKit.Xunit/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.TestKit.Xunit/PublicAPI.Unshipped.txt
@@ -8,3 +8,18 @@ Wolfgang.Etl.TestKit.Xunit.SupportsDryRunContractTests<TSut>.When_IsDryRun_is_fa
 Wolfgang.Etl.TestKit.Xunit.SupportsDryRunContractTests<TSut>.When_IsDryRun_is_true_side_effect_is_skipped_Async() -> System.Threading.Tasks.Task!
 abstract Wolfgang.Etl.TestKit.Xunit.SupportsDryRunContractTests<TSut>.CreateSut() -> TSut
 abstract Wolfgang.Etl.TestKit.Xunit.SupportsDryRunContractTests<TSut>.RunAndReportSideEffectAsync(bool isDryRun) -> System.Threading.Tasks.Task<bool>!
+Wolfgang.Etl.TestKit.Xunit.ErrorHandlingContractTests<TSut>
+Wolfgang.Etl.TestKit.Xunit.ErrorHandlingContractTests<TSut>.ErrorHandlingContractTests() -> void
+Wolfgang.Etl.TestKit.Xunit.ErrorHandlingContractTests<TSut>.Skip_policy_completes_the_run_Async() -> System.Threading.Tasks.Task!
+Wolfgang.Etl.TestKit.Xunit.ErrorHandlingContractTests<TSut>.Skip_policy_counts_the_failure_as_an_error_Async() -> System.Threading.Tasks.Task!
+Wolfgang.Etl.TestKit.Xunit.ErrorHandlingContractTests<TSut>.Skip_policy_does_not_count_the_failure_as_an_intentional_skip_Async() -> System.Threading.Tasks.Task!
+Wolfgang.Etl.TestKit.Xunit.ErrorHandlingContractTests<TSut>.Skip_policy_processes_the_surviving_items_Async() -> System.Threading.Tasks.Task!
+Wolfgang.Etl.TestKit.Xunit.ErrorHandlingContractTests<TSut>.Abort_policy_rethrows_and_aborts_Async() -> System.Threading.Tasks.Task!
+Wolfgang.Etl.TestKit.Xunit.ErrorHandlingContractTests<TSut>.Abort_policy_does_not_count_an_error_Async() -> System.Threading.Tasks.Task!
+abstract Wolfgang.Etl.TestKit.Xunit.ErrorHandlingContractTests<TSut>.RunSingleFaultScenarioAsync(Wolfgang.Etl.Abstractions.ItemErrorAction policy) -> System.Threading.Tasks.Task<Wolfgang.Etl.TestKit.Xunit.ErrorHandlingOutcome!>!
+Wolfgang.Etl.TestKit.Xunit.ErrorHandlingOutcome
+Wolfgang.Etl.TestKit.Xunit.ErrorHandlingOutcome.ErrorHandlingOutcome(bool aborted, int itemCount, int errorItemCount, int skippedItemCount) -> void
+Wolfgang.Etl.TestKit.Xunit.ErrorHandlingOutcome.Aborted.get -> bool
+Wolfgang.Etl.TestKit.Xunit.ErrorHandlingOutcome.ItemCount.get -> int
+Wolfgang.Etl.TestKit.Xunit.ErrorHandlingOutcome.ErrorItemCount.get -> int
+Wolfgang.Etl.TestKit.Xunit.ErrorHandlingOutcome.SkippedItemCount.get -> int

--- a/src/Wolfgang.Etl.TestKit.Xunit/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.TestKit.Xunit/PublicAPI.Unshipped.txt
@@ -23,3 +23,12 @@ Wolfgang.Etl.TestKit.Xunit.ErrorHandlingOutcome.Aborted.get -> bool
 Wolfgang.Etl.TestKit.Xunit.ErrorHandlingOutcome.ItemCount.get -> int
 Wolfgang.Etl.TestKit.Xunit.ErrorHandlingOutcome.ErrorItemCount.get -> int
 Wolfgang.Etl.TestKit.Xunit.ErrorHandlingOutcome.SkippedItemCount.get -> int
+Wolfgang.Etl.TestKit.Xunit.DisposableStageContractTests<TSut>
+Wolfgang.Etl.TestKit.Xunit.DisposableStageContractTests<TSut>.DisposableStageContractTests() -> void
+Wolfgang.Etl.TestKit.Xunit.DisposableStageContractTests<TSut>.DisposeAsync_is_idempotent_Async() -> System.Threading.Tasks.Task!
+Wolfgang.Etl.TestKit.Xunit.DisposableStageContractTests<TSut>.Dispose_is_idempotent() -> void
+Wolfgang.Etl.TestKit.Xunit.DisposableStageContractTests<TSut>.Public_operation_after_DisposeAsync_throws_ObjectDisposedException_Async() -> System.Threading.Tasks.Task!
+Wolfgang.Etl.TestKit.Xunit.DisposableStageContractTests<TSut>.Public_operation_after_Dispose_throws_ObjectDisposedException_Async() -> System.Threading.Tasks.Task!
+Wolfgang.Etl.TestKit.Xunit.DisposableStageContractTests<TSut>.Public_operation_before_dispose_does_not_throw_ObjectDisposedException_Async() -> System.Threading.Tasks.Task!
+abstract Wolfgang.Etl.TestKit.Xunit.DisposableStageContractTests<TSut>.CreateSut() -> TSut!
+abstract Wolfgang.Etl.TestKit.Xunit.DisposableStageContractTests<TSut>.InvokeReportsObjectDisposedAsync(bool disposeFirst, bool useAsyncDispose) -> System.Threading.Tasks.Task<bool>!

--- a/src/Wolfgang.Etl.TestKit.Xunit/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.TestKit.Xunit/PublicAPI.Unshipped.txt
@@ -32,3 +32,12 @@ Wolfgang.Etl.TestKit.Xunit.DisposableStageContractTests<TSut>.Public_operation_a
 Wolfgang.Etl.TestKit.Xunit.DisposableStageContractTests<TSut>.Public_operation_before_dispose_does_not_throw_ObjectDisposedException_Async() -> System.Threading.Tasks.Task!
 abstract Wolfgang.Etl.TestKit.Xunit.DisposableStageContractTests<TSut>.CreateSut() -> TSut!
 abstract Wolfgang.Etl.TestKit.Xunit.DisposableStageContractTests<TSut>.InvokeReportsObjectDisposedAsync(bool disposeFirst, bool useAsyncDispose) -> System.Threading.Tasks.Task<bool>!
+Wolfgang.Etl.TestKit.Xunit.ExtractorBaseContractTests<TSut, TItem, TProgress>.CurrentItemCount_defaults_to_zero() -> void
+Wolfgang.Etl.TestKit.Xunit.ExtractorBaseContractTests<TSut, TItem, TProgress>.CurrentSkippedItemCount_defaults_to_zero() -> void
+Wolfgang.Etl.TestKit.Xunit.ExtractorBaseContractTests<TSut, TItem, TProgress>.ExtractAsync_CurrentSkippedItemCount_reflects_the_number_of_items_skipped_Async() -> System.Threading.Tasks.Task!
+Wolfgang.Etl.TestKit.Xunit.LoaderBaseContractTests<TSut, TItem, TProgress>.CurrentItemCount_defaults_to_zero() -> void
+Wolfgang.Etl.TestKit.Xunit.LoaderBaseContractTests<TSut, TItem, TProgress>.CurrentSkippedItemCount_defaults_to_zero() -> void
+Wolfgang.Etl.TestKit.Xunit.LoaderBaseContractTests<TSut, TItem, TProgress>.LoadAsync_CurrentSkippedItemCount_reflects_the_number_of_items_skipped_Async() -> System.Threading.Tasks.Task!
+Wolfgang.Etl.TestKit.Xunit.TransformerBaseContractTests<TSut, TItem, TProgress>.CurrentItemCount_defaults_to_zero() -> void
+Wolfgang.Etl.TestKit.Xunit.TransformerBaseContractTests<TSut, TItem, TProgress>.CurrentSkippedItemCount_defaults_to_zero() -> void
+Wolfgang.Etl.TestKit.Xunit.TransformerBaseContractTests<TSut, TItem, TProgress>.TransformAsync_CurrentSkippedItemCount_reflects_the_number_of_items_skipped_Async() -> System.Threading.Tasks.Task!

--- a/src/Wolfgang.Etl.TestKit.Xunit/PullCounter.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/PullCounter.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Wolfgang.Etl.TestKit.Xunit;
+
+/// <summary>
+/// Counts how many items a stage pulls from a wrapped source, so the "no over-read" contract
+/// tests (issue #49) can assert that a stage stops reading upstream once
+/// <c>MaximumItemCount</c> is reached or the run is cancelled, rather than draining the whole
+/// source. Internal test-harness helper.
+/// </summary>
+internal sealed class PullCounter
+{
+    private int _count;
+
+    /// <summary>The number of items pulled from the wrapped source so far.</summary>
+    public int Count => Volatile.Read(ref _count);
+
+    /// <summary>
+    /// Wraps an async source, incrementing <see cref="Count"/> as each item is pulled and
+    /// awaiting <paramref name="onPull"/> after each increment (used to trigger cancellation
+    /// after a chosen number of pulls).
+    /// </summary>
+    public async IAsyncEnumerable<T> CountAsync<T>
+    (
+        IAsyncEnumerable<T> source,
+        Action? onPull = null,
+        [EnumeratorCancellation] CancellationToken token = default
+    )
+    {
+        await foreach (var item in source.WithCancellation(token).ConfigureAwait(false))
+        {
+            _ = Interlocked.Increment(ref _count);
+            onPull?.Invoke();
+            yield return item;
+        }
+    }
+
+    /// <summary>
+    /// Wraps a synchronous source (an extractor's in-memory sequence), incrementing
+    /// <see cref="Count"/> as each item is pulled.
+    /// </summary>
+    public IEnumerable<T> CountSync<T>(IEnumerable<T> source)
+    {
+        foreach (var item in source)
+        {
+            _ = Interlocked.Increment(ref _count);
+            yield return item;
+        }
+    }
+}

--- a/src/Wolfgang.Etl.TestKit.Xunit/TransformerBaseContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/TransformerBaseContractTests.cs
@@ -870,4 +870,46 @@ public abstract class TransformerBaseContractTests<TSut, TItem, TProgress>
         Assert.Equal(expected.Count - 1, actual.Count);
         Assert.Equal(expected.Skip(1).ToList(), actual);
     }
+
+    /// <summary>
+    /// Verifies that <c>CurrentItemCount</c> is zero on a freshly created transformer, before any
+    /// transformation has run.
+    /// </summary>
+    [Fact]
+    public void CurrentItemCount_defaults_to_zero()
+    {
+        var sut = CreateSut();
+
+        Assert.Equal(0, sut.CurrentItemCount);
+    }
+
+    /// <summary>
+    /// Verifies that <c>CurrentSkippedItemCount</c> is zero on a freshly created transformer,
+    /// before any transformation has run.
+    /// </summary>
+    [Fact]
+    public void CurrentSkippedItemCount_defaults_to_zero()
+    {
+        var sut = CreateSut();
+
+        Assert.Equal(0, sut.CurrentSkippedItemCount);
+    }
+
+    /// <summary>
+    /// Verifies that <c>CurrentSkippedItemCount</c> reflects the exact number of items skipped by
+    /// <c>SkipItemCount</c> after a run.
+    /// </summary>
+    [Fact]
+    public async Task TransformAsync_CurrentSkippedItemCount_reflects_the_number_of_items_skipped_Async()
+    {
+        var sut = CreateSut();
+        var expected = CreateExpectedItems();
+        Assert.True(expected.Count >= 3, "CreateExpectedItems() must return at least 3 items.");
+
+        sut.SkipItemCount = 2;
+
+        await sut.TransformAsync(CreateInputItemsAsync()).ToListAsync().ConfigureAwait(false);
+
+        Assert.Equal(2, sut.CurrentSkippedItemCount);
+    }
 }

--- a/src/Wolfgang.Etl.TestKit.Xunit/TransformerBaseContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/TransformerBaseContractTests.cs
@@ -912,4 +912,92 @@ public abstract class TransformerBaseContractTests<TSut, TItem, TProgress>
 
         Assert.Equal(2, sut.CurrentSkippedItemCount);
     }
+
+    /// <summary>
+    /// Verifies that <c>CurrentErrorItemCount</c> is zero on a freshly created transformer, before
+    /// any item has failed (Abstractions 0.18.0 error hook).
+    /// </summary>
+    [Fact]
+    public void CurrentErrorItemCount_defaults_to_zero()
+    {
+        var sut = CreateSut();
+
+        Assert.Equal(0, sut.CurrentErrorItemCount);
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // No over-read (issue #49)
+    // ------------------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that once <c>MaximumItemCount</c> is reached the transformer stops pulling from
+    /// its source rather than draining it — at most M+1 reads (the +1 discovers the limit).
+    /// </summary>
+    [Fact]
+    public async Task TransformAsync_does_not_over_read_past_MaximumItemCount_Async()
+    {
+        var sut = CreateSut();
+        sut.MaximumItemCount = 3;
+        var counter = new PullCounter();
+
+        await sut.TransformAsync(counter.CountAsync(CreateInputItemsAsync())).ToListAsync().ConfigureAwait(false);
+
+        Assert.True(counter.Count <= 4, $"Expected at most 4 upstream reads, saw {counter.Count}.");
+    }
+
+    // Cancel() runs synchronously to cancel mid-enumeration; CancelAsync is net8.0+ only and
+    // this base targets net462+.
+#pragma warning disable CA1849, VSTHRD103
+    /// <summary>
+    /// Verifies that cancelling mid-run stops the transformer pulling from its source at the
+    /// next check, rather than draining the already-available items.
+    /// </summary>
+    [Fact]
+    public async Task TransformAsync_stops_reading_on_cancellation_Async()
+    {
+        var sut = CreateSut();
+        using var cts = new CancellationTokenSource();
+        var counter = new PullCounter();
+        var seen = 0;
+
+        try
+        {
+            var source = counter.CountAsync(CreateInputItemsAsync(), token: cts.Token);
+
+            await foreach (var _ in sut.TransformAsync(source, cts.Token).ConfigureAwait(false))
+            {
+                if (++seen == 3)
+                {
+                    cts.Cancel();
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+        }
+
+        Assert.True(counter.Count <= 4, $"Expected at most 4 upstream reads, saw {counter.Count}.");
+    }
+#pragma warning restore CA1849, VSTHRD103
+
+    /// <summary>
+    /// Verifies that a pre-cancelled token short-circuits the transformer before it pulls any
+    /// item from its source.
+    /// </summary>
+    [Fact]
+    public async Task TransformAsync_with_a_pre_cancelled_token_reads_nothing_Async()
+    {
+        var sut = CreateSut();
+        var token = new CancellationToken(canceled: true);
+        var counter = new PullCounter();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>
+        (
+            () => sut.TransformAsync(counter.CountAsync(CreateInputItemsAsync(), token: token), token).ToListAsync(token).AsTask()
+        ).ConfigureAwait(false);
+
+        Assert.Equal(0, counter.Count);
+    }
 }

--- a/src/Wolfgang.Etl.TestKit.Xunit/Wolfgang.Etl.TestKit.Xunit.csproj
+++ b/src/Wolfgang.Etl.TestKit.Xunit/Wolfgang.Etl.TestKit.Xunit.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net462;net481;netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>
-    <Version>0.10.1</Version>
+    <Version>0.11.0</Version>
     <!-- Pin AssemblyVersion to a fixed binding-stability baseline so consumers
          do not need to recompile / add binding redirects on every minor/patch
          bump. Bump only on a deliberate breaking API change. FileVersion +
@@ -79,7 +79,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Bcl.Memory" Version="10.0.10" />
-    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.17.0" />
+    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.18.0" />
     <PackageReference Include="System.Linq.Async" Version="7.0.1" />
     <PackageReference Include="xunit.abstractions" Version="2.0.3" />
     <PackageReference Include="xunit.assert" Version="2.9.3" />

--- a/src/Wolfgang.Etl.TestKit.Xunit/Wolfgang.Etl.TestKit.Xunit.csproj
+++ b/src/Wolfgang.Etl.TestKit.Xunit/Wolfgang.Etl.TestKit.Xunit.csproj
@@ -21,7 +21,7 @@
          is live on NuGet (otherwise pack fails NU1102). Intentional breaks in a
          MAJOR bump are recorded via a generated CompatibilitySuppressions.xml. -->
     <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>0.10.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>0.10.1</PackageValidationBaselineVersion>
     <Title>Wolfgang.Etl.TestKit.Xunit</Title>
     <Description>Abstract xUnit contract test base classes for verifying custom ETL extractors, transformers, and loaders built on Wolfgang.Etl.Abstractions.</Description>
     <PackageProjectUrl>https://github.com/Chris-Wolfgang/ETL-Test-Kit</PackageProjectUrl>

--- a/src/Wolfgang.Etl.TestKit.Xunit/Wolfgang.Etl.TestKit.Xunit.csproj
+++ b/src/Wolfgang.Etl.TestKit.Xunit/Wolfgang.Etl.TestKit.Xunit.csproj
@@ -79,7 +79,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Bcl.Memory" Version="10.0.10" />
-    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.18.0" />
+    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.18.1" />
     <PackageReference Include="System.Linq.Async" Version="7.0.1" />
     <PackageReference Include="xunit.abstractions" Version="2.0.3" />
     <PackageReference Include="xunit.assert" Version="2.9.3" />

--- a/src/Wolfgang.Etl.TestKit/FaultyExtractor.cs
+++ b/src/Wolfgang.Etl.TestKit/FaultyExtractor.cs
@@ -353,7 +353,15 @@ public class FaultyExtractor<T> : ExtractorBase<T, Report>
 
     /// <inheritdoc/>
     protected override Report CreateProgressReport() =>
-        new(CurrentItemCount) { StartedAt = StartedAt, Elapsed = Elapsed };
+        new(CurrentItemCount)
+        {
+            StartedAt = StartedAt,
+            Elapsed = Elapsed,
+
+            // When the source is a materialized collection its size is a cheap, known
+            // total, so PercentComplete / EstimatedRemaining can be computed.
+            TotalItemCount = (_items as ICollection<T>)?.Count,
+        };
 
 
 

--- a/src/Wolfgang.Etl.TestKit/FaultyExtractor.cs
+++ b/src/Wolfgang.Etl.TestKit/FaultyExtractor.cs
@@ -55,6 +55,8 @@ public class FaultyExtractor<T> : ExtractorBase<T, Report>
     private readonly Dictionary<int, Exception> _throwAt = new Dictionary<int, Exception>();
     private readonly HashSet<int> _duplicateAt = new HashSet<int>();
     private Exception? _throwAfterCompletion;
+    private Func<ItemErrorContext, ItemErrorAction>? _onItemErrorPolicy;
+    private readonly List<ItemErrorContext> _capturedErrors = new List<ItemErrorContext>();
     private readonly IProgressTimer? _progressTimer;
     private bool _progressTimerWired;
     private Action? _elapsedHandler;
@@ -200,8 +202,113 @@ public class FaultyExtractor<T> : ExtractorBase<T, Report>
 
 
     // ------------------------------------------------------------------
+    // Error-hook configuration (Abstractions 0.18.0)
+    // ------------------------------------------------------------------
+
+    /// <summary>
+    /// Configures the extractor to route every injected <see cref="ThrowAt"/> fault through
+    /// the base <see cref="ExtractorBase{TSource,TProgress}.HandleItemError"/> hook with a
+    /// policy of <see cref="ItemErrorAction.Skip"/>, so the failing item is discarded and
+    /// counted as an error (<see cref="ExtractorBase{TSource,TProgress}.CurrentErrorItemCount"/>)
+    /// rather than propagating. Use this to exercise a resumable stage's skip-and-continue path.
+    /// </summary>
+    /// <returns>The same <see cref="FaultyExtractor{T}"/> instance, to allow chaining.</returns>
+    /// <remarks>
+    /// Without an error policy an injected fault propagates (fail-fast), preserving the
+    /// default behaviour. The failing item is not yielded, and its
+    /// <see cref="ItemErrorContext"/> is recorded in <see cref="CapturedErrors"/>.
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// var extractor = new FaultyExtractor&lt;int&gt;(items)
+    ///     .ThrowAt(2, new System.FormatException("bad row"))
+    ///     .SkipErrors();
+    ///
+    /// // Item at index 2 is skipped (counted as an error); enumeration continues. /* ... */
+    /// </code>
+    /// </example>
+    public FaultyExtractor<T> SkipErrors()
+    {
+        _onItemErrorPolicy = _ => ItemErrorAction.Skip;
+
+        return this;
+    }
+
+
+
+    /// <summary>
+    /// Configures a custom per-item error policy. When an injected <see cref="ThrowAt"/> fault
+    /// fires, <paramref name="policy"/> is invoked with the failing item's
+    /// <see cref="ItemErrorContext"/> and decides whether to
+    /// <see cref="ItemErrorAction.Skip"/> the item (counting it as an error and continuing) or
+    /// <see cref="ItemErrorAction.Abort"/> the run (re-throwing).
+    /// </summary>
+    /// <param name="policy">The policy invoked for each failed item.</param>
+    /// <returns>The same <see cref="FaultyExtractor{T}"/> instance, to allow chaining.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="policy"/> is <see langword="null"/>.
+    /// </exception>
+    public FaultyExtractor<T> HandleErrorsWith(Func<ItemErrorContext, ItemErrorAction> policy)
+    {
+        _onItemErrorPolicy = policy ?? throw new ArgumentNullException(nameof(policy));
+
+        return this;
+    }
+
+
+
+    /// <summary>
+    /// The <see cref="ItemErrorContext"/> for every item whose injected fault was routed
+    /// through the error hook, in the order they occurred. Empty when no error policy is
+    /// configured (faults propagate) or when no fault has fired.
+    /// </summary>
+    public IReadOnlyList<ItemErrorContext> CapturedErrors => _capturedErrors.ToArray();
+
+
+
+    // ------------------------------------------------------------------
     // ExtractorBase overrides
     // ------------------------------------------------------------------
+
+    /// <summary>
+    /// Records the failed item and applies the configured error policy. Invoked by the base
+    /// <see cref="ExtractorBase{TSource,TProgress}.HandleItemError"/> when a fault is routed
+    /// through the hook; falls back to the base (<see cref="ItemErrorAction.Abort"/>) when no
+    /// policy is configured.
+    /// </summary>
+    /// <param name="context">Describes the failed item.</param>
+    /// <returns>The action to take for the failed item.</returns>
+    protected override ItemErrorAction OnItemError(ItemErrorContext context)
+    {
+        _capturedErrors.Add(context);
+
+        return _onItemErrorPolicy is not null
+            ? _onItemErrorPolicy(context)
+            : base.OnItemError(context);
+    }
+
+
+
+    // Applies the configured error policy to an injected fault. Returns true when the
+    // failing item should be skipped — routed through the base HandleItemError hook,
+    // which counts it as an error (not a processed item). Throws to abort the run, or,
+    // when no policy is configured, to preserve fail-fast behaviour (counting the
+    // failing item first, matching the ThrowAt contract).
+    private bool HandleInjectedFault(int index, Exception exception)
+    {
+        if (_onItemErrorPolicy is not null)
+        {
+            if (HandleItemError(new ItemErrorContext(index + 1, exception)) == ItemErrorAction.Skip)
+            {
+                return true;
+            }
+
+            throw exception;
+        }
+
+        IncrementCurrentItemCount();
+        throw exception;
+    }
 
     /// <inheritdoc/>
     protected override IProgressTimer CreateProgressTimer(IProgress<Report> progress)
@@ -257,10 +364,8 @@ public class FaultyExtractor<T> : ExtractorBase<T, Report>
     {
         token.ThrowIfCancellationRequested();
 
-        // The wrapped source is synchronous, so this iterator would otherwise
-        // contain no await. Yield once up front to honour the async-iterator
-        // contract on every exit path (including the MaximumItemCount yield-break
-        // and ThrowAfterCompletion throw), reachable however the loop terminates.
+        // The wrapped source is synchronous; yield once up front to honour the
+        // async-iterator contract on every exit path however the loop terminates.
         await Task.Yield();
 
         var enumerator = _items.GetEnumerator();
@@ -286,12 +391,14 @@ public class FaultyExtractor<T> : ExtractorBase<T, Report>
 
                 var item = enumerator.Current;
 
-                IncrementCurrentItemCount();
-
-                if (_throwAt.TryGetValue(index, out var exception))
+                if (_throwAt.TryGetValue(index, out var exception)
+                    && HandleInjectedFault(index, exception))
                 {
-                    throw exception;
+                    index++;
+                    continue;
                 }
+
+                IncrementCurrentItemCount();
 
                 yield return item;
 

--- a/src/Wolfgang.Etl.TestKit/FaultyExtractor.cs
+++ b/src/Wolfgang.Etl.TestKit/FaultyExtractor.cs
@@ -352,7 +352,8 @@ public class FaultyExtractor<T> : ExtractorBase<T, Report>
 
 
     /// <inheritdoc/>
-    protected override Report CreateProgressReport() => new(CurrentItemCount);
+    protected override Report CreateProgressReport() =>
+        new(CurrentItemCount) { StartedAt = StartedAt, Elapsed = Elapsed };
 
 
 

--- a/src/Wolfgang.Etl.TestKit/FaultyExtractor.cs
+++ b/src/Wolfgang.Etl.TestKit/FaultyExtractor.cs
@@ -353,15 +353,11 @@ public class FaultyExtractor<T> : ExtractorBase<T, Report>
 
     /// <inheritdoc/>
     protected override Report CreateProgressReport() =>
-        new(CurrentItemCount)
-        {
-            StartedAt = StartedAt,
-            Elapsed = Elapsed,
-
-            // When the source is a materialized collection its size is a cheap, known
-            // total, so PercentComplete / EstimatedRemaining can be computed.
-            TotalItemCount = (_items as ICollection<T>)?.Count,
-        };
+        // When the source is a materialized collection its size is a cheap, known total, so
+        // PercentComplete / EstimatedRemaining can be computed. The timing constructor
+        // (Abstractions 0.18.1) sets these via plain parameters, avoiding the init-setter
+        // cross-assembly modreq mismatch that broke netstandard2.0 consumers on .NET 6/7.
+        new(CurrentItemCount, StartedAt, Elapsed, (_items as ICollection<T>)?.Count);
 
 
 

--- a/src/Wolfgang.Etl.TestKit/FaultyLoader.cs
+++ b/src/Wolfgang.Etl.TestKit/FaultyLoader.cs
@@ -363,7 +363,8 @@ public class FaultyLoader<T> : LoaderBase<T, Report>
 
 
     /// <inheritdoc/>
-    protected override Report CreateProgressReport() => new(CurrentItemCount);
+    protected override Report CreateProgressReport() =>
+        new(CurrentItemCount) { StartedAt = StartedAt, Elapsed = Elapsed };
 
 
 

--- a/src/Wolfgang.Etl.TestKit/FaultyLoader.cs
+++ b/src/Wolfgang.Etl.TestKit/FaultyLoader.cs
@@ -55,6 +55,8 @@ public class FaultyLoader<T> : LoaderBase<T, Report>
     private readonly Dictionary<int, Exception> _throwAt = new Dictionary<int, Exception>();
     private readonly HashSet<int> _duplicateAt = new HashSet<int>();
     private Exception? _throwAfterCompletion;
+    private Func<ItemErrorContext, ItemErrorAction>? _onItemErrorPolicy;
+    private readonly List<ItemErrorContext> _capturedErrors = new List<ItemErrorContext>();
     private readonly IProgressTimer? _progressTimer;
     private bool _progressTimerWired;
     private Action? _elapsedHandler;
@@ -220,8 +222,104 @@ public class FaultyLoader<T> : LoaderBase<T, Report>
 
 
     // ------------------------------------------------------------------
+    // Error-hook configuration (Abstractions 0.18.0)
+    // ------------------------------------------------------------------
+
+    /// <summary>
+    /// Configures the loader to route every injected <see cref="ThrowAt"/> fault through the
+    /// base <see cref="LoaderBase{TDestination,TProgress}.HandleItemError"/> hook with a policy
+    /// of <see cref="ItemErrorAction.Skip"/>, so the failing item is discarded and counted as
+    /// an error (<see cref="LoaderBase{TDestination,TProgress}.CurrentErrorItemCount"/>) rather
+    /// than propagating. Use this to exercise a resumable stage's skip-and-continue path.
+    /// </summary>
+    /// <returns>The same <see cref="FaultyLoader{T}"/> instance, to allow chaining.</returns>
+    /// <remarks>
+    /// Without an error policy an injected fault propagates (fail-fast), preserving the
+    /// default behaviour. The failing item is neither stored nor counted as loaded, and its
+    /// <see cref="ItemErrorContext"/> is recorded in <see cref="CapturedErrors"/>.
+    /// </remarks>
+    public FaultyLoader<T> SkipErrors()
+    {
+        _onItemErrorPolicy = _ => ItemErrorAction.Skip;
+
+        return this;
+    }
+
+
+
+    /// <summary>
+    /// Configures a custom per-item error policy. When an injected <see cref="ThrowAt"/> fault
+    /// fires, <paramref name="policy"/> is invoked with the failing item's
+    /// <see cref="ItemErrorContext"/> and decides whether to
+    /// <see cref="ItemErrorAction.Skip"/> the item (counting it as an error and continuing) or
+    /// <see cref="ItemErrorAction.Abort"/> the run (re-throwing).
+    /// </summary>
+    /// <param name="policy">The policy invoked for each failed item.</param>
+    /// <returns>The same <see cref="FaultyLoader{T}"/> instance, to allow chaining.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="policy"/> is <see langword="null"/>.
+    /// </exception>
+    public FaultyLoader<T> HandleErrorsWith(Func<ItemErrorContext, ItemErrorAction> policy)
+    {
+        _onItemErrorPolicy = policy ?? throw new ArgumentNullException(nameof(policy));
+
+        return this;
+    }
+
+
+
+    /// <summary>
+    /// The <see cref="ItemErrorContext"/> for every item whose injected fault was routed
+    /// through the error hook, in the order they occurred. Empty when no error policy is
+    /// configured (faults propagate) or when no fault has fired.
+    /// </summary>
+    public IReadOnlyList<ItemErrorContext> CapturedErrors => _capturedErrors.ToArray();
+
+
+
+    // ------------------------------------------------------------------
     // LoaderBase overrides
     // ------------------------------------------------------------------
+
+    /// <summary>
+    /// Records the failed item and applies the configured error policy. Invoked by the base
+    /// <see cref="LoaderBase{TDestination,TProgress}.HandleItemError"/> when a fault is routed
+    /// through the hook; falls back to the base (<see cref="ItemErrorAction.Abort"/>) when no
+    /// policy is configured.
+    /// </summary>
+    /// <param name="context">Describes the failed item.</param>
+    /// <returns>The action to take for the failed item.</returns>
+    protected override ItemErrorAction OnItemError(ItemErrorContext context)
+    {
+        _capturedErrors.Add(context);
+
+        return _onItemErrorPolicy is not null
+            ? _onItemErrorPolicy(context)
+            : base.OnItemError(context);
+    }
+
+
+
+    // Applies the configured error policy to an injected fault. Returns true when the
+    // failing item should be skipped — routed through the base HandleItemError hook,
+    // which counts it as an error (not a loaded item). Throws to abort the run, or,
+    // when no policy is configured, to preserve fail-fast behaviour (counting the
+    // failing item first, matching the ThrowAt contract).
+    private bool HandleInjectedFault(int index, Exception exception)
+    {
+        if (_onItemErrorPolicy is not null)
+        {
+            if (HandleItemError(new ItemErrorContext(index + 1, exception)) == ItemErrorAction.Skip)
+            {
+                return true;
+            }
+
+            throw exception;
+        }
+
+        IncrementCurrentItemCount();
+        throw exception;
+    }
 
     /// <inheritdoc/>
     protected override IProgressTimer CreateProgressTimer(IProgress<Report> progress)
@@ -299,12 +397,14 @@ public class FaultyLoader<T> : LoaderBase<T, Report>
                     break;
                 }
 
-                IncrementCurrentItemCount();
-
-                if (_throwAt.TryGetValue(index, out var exception))
+                if (_throwAt.TryGetValue(index, out var exception)
+                    && HandleInjectedFault(index, exception))
                 {
-                    throw exception;
+                    index++;
+                    continue;
                 }
+
+                IncrementCurrentItemCount();
 
                 if (_collectItems)
                 {

--- a/src/Wolfgang.Etl.TestKit/FaultyLoader.cs
+++ b/src/Wolfgang.Etl.TestKit/FaultyLoader.cs
@@ -364,7 +364,7 @@ public class FaultyLoader<T> : LoaderBase<T, Report>
 
     /// <inheritdoc/>
     protected override Report CreateProgressReport() =>
-        new(CurrentItemCount) { StartedAt = StartedAt, Elapsed = Elapsed };
+        new(CurrentItemCount, StartedAt, Elapsed);
 
 
 

--- a/src/Wolfgang.Etl.TestKit/FaultyTransformer.cs
+++ b/src/Wolfgang.Etl.TestKit/FaultyTransformer.cs
@@ -327,7 +327,8 @@ public class FaultyTransformer<T> : TransformerBase<T, T, Report>
 
 
     /// <inheritdoc/>
-    protected override Report CreateProgressReport() => new(CurrentItemCount);
+    protected override Report CreateProgressReport() =>
+        new(CurrentItemCount) { StartedAt = StartedAt, Elapsed = Elapsed };
 
 
 

--- a/src/Wolfgang.Etl.TestKit/FaultyTransformer.cs
+++ b/src/Wolfgang.Etl.TestKit/FaultyTransformer.cs
@@ -51,6 +51,8 @@ public class FaultyTransformer<T> : TransformerBase<T, T, Report>
     private readonly Dictionary<int, Exception> _throwAt = new Dictionary<int, Exception>();
     private readonly HashSet<int> _duplicateAt = new HashSet<int>();
     private Exception? _throwAfterCompletion;
+    private Func<ItemErrorContext, ItemErrorAction>? _onItemErrorPolicy;
+    private readonly List<ItemErrorContext> _capturedErrors = new List<ItemErrorContext>();
     private readonly IProgressTimer? _progressTimer;
     private bool _progressTimerWired;
     private Action? _elapsedHandler;
@@ -183,8 +185,105 @@ public class FaultyTransformer<T> : TransformerBase<T, T, Report>
 
 
     // ------------------------------------------------------------------
+    // Error-hook configuration (Abstractions 0.18.0)
+    // ------------------------------------------------------------------
+
+    /// <summary>
+    /// Configures the transformer to route every injected <see cref="ThrowAt"/> fault through
+    /// the base <see cref="TransformerBase{TSource,TDestination,TProgress}.HandleItemError"/>
+    /// hook with a policy of <see cref="ItemErrorAction.Skip"/>, so the failing item is
+    /// discarded and counted as an error
+    /// (<see cref="TransformerBase{TSource,TDestination,TProgress}.CurrentErrorItemCount"/>)
+    /// rather than propagating. Use this to exercise a resumable stage's skip-and-continue path.
+    /// </summary>
+    /// <returns>The same <see cref="FaultyTransformer{T}"/> instance, to allow chaining.</returns>
+    /// <remarks>
+    /// Without an error policy an injected fault propagates (fail-fast), preserving the
+    /// default behaviour. The failing item is not emitted, and its
+    /// <see cref="ItemErrorContext"/> is recorded in <see cref="CapturedErrors"/>.
+    /// </remarks>
+    public FaultyTransformer<T> SkipErrors()
+    {
+        _onItemErrorPolicy = _ => ItemErrorAction.Skip;
+
+        return this;
+    }
+
+
+
+    /// <summary>
+    /// Configures a custom per-item error policy. When an injected <see cref="ThrowAt"/> fault
+    /// fires, <paramref name="policy"/> is invoked with the failing item's
+    /// <see cref="ItemErrorContext"/> and decides whether to
+    /// <see cref="ItemErrorAction.Skip"/> the item (counting it as an error and continuing) or
+    /// <see cref="ItemErrorAction.Abort"/> the run (re-throwing).
+    /// </summary>
+    /// <param name="policy">The policy invoked for each failed item.</param>
+    /// <returns>The same <see cref="FaultyTransformer{T}"/> instance, to allow chaining.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="policy"/> is <see langword="null"/>.
+    /// </exception>
+    public FaultyTransformer<T> HandleErrorsWith(Func<ItemErrorContext, ItemErrorAction> policy)
+    {
+        _onItemErrorPolicy = policy ?? throw new ArgumentNullException(nameof(policy));
+
+        return this;
+    }
+
+
+
+    /// <summary>
+    /// The <see cref="ItemErrorContext"/> for every item whose injected fault was routed
+    /// through the error hook, in the order they occurred. Empty when no error policy is
+    /// configured (faults propagate) or when no fault has fired.
+    /// </summary>
+    public IReadOnlyList<ItemErrorContext> CapturedErrors => _capturedErrors.ToArray();
+
+
+
+    // ------------------------------------------------------------------
     // TransformerBase overrides
     // ------------------------------------------------------------------
+
+    /// <summary>
+    /// Records the failed item and applies the configured error policy. Invoked by the base
+    /// <see cref="TransformerBase{TSource,TDestination,TProgress}.HandleItemError"/> when a
+    /// fault is routed through the hook; falls back to the base
+    /// (<see cref="ItemErrorAction.Abort"/>) when no policy is configured.
+    /// </summary>
+    /// <param name="context">Describes the failed item.</param>
+    /// <returns>The action to take for the failed item.</returns>
+    protected override ItemErrorAction OnItemError(ItemErrorContext context)
+    {
+        _capturedErrors.Add(context);
+
+        return _onItemErrorPolicy is not null
+            ? _onItemErrorPolicy(context)
+            : base.OnItemError(context);
+    }
+
+
+
+    // Applies the configured error policy to an injected fault. Returns true when the
+    // failing item should be skipped — routed through the base HandleItemError hook,
+    // which counts it as an error (not a processed item). Throws to abort the run, or,
+    // when no policy is configured, to preserve fail-fast behaviour (counting the
+    // failing item first, matching the ThrowAt contract).
+    private bool HandleInjectedFault(int index, Exception exception)
+    {
+        if (_onItemErrorPolicy is not null)
+        {
+            if (HandleItemError(new ItemErrorContext(index + 1, exception)) == ItemErrorAction.Skip)
+            {
+                return true;
+            }
+
+            throw exception;
+        }
+
+        IncrementCurrentItemCount();
+        throw exception;
+    }
 
     /// <inheritdoc/>
     protected override IProgressTimer CreateProgressTimer(IProgress<Report> progress)
@@ -260,12 +359,14 @@ public class FaultyTransformer<T> : TransformerBase<T, T, Report>
                     yield break;
                 }
 
-                IncrementCurrentItemCount();
-
-                if (_throwAt.TryGetValue(index, out var exception))
+                if (_throwAt.TryGetValue(index, out var exception)
+                    && HandleInjectedFault(index, exception))
                 {
-                    throw exception;
+                    index++;
+                    continue;
                 }
+
+                IncrementCurrentItemCount();
 
                 yield return item;
 

--- a/src/Wolfgang.Etl.TestKit/FaultyTransformer.cs
+++ b/src/Wolfgang.Etl.TestKit/FaultyTransformer.cs
@@ -328,7 +328,7 @@ public class FaultyTransformer<T> : TransformerBase<T, T, Report>
 
     /// <inheritdoc/>
     protected override Report CreateProgressReport() =>
-        new(CurrentItemCount) { StartedAt = StartedAt, Elapsed = Elapsed };
+        new(CurrentItemCount, StartedAt, Elapsed);
 
 
 

--- a/src/Wolfgang.Etl.TestKit/PublicAPI.Shipped.txt
+++ b/src/Wolfgang.Etl.TestKit/PublicAPI.Shipped.txt
@@ -62,3 +62,5 @@ override Wolfgang.Etl.TestKit.TestTransformer<T>.CreateProgressReport() -> Wolfg
 override Wolfgang.Etl.TestKit.TestTransformer<T>.CreateProgressTimer(System.IProgress<Wolfgang.Etl.Abstractions.Report> progress) -> Wolfgang.Etl.Abstractions.IProgressTimer
 override Wolfgang.Etl.TestKit.TestTransformer<T>.Dispose(bool disposing) -> void
 override Wolfgang.Etl.TestKit.TestTransformer<T>.TransformWorkerAsync(System.Collections.Generic.IAsyncEnumerable<T> items, System.Threading.CancellationToken token) -> System.Collections.Generic.IAsyncEnumerable<T>
+Wolfgang.Etl.TestKit.TestLoader<T>.IsDryRun.get -> bool
+Wolfgang.Etl.TestKit.TestLoader<T>.IsDryRun.set -> void

--- a/src/Wolfgang.Etl.TestKit/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.TestKit/PublicAPI.Unshipped.txt
@@ -1,6 +1,4 @@
 #nullable enable
-Wolfgang.Etl.TestKit.TestLoader<T>.IsDryRun.get -> bool
-Wolfgang.Etl.TestKit.TestLoader<T>.IsDryRun.set -> void
 Wolfgang.Etl.TestKit.FaultyExtractor<T>.SkipErrors() -> Wolfgang.Etl.TestKit.FaultyExtractor<T>!
 Wolfgang.Etl.TestKit.FaultyExtractor<T>.HandleErrorsWith(System.Func<Wolfgang.Etl.Abstractions.ItemErrorContext!, Wolfgang.Etl.Abstractions.ItemErrorAction>! policy) -> Wolfgang.Etl.TestKit.FaultyExtractor<T>!
 Wolfgang.Etl.TestKit.FaultyExtractor<T>.CapturedErrors.get -> System.Collections.Generic.IReadOnlyList<Wolfgang.Etl.Abstractions.ItemErrorContext!>!

--- a/src/Wolfgang.Etl.TestKit/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.TestKit/PublicAPI.Unshipped.txt
@@ -1,3 +1,15 @@
 #nullable enable
 Wolfgang.Etl.TestKit.TestLoader<T>.IsDryRun.get -> bool
 Wolfgang.Etl.TestKit.TestLoader<T>.IsDryRun.set -> void
+Wolfgang.Etl.TestKit.FaultyExtractor<T>.SkipErrors() -> Wolfgang.Etl.TestKit.FaultyExtractor<T>!
+Wolfgang.Etl.TestKit.FaultyExtractor<T>.HandleErrorsWith(System.Func<Wolfgang.Etl.Abstractions.ItemErrorContext!, Wolfgang.Etl.Abstractions.ItemErrorAction>! policy) -> Wolfgang.Etl.TestKit.FaultyExtractor<T>!
+Wolfgang.Etl.TestKit.FaultyExtractor<T>.CapturedErrors.get -> System.Collections.Generic.IReadOnlyList<Wolfgang.Etl.Abstractions.ItemErrorContext!>!
+override Wolfgang.Etl.TestKit.FaultyExtractor<T>.OnItemError(Wolfgang.Etl.Abstractions.ItemErrorContext! context) -> Wolfgang.Etl.Abstractions.ItemErrorAction
+Wolfgang.Etl.TestKit.FaultyLoader<T>.SkipErrors() -> Wolfgang.Etl.TestKit.FaultyLoader<T>!
+Wolfgang.Etl.TestKit.FaultyLoader<T>.HandleErrorsWith(System.Func<Wolfgang.Etl.Abstractions.ItemErrorContext!, Wolfgang.Etl.Abstractions.ItemErrorAction>! policy) -> Wolfgang.Etl.TestKit.FaultyLoader<T>!
+Wolfgang.Etl.TestKit.FaultyLoader<T>.CapturedErrors.get -> System.Collections.Generic.IReadOnlyList<Wolfgang.Etl.Abstractions.ItemErrorContext!>!
+override Wolfgang.Etl.TestKit.FaultyLoader<T>.OnItemError(Wolfgang.Etl.Abstractions.ItemErrorContext! context) -> Wolfgang.Etl.Abstractions.ItemErrorAction
+Wolfgang.Etl.TestKit.FaultyTransformer<T>.SkipErrors() -> Wolfgang.Etl.TestKit.FaultyTransformer<T>!
+Wolfgang.Etl.TestKit.FaultyTransformer<T>.HandleErrorsWith(System.Func<Wolfgang.Etl.Abstractions.ItemErrorContext!, Wolfgang.Etl.Abstractions.ItemErrorAction>! policy) -> Wolfgang.Etl.TestKit.FaultyTransformer<T>!
+Wolfgang.Etl.TestKit.FaultyTransformer<T>.CapturedErrors.get -> System.Collections.Generic.IReadOnlyList<Wolfgang.Etl.Abstractions.ItemErrorContext!>!
+override Wolfgang.Etl.TestKit.FaultyTransformer<T>.OnItemError(Wolfgang.Etl.Abstractions.ItemErrorContext! context) -> Wolfgang.Etl.Abstractions.ItemErrorAction

--- a/src/Wolfgang.Etl.TestKit/TestExtractor.cs
+++ b/src/Wolfgang.Etl.TestKit/TestExtractor.cs
@@ -515,16 +515,12 @@ public class TestExtractor<T> : ExtractorBase<T, Report>
 
     /// <inheritdoc/>
     protected override Report CreateProgressReport() =>
-        new(CurrentItemCount)
-        {
-            StartedAt = StartedAt,
-            Elapsed = Elapsed,
-
-            // When the source is a materialized collection its size is a cheap, known
-            // total, so PercentComplete / EstimatedRemaining can be computed. An
-            // enumerator- or factory-backed source has no known total (stays null).
-            TotalItemCount = (_enumerable as ICollection<T>)?.Count,
-        };
+        // When the source is a materialized collection its size is a cheap, known total, so
+        // PercentComplete / EstimatedRemaining can be computed. An enumerator- or factory-backed
+        // source has no known total (stays null). The timing constructor (Abstractions 0.18.1)
+        // sets these via plain parameters, avoiding the init-setter cross-assembly modreq
+        // mismatch that broke netstandard2.0 consumers running on .NET 6/7.
+        new(CurrentItemCount, StartedAt, Elapsed, (_enumerable as ICollection<T>)?.Count);
 
 
 

--- a/src/Wolfgang.Etl.TestKit/TestExtractor.cs
+++ b/src/Wolfgang.Etl.TestKit/TestExtractor.cs
@@ -514,7 +514,8 @@ public class TestExtractor<T> : ExtractorBase<T, Report>
 
 
     /// <inheritdoc/>
-    protected override Report CreateProgressReport() => new(CurrentItemCount);
+    protected override Report CreateProgressReport() =>
+        new(CurrentItemCount) { StartedAt = StartedAt, Elapsed = Elapsed };
 
 
 

--- a/src/Wolfgang.Etl.TestKit/TestExtractor.cs
+++ b/src/Wolfgang.Etl.TestKit/TestExtractor.cs
@@ -515,7 +515,16 @@ public class TestExtractor<T> : ExtractorBase<T, Report>
 
     /// <inheritdoc/>
     protected override Report CreateProgressReport() =>
-        new(CurrentItemCount) { StartedAt = StartedAt, Elapsed = Elapsed };
+        new(CurrentItemCount)
+        {
+            StartedAt = StartedAt,
+            Elapsed = Elapsed,
+
+            // When the source is a materialized collection its size is a cheap, known
+            // total, so PercentComplete / EstimatedRemaining can be computed. An
+            // enumerator- or factory-backed source has no known total (stays null).
+            TotalItemCount = (_enumerable as ICollection<T>)?.Count,
+        };
 
 
 

--- a/src/Wolfgang.Etl.TestKit/TestLoader.cs
+++ b/src/Wolfgang.Etl.TestKit/TestLoader.cs
@@ -191,7 +191,8 @@ public class TestLoader<T> : LoaderBase<T, Report>, ISupportDryRun
 
 
     /// <inheritdoc/>
-    protected override Report CreateProgressReport() => new(CurrentItemCount);
+    protected override Report CreateProgressReport() =>
+        new(CurrentItemCount) { StartedAt = StartedAt, Elapsed = Elapsed };
 
 
 

--- a/src/Wolfgang.Etl.TestKit/TestLoader.cs
+++ b/src/Wolfgang.Etl.TestKit/TestLoader.cs
@@ -192,7 +192,7 @@ public class TestLoader<T> : LoaderBase<T, Report>, ISupportDryRun
 
     /// <inheritdoc/>
     protected override Report CreateProgressReport() =>
-        new(CurrentItemCount) { StartedAt = StartedAt, Elapsed = Elapsed };
+        new(CurrentItemCount, StartedAt, Elapsed);
 
 
 

--- a/src/Wolfgang.Etl.TestKit/TestTransformer.cs
+++ b/src/Wolfgang.Etl.TestKit/TestTransformer.cs
@@ -123,7 +123,7 @@ public class TestTransformer<T> : TransformerBase<T, T, Report>
 
     /// <inheritdoc/>
     protected override Report CreateProgressReport() =>
-        new(CurrentItemCount) { StartedAt = StartedAt, Elapsed = Elapsed };
+        new(CurrentItemCount, StartedAt, Elapsed);
 
 
 

--- a/src/Wolfgang.Etl.TestKit/TestTransformer.cs
+++ b/src/Wolfgang.Etl.TestKit/TestTransformer.cs
@@ -122,7 +122,8 @@ public class TestTransformer<T> : TransformerBase<T, T, Report>
 
 
     /// <inheritdoc/>
-    protected override Report CreateProgressReport() => new(CurrentItemCount);
+    protected override Report CreateProgressReport() =>
+        new(CurrentItemCount) { StartedAt = StartedAt, Elapsed = Elapsed };
 
 
 

--- a/src/Wolfgang.Etl.TestKit/Wolfgang.Etl.TestKit.csproj
+++ b/src/Wolfgang.Etl.TestKit/Wolfgang.Etl.TestKit.csproj
@@ -21,7 +21,7 @@
          is live on NuGet (otherwise pack fails NU1102). Intentional breaks in a
          MAJOR bump are recorded via a generated CompatibilitySuppressions.xml. -->
     <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>0.10.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>0.10.1</PackageValidationBaselineVersion>
     <Title>Wolfgang.Etl.TestKit</Title>
     <Description>An implementation of Extractor, Transformer and Loader for use in ETL examples and benchmarks. Built on Wolfgang.Etl.Abstractions.</Description>
     <PackageProjectUrl>https://github.com/Chris-Wolfgang/ETL-Test-Kit</PackageProjectUrl>

--- a/src/Wolfgang.Etl.TestKit/Wolfgang.Etl.TestKit.csproj
+++ b/src/Wolfgang.Etl.TestKit/Wolfgang.Etl.TestKit.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net462;net481;netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>
-    <Version>0.10.1</Version>
+    <Version>0.11.0</Version>
     <!-- Pin AssemblyVersion to a fixed binding-stability baseline so consumers
          do not need to recompile / add binding redirects on every minor/patch
          bump. Bump only on a deliberate breaking API change. FileVersion +
@@ -74,7 +74,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Bcl.Memory" Version="10.0.10" />
-    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.17.0" />
+    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.18.0" />
     <PackageReference Include="System.Linq.Async" Version="7.0.1" />
   </ItemGroup>
 

--- a/src/Wolfgang.Etl.TestKit/Wolfgang.Etl.TestKit.csproj
+++ b/src/Wolfgang.Etl.TestKit/Wolfgang.Etl.TestKit.csproj
@@ -74,7 +74,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Bcl.Memory" Version="10.0.10" />
-    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.18.0" />
+    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.18.1" />
     <PackageReference Include="System.Linq.Async" Version="7.0.1" />
   </ItemGroup>
 

--- a/tests/Wolfgang.Etl.TestKit.Tests.Unit/DoubleReportTimingTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Unit/DoubleReportTimingTests.cs
@@ -50,11 +50,38 @@ public class DoubleReportTimingTests
         Assert.True(report.ItemsPerSecond >= 0);
     }
 
+    [Fact]
+    public async Task CreateProgressReport_for_a_collection_source_surfaces_TotalItemCount()
+    {
+        var sut = new ExposedTestExtractor<int>(new List<int> { 1, 2, 3, 4, 5 });
+
+        await sut.ExtractAsync().ToListAsync();
+        var report = sut.GetProgressReport();
+
+        Assert.Equal(5, report.TotalItemCount);
+        Assert.Equal(100d, report.PercentComplete!.Value);
+    }
+
+    [Fact]
+    public void CreateProgressReport_for_an_enumerator_source_has_no_TotalItemCount()
+    {
+        var sut = new ExposedTestExtractor<int>(Enumerable.Range(1, 3).GetEnumerator());
+
+        var report = sut.GetProgressReport();
+
+        Assert.Null(report.TotalItemCount);
+    }
+
     private sealed class ExposedTestExtractor<T> : TestExtractor<T>
         where T : notnull
     {
         public ExposedTestExtractor(IEnumerable<T> items)
             : base(items)
+        {
+        }
+
+        public ExposedTestExtractor(IEnumerator<T> enumerator)
+            : base(enumerator)
         {
         }
 

--- a/tests/Wolfgang.Etl.TestKit.Tests.Unit/DoubleReportTimingTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Unit/DoubleReportTimingTests.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+using Xunit;
+
+namespace Wolfgang.Etl.TestKit.Tests.Unit;
+
+/// <summary>
+/// Verifies that the doubles surface the base class's timing instrumentation (Abstractions
+/// 0.14.0) in the <see cref="Report"/> they build — <see cref="Report.StartedAt"/> and
+/// <see cref="Report.Elapsed"/>, which in turn drive <see cref="Report.ItemsPerSecond"/>. The
+/// <c>CreateProgressReport</c> override is byte-identical across all six doubles, so
+/// <see cref="TestExtractor{T}"/> stands in as the representative.
+/// </summary>
+public class DoubleReportTimingTests
+{
+    [Fact]
+    public void CreateProgressReport_before_any_run_has_no_StartedAt()
+    {
+        var sut = new ExposedTestExtractor<int>(new List<int> { 1, 2, 3 });
+
+        var report = sut.GetProgressReport();
+
+        Assert.Null(report.StartedAt);
+    }
+
+    [Fact]
+    public async Task CreateProgressReport_after_a_run_surfaces_StartedAt_and_Elapsed()
+    {
+        var sut = new ExposedTestExtractor<int>(new List<int> { 1, 2, 3 });
+
+        await sut.ExtractAsync().ToListAsync();
+        var report = sut.GetProgressReport();
+
+        Assert.NotNull(report.StartedAt);
+        Assert.True(report.Elapsed >= TimeSpan.Zero);
+        Assert.Equal(3, report.CurrentItemCount);
+    }
+
+    [Fact]
+    public async Task CreateProgressReport_after_a_run_computes_a_non_negative_throughput()
+    {
+        var sut = new ExposedTestExtractor<int>(Enumerable.Range(0, 50).ToList());
+
+        await sut.ExtractAsync().ToListAsync();
+        var report = sut.GetProgressReport();
+
+        Assert.True(report.ItemsPerSecond >= 0);
+    }
+
+    private sealed class ExposedTestExtractor<T> : TestExtractor<T>
+        where T : notnull
+    {
+        public ExposedTestExtractor(IEnumerable<T> items)
+            : base(items)
+        {
+        }
+
+        public Report GetProgressReport() => CreateProgressReport();
+    }
+}

--- a/tests/Wolfgang.Etl.TestKit.Tests.Unit/FaultyExtractorErrorHookTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Unit/FaultyExtractorErrorHookTests.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+using Xunit;
+
+namespace Wolfgang.Etl.TestKit.Tests.Unit;
+
+/// <summary>
+/// Tests for the Abstractions 0.18.0 error-hook support on <see cref="FaultyExtractor{T}"/>
+/// (<c>SkipErrors</c>, <c>HandleErrorsWith</c>, <c>CapturedErrors</c>, and the
+/// <c>OnItemError</c>/<c>HandleItemError</c> routing).
+/// </summary>
+public class FaultyExtractorErrorHookTests
+{
+    private static List<int> Items() => new List<int> { 1, 2, 3, 4, 5 };
+
+    [Fact]
+    public async Task ExtractAsync_when_no_error_policy_configured_propagates_the_fault()
+    {
+        var boom = new IOException("boom");
+        var sut = new FaultyExtractor<int>(Items()).ThrowAt(2, boom);
+
+        var thrown = await Assert.ThrowsAsync<IOException>
+        (
+            async () => await sut.ExtractAsync().ToListAsync()
+        );
+
+        Assert.Same(boom, thrown);
+        Assert.Equal(0, sut.CurrentErrorItemCount);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_when_SkipErrors_discards_the_failed_item_and_continues()
+    {
+        var sut = new FaultyExtractor<int>(Items())
+            .ThrowAt(2, new FormatException("bad row"))
+            .SkipErrors();
+
+        var results = await sut.ExtractAsync().ToListAsync();
+
+        Assert.Equal(new[] { 1, 2, 4, 5 }, results);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_when_SkipErrors_counts_the_failure_as_an_error()
+    {
+        var sut = new FaultyExtractor<int>(Items())
+            .ThrowAt(2, new FormatException("bad row"))
+            .SkipErrors();
+
+        await sut.ExtractAsync().ToListAsync();
+
+        Assert.Equal(1, sut.CurrentErrorItemCount);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_when_SkipErrors_does_not_count_the_failure_as_an_intentional_skip()
+    {
+        var sut = new FaultyExtractor<int>(Items())
+            .ThrowAt(2, new FormatException("bad row"))
+            .SkipErrors();
+
+        await sut.ExtractAsync().ToListAsync();
+
+        Assert.Equal(0, sut.CurrentSkippedItemCount);
+        Assert.Equal(4, sut.CurrentItemCount);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_when_SkipErrors_records_the_failure_in_CapturedErrors()
+    {
+        var boom = new FormatException("bad row");
+        var sut = new FaultyExtractor<int>(Items())
+            .ThrowAt(2, boom)
+            .SkipErrors();
+
+        await sut.ExtractAsync().ToListAsync();
+
+        var captured = Assert.Single(sut.CapturedErrors);
+        Assert.Equal(3, captured.ItemNumber);
+        Assert.Same(boom, captured.Exception);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_when_HandleErrorsWith_returns_Abort_propagates_the_fault()
+    {
+        var boom = new IOException("fatal");
+        var sut = new FaultyExtractor<int>(Items())
+            .ThrowAt(2, boom)
+            .HandleErrorsWith(_ => ItemErrorAction.Abort);
+
+        var thrown = await Assert.ThrowsAsync<IOException>
+        (
+            async () => await sut.ExtractAsync().ToListAsync()
+        );
+
+        Assert.Same(boom, thrown);
+        Assert.Equal(0, sut.CurrentErrorItemCount);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_when_HandleErrorsWith_decides_per_exception_type()
+    {
+        var sut = new FaultyExtractor<int>(Items())
+            .ThrowAt(1, new FormatException("skip me"))
+            .ThrowAt(3, new IOException("abort me"))
+            .HandleErrorsWith(ctx => ctx.Exception is FormatException
+                ? ItemErrorAction.Skip
+                : ItemErrorAction.Abort);
+
+        var results = new List<int>();
+
+        await Assert.ThrowsAsync<IOException>
+        (
+            async () =>
+            {
+                await foreach (var item in sut.ExtractAsync())
+                {
+                    results.Add(item);
+                }
+            }
+        );
+
+        // Item at index 1 skipped (FormatException), then aborts at index 3 (IOException).
+        Assert.Equal(new[] { 1, 3 }, results);
+        Assert.Equal(1, sut.CurrentErrorItemCount);
+    }
+
+    [Fact]
+    public void HandleErrorsWith_when_policy_is_null_throws_ArgumentNullException()
+    {
+        var sut = new FaultyExtractor<int>(Items());
+
+        Assert.Throws<ArgumentNullException>(() => sut.HandleErrorsWith(null!));
+    }
+
+    [Fact]
+    public void CapturedErrors_when_no_fault_fired_is_empty()
+    {
+        var sut = new FaultyExtractor<int>(Items()).SkipErrors();
+
+        Assert.Empty(sut.CapturedErrors);
+    }
+}

--- a/tests/Wolfgang.Etl.TestKit.Tests.Unit/FaultyLoaderErrorHookTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Unit/FaultyLoaderErrorHookTests.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+using Xunit;
+
+namespace Wolfgang.Etl.TestKit.Tests.Unit;
+
+/// <summary>
+/// Tests for the Abstractions 0.18.0 error-hook support on <see cref="FaultyLoader{T}"/>.
+/// </summary>
+public class FaultyLoaderErrorHookTests
+{
+    private static IAsyncEnumerable<int> SourceAsync() =>
+        Enumerable.Range(1, 5).ToAsyncEnumerable();
+
+    [Fact]
+    public async Task LoadAsync_when_no_error_policy_configured_propagates_the_fault()
+    {
+        var boom = new IOException("boom");
+        var sut = new FaultyLoader<int>(collectItems: true).ThrowAt(2, boom);
+
+        var thrown = await Assert.ThrowsAsync<IOException>
+        (
+            async () => await sut.LoadAsync(SourceAsync())
+        );
+
+        Assert.Same(boom, thrown);
+        Assert.Equal(0, sut.CurrentErrorItemCount);
+    }
+
+    [Fact]
+    public async Task LoadAsync_when_SkipErrors_discards_the_failed_item_and_continues()
+    {
+        var sut = new FaultyLoader<int>(collectItems: true)
+            .ThrowAt(2, new FormatException("bad row"))
+            .SkipErrors();
+
+        await sut.LoadAsync(SourceAsync());
+
+        Assert.Equal(new[] { 1, 2, 4, 5 }, sut.GetCollectedItems());
+    }
+
+    [Fact]
+    public async Task LoadAsync_when_SkipErrors_counts_the_failure_as_an_error_not_a_skip()
+    {
+        var sut = new FaultyLoader<int>(collectItems: false)
+            .ThrowAt(2, new FormatException("bad row"))
+            .SkipErrors();
+
+        await sut.LoadAsync(SourceAsync());
+
+        Assert.Equal(1, sut.CurrentErrorItemCount);
+        Assert.Equal(0, sut.CurrentSkippedItemCount);
+        Assert.Equal(4, sut.CurrentItemCount);
+    }
+
+    [Fact]
+    public async Task LoadAsync_when_SkipErrors_records_the_failure_in_CapturedErrors()
+    {
+        var boom = new FormatException("bad row");
+        var sut = new FaultyLoader<int>(collectItems: false)
+            .ThrowAt(2, boom)
+            .SkipErrors();
+
+        await sut.LoadAsync(SourceAsync());
+
+        var captured = Assert.Single(sut.CapturedErrors);
+        Assert.Equal(3, captured.ItemNumber);
+        Assert.Same(boom, captured.Exception);
+    }
+
+    [Fact]
+    public async Task LoadAsync_when_HandleErrorsWith_returns_Abort_propagates_the_fault()
+    {
+        var boom = new IOException("fatal");
+        var sut = new FaultyLoader<int>(collectItems: false)
+            .ThrowAt(2, boom)
+            .HandleErrorsWith(_ => ItemErrorAction.Abort);
+
+        var thrown = await Assert.ThrowsAsync<IOException>
+        (
+            async () => await sut.LoadAsync(SourceAsync())
+        );
+
+        Assert.Same(boom, thrown);
+    }
+
+    [Fact]
+    public void HandleErrorsWith_when_policy_is_null_throws_ArgumentNullException()
+    {
+        var sut = new FaultyLoader<int>(collectItems: false);
+
+        Assert.Throws<ArgumentNullException>(() => sut.HandleErrorsWith(null!));
+    }
+}

--- a/tests/Wolfgang.Etl.TestKit.Tests.Unit/FaultyTransformerErrorHookTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Unit/FaultyTransformerErrorHookTests.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+using Xunit;
+
+namespace Wolfgang.Etl.TestKit.Tests.Unit;
+
+/// <summary>
+/// Tests for the Abstractions 0.18.0 error-hook support on <see cref="FaultyTransformer{T}"/>.
+/// </summary>
+public class FaultyTransformerErrorHookTests
+{
+    private static IAsyncEnumerable<int> SourceAsync() =>
+        Enumerable.Range(1, 5).ToAsyncEnumerable();
+
+    [Fact]
+    public async Task TransformAsync_when_no_error_policy_configured_propagates_the_fault()
+    {
+        var boom = new IOException("boom");
+        var sut = new FaultyTransformer<int>().ThrowAt(2, boom);
+
+        var thrown = await Assert.ThrowsAsync<IOException>
+        (
+            async () => await sut.TransformAsync(SourceAsync()).ToListAsync()
+        );
+
+        Assert.Same(boom, thrown);
+        Assert.Equal(0, sut.CurrentErrorItemCount);
+    }
+
+    [Fact]
+    public async Task TransformAsync_when_SkipErrors_discards_the_failed_item_and_continues()
+    {
+        var sut = new FaultyTransformer<int>()
+            .ThrowAt(2, new FormatException("bad row"))
+            .SkipErrors();
+
+        var results = await sut.TransformAsync(SourceAsync()).ToListAsync();
+
+        Assert.Equal(new[] { 1, 2, 4, 5 }, results);
+    }
+
+    [Fact]
+    public async Task TransformAsync_when_SkipErrors_counts_the_failure_as_an_error_not_a_skip()
+    {
+        var sut = new FaultyTransformer<int>()
+            .ThrowAt(2, new FormatException("bad row"))
+            .SkipErrors();
+
+        await sut.TransformAsync(SourceAsync()).ToListAsync();
+
+        Assert.Equal(1, sut.CurrentErrorItemCount);
+        Assert.Equal(0, sut.CurrentSkippedItemCount);
+        Assert.Equal(4, sut.CurrentItemCount);
+    }
+
+    [Fact]
+    public async Task TransformAsync_when_SkipErrors_records_the_failure_in_CapturedErrors()
+    {
+        var boom = new FormatException("bad row");
+        var sut = new FaultyTransformer<int>()
+            .ThrowAt(2, boom)
+            .SkipErrors();
+
+        await sut.TransformAsync(SourceAsync()).ToListAsync();
+
+        var captured = Assert.Single(sut.CapturedErrors);
+        Assert.Equal(3, captured.ItemNumber);
+        Assert.Same(boom, captured.Exception);
+    }
+
+    [Fact]
+    public async Task TransformAsync_when_HandleErrorsWith_returns_Abort_propagates_the_fault()
+    {
+        var boom = new IOException("fatal");
+        var sut = new FaultyTransformer<int>()
+            .ThrowAt(2, boom)
+            .HandleErrorsWith(_ => ItemErrorAction.Abort);
+
+        var thrown = await Assert.ThrowsAsync<IOException>
+        (
+            async () => await sut.TransformAsync(SourceAsync()).ToListAsync()
+        );
+
+        Assert.Same(boom, thrown);
+    }
+
+    [Fact]
+    public void HandleErrorsWith_when_policy_is_null_throws_ArgumentNullException()
+    {
+        var sut = new FaultyTransformer<int>();
+
+        Assert.Throws<ArgumentNullException>(() => sut.HandleErrorsWith(null!));
+    }
+}

--- a/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/FaultyExtractorErrorHandlingContractTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/FaultyExtractorErrorHandlingContractTests.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+
+namespace Wolfgang.Etl.TestKit.Xunit.Tests.Unit;
+
+/// <summary>
+/// Verifies that <see cref="FaultyExtractor{T}"/> satisfies the
+/// <see cref="ErrorHandlingContractTests{TSut}"/> contract, and serves as a reference example
+/// of wiring the error-hook contract for a custom extractor.
+/// </summary>
+public class FaultyExtractorErrorHandlingContractTests
+    : ErrorHandlingContractTests<FaultyExtractor<int>>
+{
+    /// <inheritdoc/>
+    protected override async Task<ErrorHandlingOutcome> RunSingleFaultScenarioAsync(ItemErrorAction policy)
+    {
+        // Five items with exactly one failing item (index 2) and two survivors after it.
+        var sut = new FaultyExtractor<int>(Enumerable.Range(1, 5).ToList())
+            .ThrowAt(2, new FormatException("bad row"))
+            .HandleErrorsWith(_ => policy);
+
+        var aborted = false;
+
+        try
+        {
+            await foreach (var _ in sut.ExtractAsync().ConfigureAwait(false))
+            {
+            }
+        }
+        catch (FormatException)
+        {
+            aborted = true;
+        }
+
+        return new ErrorHandlingOutcome
+        (
+            aborted,
+            sut.CurrentItemCount,
+            sut.CurrentErrorItemCount,
+            sut.CurrentSkippedItemCount
+        );
+    }
+}

--- a/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/FaultyLoaderErrorHandlingContractTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/FaultyLoaderErrorHandlingContractTests.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+
+namespace Wolfgang.Etl.TestKit.Xunit.Tests.Unit;
+
+/// <summary>
+/// Verifies that <see cref="FaultyLoader{T}"/> satisfies the
+/// <see cref="ErrorHandlingContractTests{TSut}"/> contract, and serves as a reference example
+/// of wiring the error-hook contract for a custom loader.
+/// </summary>
+public class FaultyLoaderErrorHandlingContractTests
+    : ErrorHandlingContractTests<FaultyLoader<int>>
+{
+    /// <inheritdoc/>
+    protected override async Task<ErrorHandlingOutcome> RunSingleFaultScenarioAsync(ItemErrorAction policy)
+    {
+        var sut = new FaultyLoader<int>(collectItems: false)
+            .ThrowAt(2, new FormatException("bad row"))
+            .HandleErrorsWith(_ => policy);
+
+        var aborted = false;
+
+        try
+        {
+            await sut.LoadAsync(Enumerable.Range(1, 5).ToAsyncEnumerable()).ConfigureAwait(false);
+        }
+        catch (FormatException)
+        {
+            aborted = true;
+        }
+
+        return new ErrorHandlingOutcome
+        (
+            aborted,
+            sut.CurrentItemCount,
+            sut.CurrentErrorItemCount,
+            sut.CurrentSkippedItemCount
+        );
+    }
+}

--- a/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/FaultyTransformerErrorHandlingContractTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/FaultyTransformerErrorHandlingContractTests.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+
+namespace Wolfgang.Etl.TestKit.Xunit.Tests.Unit;
+
+/// <summary>
+/// Verifies that <see cref="FaultyTransformer{T}"/> satisfies the
+/// <see cref="ErrorHandlingContractTests{TSut}"/> contract, and serves as a reference example
+/// of wiring the error-hook contract for a custom transformer.
+/// </summary>
+public class FaultyTransformerErrorHandlingContractTests
+    : ErrorHandlingContractTests<FaultyTransformer<int>>
+{
+    /// <inheritdoc/>
+    protected override async Task<ErrorHandlingOutcome> RunSingleFaultScenarioAsync(ItemErrorAction policy)
+    {
+        var sut = new FaultyTransformer<int>()
+            .ThrowAt(2, new FormatException("bad row"))
+            .HandleErrorsWith(_ => policy);
+
+        var aborted = false;
+
+        try
+        {
+            await foreach (var _ in sut.TransformAsync(Enumerable.Range(1, 5).ToAsyncEnumerable()).ConfigureAwait(false))
+            {
+            }
+        }
+        catch (FormatException)
+        {
+            aborted = true;
+        }
+
+        return new ErrorHandlingOutcome
+        (
+            aborted,
+            sut.CurrentItemCount,
+            sut.CurrentErrorItemCount,
+            sut.CurrentSkippedItemCount
+        );
+    }
+}

--- a/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/TestExtractorContractTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/TestExtractorContractTests.cs
@@ -27,6 +27,10 @@ public class TestExtractorContractTests
     protected override TestExtractor<int> CreateSutWithTimer(IProgressTimer timer) =>
         new TestExtractorWithTimer(Enumerable.Range(1, 5).ToList(), timer);
 
+    /// <inheritdoc/>
+    protected override TestExtractor<int> CreateSutOverSource(IEnumerable<int> source) =>
+        new TestExtractor<int>(source);
+
 
 
     // Exposes the protected timer constructor of TestExtractor<T> for contract testing.

--- a/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/TestExtractorDisposableContractTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/TestExtractorDisposableContractTests.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Wolfgang.Etl.TestKit.Xunit.Tests.Unit;
+
+/// <summary>
+/// Verifies that <see cref="TestExtractor{T}"/> satisfies the
+/// <see cref="DisposableStageContractTests{TSut}"/> contract (0.14 disposability + 0.17
+/// use-after-dispose guard), and serves as a reference example for a custom extractor.
+/// </summary>
+public class TestExtractorDisposableContractTests
+    : DisposableStageContractTests<TestExtractor<int>>
+{
+    /// <inheritdoc/>
+    protected override TestExtractor<int> CreateSut() =>
+        new TestExtractor<int>(new List<int> { 1, 2, 3 });
+
+    /// <inheritdoc/>
+    protected override async Task<bool> InvokeReportsObjectDisposedAsync(bool disposeFirst, bool useAsyncDispose)
+    {
+        var sut = CreateSut();
+
+        if (disposeFirst)
+        {
+            if (useAsyncDispose)
+            {
+                await sut.DisposeAsync().ConfigureAwait(false);
+            }
+            else
+            {
+                sut.Dispose();
+            }
+        }
+
+        try
+        {
+            await foreach (var _ in sut.ExtractAsync().ConfigureAwait(false))
+            {
+            }
+
+            return false;
+        }
+        catch (ObjectDisposedException)
+        {
+            return true;
+        }
+    }
+}

--- a/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/TestLoaderDisposableContractTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/TestLoaderDisposableContractTests.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Wolfgang.Etl.TestKit.Xunit.Tests.Unit;
+
+/// <summary>
+/// Verifies that <see cref="TestLoader{T}"/> satisfies the
+/// <see cref="DisposableStageContractTests{TSut}"/> contract (0.14 disposability + 0.17
+/// use-after-dispose guard), and serves as a reference example for a custom loader.
+/// </summary>
+public class TestLoaderDisposableContractTests
+    : DisposableStageContractTests<TestLoader<int>>
+{
+    /// <inheritdoc/>
+    protected override TestLoader<int> CreateSut() =>
+        new TestLoader<int>(collectItems: false);
+
+    /// <inheritdoc/>
+    protected override async Task<bool> InvokeReportsObjectDisposedAsync(bool disposeFirst, bool useAsyncDispose)
+    {
+        var sut = CreateSut();
+
+        if (disposeFirst)
+        {
+            if (useAsyncDispose)
+            {
+                await sut.DisposeAsync().ConfigureAwait(false);
+            }
+            else
+            {
+                sut.Dispose();
+            }
+        }
+
+        try
+        {
+            await sut.LoadAsync(Enumerable.Range(1, 3).ToAsyncEnumerable()).ConfigureAwait(false);
+
+            return false;
+        }
+        catch (ObjectDisposedException)
+        {
+            return true;
+        }
+    }
+}

--- a/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/TestTransformerDisposableContractTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/TestTransformerDisposableContractTests.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Wolfgang.Etl.TestKit.Xunit.Tests.Unit;
+
+/// <summary>
+/// Verifies that <see cref="TestTransformer{T}"/> satisfies the
+/// <see cref="DisposableStageContractTests{TSut}"/> contract (0.14 disposability + 0.17
+/// use-after-dispose guard), and serves as a reference example for a custom transformer.
+/// </summary>
+public class TestTransformerDisposableContractTests
+    : DisposableStageContractTests<TestTransformer<int>>
+{
+    /// <inheritdoc/>
+    protected override TestTransformer<int> CreateSut() =>
+        new TestTransformer<int>();
+
+    /// <inheritdoc/>
+    protected override async Task<bool> InvokeReportsObjectDisposedAsync(bool disposeFirst, bool useAsyncDispose)
+    {
+        var sut = CreateSut();
+
+        if (disposeFirst)
+        {
+            if (useAsyncDispose)
+            {
+                await sut.DisposeAsync().ConfigureAwait(false);
+            }
+            else
+            {
+                sut.Dispose();
+            }
+        }
+
+        try
+        {
+            await foreach (var _ in sut.TransformAsync(Enumerable.Range(1, 3).ToAsyncEnumerable()).ConfigureAwait(false))
+            {
+            }
+
+            return false;
+        }
+        catch (ObjectDisposedException)
+        {
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
Release **0.11.0** (MINOR) — adopts the `Wolfgang.Etl.Abstractions` 0.18 error hook (built against **0.18.1**) and closes the earlier-version contract-coverage gaps. New public API only; no breaking change. PackageValidation baseline stays 0.10.1.

## Highlights

**0.18 — per-item error hook**
- `FaultyExtractor<T>` / `FaultyLoader<T>` / `FaultyTransformer<T>` gain `SkipErrors()`, `HandleErrorsWith(policy)`, `CapturedErrors` — an injected `ThrowAt` fault routes through the base `HandleItemError` (Skip → counts `CurrentErrorItemCount`, continues; Abort → rethrow; no policy → fail-fast, unchanged).
- `ErrorHandlingContractTests<TSut>` + `ErrorHandlingOutcome` — opt-in base verifying the hook.

**0.17 — disposability**
- `DisposableStageContractTests<TSut>` — verifies `ObjectDisposedException` after `Dispose()`/`DisposeAsync()` and idempotent double-dispose.

**0.14 — progress timing**
- The doubles' `CreateProgressReport()` surfaces `StartedAt`/`Elapsed` (→ `ItemsPerSecond`); the extractor doubles set `TotalItemCount` from a known `ICollection<T>` source (→ `PercentComplete`/`EstimatedRemaining`).

**0.16 — pipeline**
- Sample composes the doubles via `EtlPipeline.Create().From().Through().To().RunAsync()`, incl. a `SkipErrors()` error-hook pipeline.

**Contract-test completeness**
- `CurrentItemCount`/`CurrentSkippedItemCount`/`CurrentErrorItemCount` default-zero + skip-count-tracking tests on all three base classes (#248).
- "No over-read" tests (#49) on all three bases: a stage stops pulling once `MaximumItemCount` is reached (≤ M+1 reads) or the run is cancelled; a pre-cancelled token reads nothing.
- Promoted the stranded 0.10.x entries from `PublicAPI.Unshipped` → `Shipped`.

## Verification
Full multi-TFM Release build clean (net462→net10.0); all tests green on net10.0 and net48.

Closes #248
Closes #49
