### PR TITLE
Add EtlPipelineContractTests base for pipeline composition (#256)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `EtlPipelineContractTests<TItem, TProgress>` — an opt-in xUnit contract-test base that composes a
+  source and a loader sink into the `Wolfgang.Etl.Abstractions` 0.16 `EtlPipeline`
+  (`EtlPipeline.Create().From(...).To(...).RunAsync()`) and verifies the run delivers every source
+  item and reports each record as extracted and loaded via `EtlPipelineProgress`. The derived test
+  supplies `CreateSourceItems()`, `CreateSink()`, and `GetLoadedItems()`; the harness-managed `Sink`
+  property carries the composed loader so the read-back needs no null-argument validation (#256).
+
 ### Changed
 
 ### Deprecated

--- a/README.md
+++ b/README.md
@@ -251,6 +251,28 @@ public sealed class MyExtractorDisposableTests
 }
 ```
 
+### xUnit — verifying pipeline composition
+
+Derive from `EtlPipelineContractTests<TItem, TProgress>` to verify that your loader composes into the `Wolfgang.Etl.Abstractions` 0.16 `EtlPipeline` and runs end-to-end — every source item is delivered, and the `EtlPipelineProgress` counts each record as extracted and loaded. The harness composes and runs the pipeline; you supply the source data, the sink, and a read-back:
+
+```csharp
+using System.Collections.Generic;
+using Wolfgang.Etl.Abstractions;
+using Wolfgang.Etl.TestKit.Xunit;
+
+public sealed class MyLoaderPipelineTests
+    : EtlPipelineContractTests<MyRecord, MyProgress>
+{
+    protected override IReadOnlyList<MyRecord> CreateSourceItems() =>
+        new List<MyRecord> { new("a"), new("b"), new("c") };
+
+    protected override LoaderBase<MyRecord, MyProgress> CreateSink() => new MyLoader();
+
+    // Read back what the harness-composed `Sink` received, or return null to skip the delivery check.
+    protected override IReadOnlyList<MyRecord>? GetLoadedItems() => ((MyLoader)Sink).Written;
+}
+```
+
 ### xUnit add-on — contract-testing your own ETL types
 
 Derive your test class from the matching contract base and implement the abstract factory methods. You inherit the complete suite of `ExtractAsync` / `TransformAsync` / `LoadAsync` contract tests — all overloads, cancellation, progress, `SkipItemCount`, and `MaximumItemCount` — with zero boilerplate.

--- a/src/Wolfgang.Etl.TestKit.Xunit/EtlPipelineContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/EtlPipelineContractTests.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+using Xunit;
+
+namespace Wolfgang.Etl.TestKit.Xunit;
+
+/// <summary>
+/// Abstract base class providing xUnit contract tests for composing a source and a sink into the
+/// <c>Wolfgang.Etl.Abstractions</c> 0.16 <see cref="EtlPipeline"/>
+/// (<c>EtlPipeline.Create().From(...).To(...).RunAsync()</c>) and for the
+/// <see cref="EtlPipelineProgress"/> it reports.
+/// </summary>
+/// <typeparam name="TItem">The item type flowing through the pipeline.</typeparam>
+/// <typeparam name="TProgress">The sink loader's progress report type.</typeparam>
+/// <remarks>
+/// <para>
+/// Inherit from this class to verify that your source composes with a loader sink into an
+/// <see cref="EtlPipeline"/> that runs end-to-end and delivers every item, and that its
+/// <see cref="EtlPipelineProgress"/> counts the records pulled from the source
+/// (<see cref="EtlPipelineProgress.ExtractedItemCount"/>) and delivered to the sink
+/// (<see cref="EtlPipelineProgress.LoadedItemCount"/>).
+/// </para>
+/// <para>
+/// Implement <see cref="CreateSourceItems"/> (the data the source streams), <see cref="CreateSink"/>
+/// (the loader), and <see cref="GetLoadedItems"/> (read what the harness-composed <see cref="Sink"/>
+/// received, or <see langword="null"/> if the loader does not expose it). The <see cref="Sink"/>
+/// property — rather than a parameter — carries the composed loader so the override needs no
+/// null-argument validation.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// public class MyPipelineContractTests
+///     : EtlPipelineContractTests&lt;MyRecord, MyProgress&gt;
+/// {
+///     protected override IReadOnlyList&lt;MyRecord&gt; CreateSourceItems() => new[] { ... };
+///     protected override LoaderBase&lt;MyRecord, MyProgress&gt; CreateSink() => new MyLoader();
+///     protected override IReadOnlyList&lt;MyRecord&gt;? GetLoadedItems() => ((MyLoader)Sink).Written;
+/// }
+/// </code>
+/// </example>
+public abstract class EtlPipelineContractTests<TItem, TProgress>
+    where TItem : notnull
+    where TProgress : notnull
+{
+    /// <summary>
+    /// The loader sink the harness composed into the pipeline for the current test. Read it from
+    /// <see cref="GetLoadedItems"/> to inspect what was delivered.
+    /// </summary>
+    protected LoaderBase<TItem, TProgress> Sink { get; private set; } = default!;
+
+    /// <summary>The items the source streams into the pipeline. Must return at least one item.</summary>
+    protected abstract IReadOnlyList<TItem> CreateSourceItems();
+
+    /// <summary>Creates the loader sink under test.</summary>
+    protected abstract LoaderBase<TItem, TProgress> CreateSink();
+
+    /// <summary>
+    /// Returns the items the harness-composed <see cref="Sink"/> received, or <see langword="null"/>
+    /// if the loader does not expose them (then the delivery assertion is skipped).
+    /// </summary>
+    protected abstract IReadOnlyList<TItem>? GetLoadedItems();
+
+
+
+    /// <summary>
+    /// Verifies that <c>EtlPipeline.Create().From(source).To(sink).RunAsync()</c> runs end-to-end
+    /// and the sink receives every source item, in order.
+    /// </summary>
+    [Fact]
+    public async Task Pipeline_delivers_all_source_items_to_the_sink_Async()
+    {
+        var source = CreateSourceItems();
+        Assert.True(source.Count >= 1, "CreateSourceItems() must return at least one item.");
+
+        await RunPipelineAsync(source, progress: null).ConfigureAwait(false);
+
+        var loaded = GetLoadedItems();
+        if (loaded is not null)
+        {
+            Assert.Equal(source, loaded);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that the pipeline's <see cref="EtlPipelineProgress"/> reports every source record as
+    /// extracted and delivered, with no error-discarded records on a clean run.
+    /// </summary>
+    [Fact]
+    public async Task Pipeline_progress_counts_all_records_extracted_and_loaded_Async()
+    {
+        var source = CreateSourceItems();
+        Assert.True(source.Count >= 1, "CreateSourceItems() must return at least one item.");
+
+        var capture = new ProgressCapture<EtlPipelineProgress>();
+
+        await RunPipelineAsync(source, capture).ConfigureAwait(false);
+
+        var final = capture.FinalReport;
+        Assert.NotNull(final);
+        Assert.Equal(source.Count, final!.ExtractedItemCount);
+        Assert.Equal(source.Count, final.LoadedItemCount);
+        Assert.Equal(0, final.ErrorItemCount);
+    }
+
+    private Task RunPipelineAsync(IReadOnlyList<TItem> source, IProgress<EtlPipelineProgress>? progress)
+    {
+        Sink = CreateSink();
+
+        return EtlPipeline
+            .Create()
+            .From(source.ToAsyncEnumerable())
+            .To(Sink)
+            .RunAsync(progress);
+    }
+}

--- a/src/Wolfgang.Etl.TestKit.Xunit/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.TestKit.Xunit/PublicAPI.Unshipped.txt
@@ -1,1 +1,9 @@
 #nullable enable
+Wolfgang.Etl.TestKit.Xunit.EtlPipelineContractTests<TItem, TProgress>
+Wolfgang.Etl.TestKit.Xunit.EtlPipelineContractTests<TItem, TProgress>.EtlPipelineContractTests() -> void
+Wolfgang.Etl.TestKit.Xunit.EtlPipelineContractTests<TItem, TProgress>.Pipeline_delivers_all_source_items_to_the_sink_Async() -> System.Threading.Tasks.Task!
+Wolfgang.Etl.TestKit.Xunit.EtlPipelineContractTests<TItem, TProgress>.Pipeline_progress_counts_all_records_extracted_and_loaded_Async() -> System.Threading.Tasks.Task!
+Wolfgang.Etl.TestKit.Xunit.EtlPipelineContractTests<TItem, TProgress>.Sink.get -> Wolfgang.Etl.Abstractions.LoaderBase<TItem, TProgress>!
+abstract Wolfgang.Etl.TestKit.Xunit.EtlPipelineContractTests<TItem, TProgress>.CreateSink() -> Wolfgang.Etl.Abstractions.LoaderBase<TItem, TProgress>!
+abstract Wolfgang.Etl.TestKit.Xunit.EtlPipelineContractTests<TItem, TProgress>.CreateSourceItems() -> System.Collections.Generic.IReadOnlyList<TItem>!
+abstract Wolfgang.Etl.TestKit.Xunit.EtlPipelineContractTests<TItem, TProgress>.GetLoadedItems() -> System.Collections.Generic.IReadOnlyList<TItem>?

--- a/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/EtlPipelineProgressTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/EtlPipelineProgressTests.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+using Wolfgang.Etl.TestKit;
+using Xunit;
+
+namespace Wolfgang.Etl.TestKit.Xunit.Tests.Unit;
+
+/// <summary>
+/// Kit self-tests for the two <see cref="EtlPipeline"/> surfaces the contract base cannot reach with
+/// a plain source: the error count the pipeline aggregates when a stage skips a faulty item, and the
+/// <c>DisposingOwned</c> sink wrapper that disposes pipeline-owned resources after the run.
+/// </summary>
+public class EtlPipelineProgressTests
+{
+    [Fact]
+    public async Task Pipeline_progress_ErrorItemCount_reflects_a_skipped_faulty_item_Async()
+    {
+        var source = new FaultyExtractor<int>(new[] { 0, 1, 2, 3, 4 })
+            .ThrowAt(2, new FormatException("bad row"))
+            .SkipErrors();
+        var sink = new TestLoader<int>(collectItems: true);
+        var capture = new ProgressCapture<EtlPipelineProgress>();
+
+        await EtlPipeline
+            .Create()
+            .From(source)
+            .To(sink)
+            .RunAsync(capture)
+            .ConfigureAwait(false);
+
+        var final = capture.FinalReport;
+        Assert.NotNull(final);
+        Assert.Equal(1, final!.ErrorItemCount);
+        Assert.Equal(4, final.LoadedItemCount);
+    }
+
+
+
+    [Fact]
+    public async Task DisposingOwned_disposes_pipeline_owned_resources_after_the_run_Async()
+    {
+        var owned = new TrackingDisposable();
+        var sink = new TestLoader<int>(collectItems: false);
+
+        await EtlPipeline
+            .Create()
+            .From(new[] { 1, 2, 3 }.ToAsyncEnumerable())
+            .To(sink)
+            .DisposingOwned(owned)
+            .RunAsync()
+            .ConfigureAwait(false);
+
+        Assert.True(owned.WasDisposed);
+    }
+
+
+
+    private sealed class TrackingDisposable : IDisposable
+    {
+        public bool WasDisposed { get; private set; }
+
+
+
+        public void Dispose() => WasDisposed = true;
+    }
+}

--- a/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/TestLoaderPipelineContractTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/TestLoaderPipelineContractTests.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+using Wolfgang.Etl.Abstractions;
+using Wolfgang.Etl.TestKit;
+using Wolfgang.Etl.TestKit.Xunit;
+
+namespace Wolfgang.Etl.TestKit.Xunit.Tests.Unit;
+
+/// <summary>
+/// Exercises <see cref="EtlPipelineContractTests{TItem, TProgress}"/> by composing a plain source
+/// with a <see cref="TestLoader{T}"/> sink, confirming the contract base drives a real
+/// <see cref="EtlPipeline"/> end-to-end.
+/// </summary>
+public class TestLoaderPipelineContractTests
+    : EtlPipelineContractTests<int, Report>
+{
+    protected override IReadOnlyList<int> CreateSourceItems() =>
+        new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+
+
+
+    protected override LoaderBase<int, Report> CreateSink() =>
+        new TestLoader<int>(collectItems: true);
+
+
+
+    protected override IReadOnlyList<int>? GetLoadedItems() =>
+        ((TestLoader<int>)Sink).GetCollectedItems();
+}


### PR DESCRIPTION
Adds an opt-in xUnit contract-test base — `EtlPipelineContractTests<TItem, TProgress>` — that composes a source and a loader sink into the `Wolfgang.Etl.Abstractions` 0.16 `EtlPipeline` (`Create().From(...).To(...).RunAsync()`) and verifies end-to-end behaviour. This promotes the 0.11 EtlPipeline coverage from a *sample* to a reusable contract base (0.12.0 cycle).

## What it verifies

- **Delivery** — every source item reaches the sink, in order.
- **Progress** — `EtlPipelineProgress` counts each record as extracted *and* loaded, with `ErrorItemCount == 0` on a clean run.

The harness composes and runs the pipeline; the derived test supplies `CreateSourceItems()`, `CreateSink()`, and `GetLoadedItems()`. The composed loader is carried on a harness-managed `Sink` property rather than passed as a parameter, so the read-back override needs no null-argument validation — CA1062-safe, matching the `ErrorHandling`/`AllocationBudget` contract-base pattern.

## Coverage the consumer base can't reach with a plain source

Kit self-tests (`EtlPipelineProgressTests`) cover the two remaining `EtlPipeline` surfaces directly against the doubles:

- `EtlPipelineProgress.ErrorItemCount` reflecting a `FaultyExtractor` item skipped through the 0.18 error hook (`.ThrowAt(...).SkipErrors()`).
- `DisposingOwned(...)` disposing pipeline-owned resources after the run.

`TestLoaderPipelineContractTests` wires the new base against `TestLoader<int>`.

## Housekeeping

- `PublicAPI.Unshipped.txt`, README ("xUnit — verifying pipeline composition"), and CHANGELOG `[Unreleased]` updated.
- Full multi-TFM Release build clean (0 warnings); net10.0 pipeline tests pass (4/4).

Closes #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)