### PR TITLE
fix: build Report timing via the 0.18.1 constructor (net6/net7 MissingMethodException)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,11 +53,23 @@ public API only — no breaking change.
 
 ### Changed
 
-- Built against `Wolfgang.Etl.Abstractions` 0.17.0 → **0.18.0**.
+- Built against `Wolfgang.Etl.Abstractions` 0.17.0 → **0.18.1**.
+- The doubles build their progress `Report` via the new
+  `Report(int, DateTimeOffset?, TimeSpan, int?)` constructor (Abstractions 0.18.1) instead of
+  the object-initializer form, so setting the timing/total values is safe cross-assembly on
+  every target framework (see Fixed).
 - The doubles' `CreateProgressReport()` now surfaces the base's `StartedAt`/`Elapsed` timing
   (Abstractions 0.14.0) in the `Report`, so `ItemsPerSecond` is computed for reported progress;
   the extractor doubles also set `TotalItemCount` from a materialized collection source so
   `PercentComplete`/`EstimatedRemaining` compute.
+
+### Fixed
+
+- Surfacing `Report` timing from the doubles no longer throws `MissingMethodException` on
+  **.NET 6 / .NET 7**. The doubles' `netstandard2.0` assembly (which those runtimes load) set the
+  `Report` timing via the object-initializer (`init`) form, whose `IsExternalInit` modreq did not
+  match the modern Abstractions assembly resolved at runtime. The doubles now use the plain
+  `Report` timing constructor added in Abstractions 0.18.1, which is safe across every framework.
 
 ## [0.10.1] - 2026-07-24
 

--- a/src/Wolfgang.Etl.TestKit.Xunit/Wolfgang.Etl.TestKit.Xunit.csproj
+++ b/src/Wolfgang.Etl.TestKit.Xunit/Wolfgang.Etl.TestKit.Xunit.csproj
@@ -79,7 +79,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Bcl.Memory" Version="10.0.10" />
-    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.18.0" />
+    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.18.1" />
     <PackageReference Include="System.Linq.Async" Version="7.0.1" />
     <PackageReference Include="xunit.abstractions" Version="2.0.3" />
     <PackageReference Include="xunit.assert" Version="2.9.3" />

--- a/src/Wolfgang.Etl.TestKit/FaultyExtractor.cs
+++ b/src/Wolfgang.Etl.TestKit/FaultyExtractor.cs
@@ -353,15 +353,11 @@ public class FaultyExtractor<T> : ExtractorBase<T, Report>
 
     /// <inheritdoc/>
     protected override Report CreateProgressReport() =>
-        new(CurrentItemCount)
-        {
-            StartedAt = StartedAt,
-            Elapsed = Elapsed,
-
-            // When the source is a materialized collection its size is a cheap, known
-            // total, so PercentComplete / EstimatedRemaining can be computed.
-            TotalItemCount = (_items as ICollection<T>)?.Count,
-        };
+        // When the source is a materialized collection its size is a cheap, known total, so
+        // PercentComplete / EstimatedRemaining can be computed. The timing constructor
+        // (Abstractions 0.18.1) sets these via plain parameters, avoiding the init-setter
+        // cross-assembly modreq mismatch that broke netstandard2.0 consumers on .NET 6/7.
+        new(CurrentItemCount, StartedAt, Elapsed, (_items as ICollection<T>)?.Count);
 
 
 

--- a/src/Wolfgang.Etl.TestKit/FaultyLoader.cs
+++ b/src/Wolfgang.Etl.TestKit/FaultyLoader.cs
@@ -364,7 +364,7 @@ public class FaultyLoader<T> : LoaderBase<T, Report>
 
     /// <inheritdoc/>
     protected override Report CreateProgressReport() =>
-        new(CurrentItemCount) { StartedAt = StartedAt, Elapsed = Elapsed };
+        new(CurrentItemCount, StartedAt, Elapsed);
 
 
 

--- a/src/Wolfgang.Etl.TestKit/FaultyTransformer.cs
+++ b/src/Wolfgang.Etl.TestKit/FaultyTransformer.cs
@@ -328,7 +328,7 @@ public class FaultyTransformer<T> : TransformerBase<T, T, Report>
 
     /// <inheritdoc/>
     protected override Report CreateProgressReport() =>
-        new(CurrentItemCount) { StartedAt = StartedAt, Elapsed = Elapsed };
+        new(CurrentItemCount, StartedAt, Elapsed);
 
 
 

--- a/src/Wolfgang.Etl.TestKit/TestExtractor.cs
+++ b/src/Wolfgang.Etl.TestKit/TestExtractor.cs
@@ -515,16 +515,12 @@ public class TestExtractor<T> : ExtractorBase<T, Report>
 
     /// <inheritdoc/>
     protected override Report CreateProgressReport() =>
-        new(CurrentItemCount)
-        {
-            StartedAt = StartedAt,
-            Elapsed = Elapsed,
-
-            // When the source is a materialized collection its size is a cheap, known
-            // total, so PercentComplete / EstimatedRemaining can be computed. An
-            // enumerator- or factory-backed source has no known total (stays null).
-            TotalItemCount = (_enumerable as ICollection<T>)?.Count,
-        };
+        // When the source is a materialized collection its size is a cheap, known total, so
+        // PercentComplete / EstimatedRemaining can be computed. An enumerator- or factory-backed
+        // source has no known total (stays null). The timing constructor (Abstractions 0.18.1)
+        // sets these via plain parameters, avoiding the init-setter cross-assembly modreq
+        // mismatch that broke netstandard2.0 consumers running on .NET 6/7.
+        new(CurrentItemCount, StartedAt, Elapsed, (_enumerable as ICollection<T>)?.Count);
 
 
 

--- a/src/Wolfgang.Etl.TestKit/TestLoader.cs
+++ b/src/Wolfgang.Etl.TestKit/TestLoader.cs
@@ -192,7 +192,7 @@ public class TestLoader<T> : LoaderBase<T, Report>, ISupportDryRun
 
     /// <inheritdoc/>
     protected override Report CreateProgressReport() =>
-        new(CurrentItemCount) { StartedAt = StartedAt, Elapsed = Elapsed };
+        new(CurrentItemCount, StartedAt, Elapsed);
 
 
 

--- a/src/Wolfgang.Etl.TestKit/TestTransformer.cs
+++ b/src/Wolfgang.Etl.TestKit/TestTransformer.cs
@@ -123,7 +123,7 @@ public class TestTransformer<T> : TransformerBase<T, T, Report>
 
     /// <inheritdoc/>
     protected override Report CreateProgressReport() =>
-        new(CurrentItemCount) { StartedAt = StartedAt, Elapsed = Elapsed };
+        new(CurrentItemCount, StartedAt, Elapsed);
 
 
 

--- a/src/Wolfgang.Etl.TestKit/Wolfgang.Etl.TestKit.csproj
+++ b/src/Wolfgang.Etl.TestKit/Wolfgang.Etl.TestKit.csproj
@@ -74,7 +74,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Bcl.Memory" Version="10.0.10" />
-    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.18.0" />
+    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.18.1" />
     <PackageReference Include="System.Linq.Async" Version="7.0.1" />
   </ItemGroup>
 


### PR DESCRIPTION
Into `vNext` for 0.11.0 — fixes the **Stage 1 / net6.0** failure on #254.

## Problem
The doubles surfaced `Report` timing via the object-initializer (`init`) form. On **.NET 6/7**, a consumer loads TestKit's `netstandard2.0` assembly but resolves Abstractions' *modern* assembly at runtime, so the `init` setter's `IsExternalInit` modreq didn't match → `MissingMethodException: Report.set_StartedAt`. (net462/net8/net10 matched, so they were green.)

## Fix
- The 6 doubles build their `Report` via the new **`Report(int, DateTimeOffset?, TimeSpan, int?)` constructor** (Abstractions **0.18.1**) instead of the initializer. A plain ctor has no modreq, so its signature is identical on every TFM. Behavior is unchanged (same values, same validation).
- Bumped the `Wolfgang.Etl.Abstractions` reference `0.18.0 → 0.18.1`.

## Verified
Clean restore against the published NuGet **0.18.1**: the previously-failing **net6.0** suite passes **194/194** (was 175 pass / 19 fail).

Once merged, #254's `net6.0` stage goes green.