### PR TITLE
Add capture-only SnapshotTestLoader<T> for approval testing (#11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `SnapshotTestLoader<T>` — a capture-only loader double that records every item a pipeline loads and
+  renders them as a single deterministic, diff-friendly `Snapshot` string (one formatted line per
+  item, joined by `\n`) plus a `LoadedItems` list. Designed to hand off to an approval / snapshot
+  framework such as [Verify](https://github.com/VerifyTests/Verify): it does no file I/O and takes
+  **no dependency on any snapshot framework**, so referencing `Wolfgang.Etl.TestKit` never pulls one
+  in. The default constructor formats each item with `ToString()` (diff-friendly for `record` types);
+  a `Func<T, string>` constructor lets you project the fields under test and scrub non-deterministic
+  values (timestamps, GUIDs, auto-increment IDs). `SkipItemCount` / `MaximumItemCount` bound the
+  capture. README documents the fleet snapshot convention (dedicated single-TFM `*.Tests.Snapshot`
+  project, `Verify.Xunit`, `.verified.txt` golden files under `Snapshots/`). (#11, closes #129)
+
 ### Changed
 
 ### Deprecated

--- a/README.md
+++ b/README.md
@@ -161,6 +161,29 @@ var picky = new FaultyExtractor<string>(source)
 // holds the ItemErrorContext for the discarded item.
 ```
 
+### Core — snapshot / approval testing with `SnapshotTestLoader<T>`
+
+`SnapshotTestLoader<T>` captures every item your pipeline loads and renders them as a single, deterministic, diff-friendly `Snapshot` string — ready to hand to an approval / snapshot framework such as [Verify](https://github.com/VerifyTests/Verify). Instead of writing per-field assertions for every record, you lock in the whole output and let the framework flag any drift.
+
+It is deliberately **capture-only**: no file I/O, and **no dependency on any snapshot framework**, so referencing `Wolfgang.Etl.TestKit` never pulls one in. The framework (in your own snapshot test project) owns the golden `.verified.txt` file, the diff, and the approval workflow; the loader only produces the content to lock in.
+
+```csharp
+using Wolfgang.Etl.TestKit;
+using VerifyXunit;      // in your snapshot test project only
+
+// Project only the fields under test and scrub non-deterministic values
+// (timestamps, GUIDs, auto-increment IDs) so the snapshot stays stable:
+var loader = new SnapshotTestLoader<OrderRecord>(o => $"<id>|{o.Customer}|{o.Total:0.00}");
+
+await loader.LoadAsync(pipeline.ExtractAsync());
+
+await Verify(loader.Snapshot);   // Verify owns the .verified.txt golden file + diff
+```
+
+`Snapshot` is one formatted line per item joined by `\n` (a fixed line feed, not `Environment.NewLine`, so snapshots are stable across operating systems). The default constructor formats each item with its `ToString()` — diff-friendly for `record` types — and `LoadedItems` exposes the raw captured items. `SkipItemCount` / `MaximumItemCount` bound what is captured; each `LoadAsync` clears the buffer first.
+
+**The fleet convention** (see ETL-FixedWidth, ETL-DbClient, ETL-Json): put snapshot tests in a **dedicated `*.Tests.Snapshot` project targeting a single modern TFM** (e.g. `net10.0` — Verify needs net6+ and the output is TFM-agnostic, which keeps snapshot filenames stable), reference `Verify.Xunit`, commit the `.verified.txt` golden files under `Snapshots/`, and gitignore the `.received.txt` files written during local iteration.
+
 ### xUnit — capturing and asserting on progress
 
 `ProgressCapture<T>` is an `IProgress<T>` that records every report; pass it straight to any progress-aware overload, then assert with `ProgressAssert`:

--- a/src/Wolfgang.Etl.TestKit/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.TestKit/PublicAPI.Unshipped.txt
@@ -1,1 +1,8 @@
 #nullable enable
+Wolfgang.Etl.TestKit.SnapshotTestLoader<T>
+Wolfgang.Etl.TestKit.SnapshotTestLoader<T>.SnapshotTestLoader() -> void
+Wolfgang.Etl.TestKit.SnapshotTestLoader<T>.SnapshotTestLoader(System.Func<T, string!>! formatter) -> void
+Wolfgang.Etl.TestKit.SnapshotTestLoader<T>.LoadedItems.get -> System.Collections.Generic.IReadOnlyList<T>!
+Wolfgang.Etl.TestKit.SnapshotTestLoader<T>.Snapshot.get -> string!
+override Wolfgang.Etl.TestKit.SnapshotTestLoader<T>.CreateProgressReport() -> Wolfgang.Etl.Abstractions.Report!
+override Wolfgang.Etl.TestKit.SnapshotTestLoader<T>.LoadWorkerAsync(System.Collections.Generic.IAsyncEnumerable<T>! items, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task!

--- a/src/Wolfgang.Etl.TestKit/SnapshotTestLoader.cs
+++ b/src/Wolfgang.Etl.TestKit/SnapshotTestLoader.cs
@@ -1,0 +1,163 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+
+namespace Wolfgang.Etl.TestKit;
+
+/// <summary>
+/// An in-memory loader that captures every item it receives and renders them as a single,
+/// deterministic, diff-friendly <see cref="Snapshot"/> string — ready to hand to an approval /
+/// snapshot-testing framework such as <see href="https://github.com/VerifyTests/Verify">Verify</see>.
+/// </summary>
+/// <typeparam name="T">The type of item to load. Must be <c>notnull</c>.</typeparam>
+/// <remarks>
+/// <para>
+/// This loader is deliberately <em>capture-only</em>: it does no file I/O and takes no dependency on
+/// any snapshot framework, so referencing <c>Wolfgang.Etl.TestKit</c> never pulls one in. Run your
+/// pipeline into it, then pass <see cref="Snapshot"/> (or <see cref="LoadedItems"/>) to your own
+/// <c>Verify(...)</c> call in a dedicated snapshot test project — the fleet convention. The framework
+/// owns the golden <c>.verified.txt</c> file, the diff, and the approval workflow; this loader only
+/// produces the content to lock in.
+/// </para>
+/// <para>
+/// <see cref="Snapshot"/> is one formatted line per item, joined by <c>\n</c> (a fixed line feed, not
+/// <see cref="Environment.NewLine"/>, so snapshots are stable across operating systems). Items are
+/// formatted with the delegate supplied to the constructor; the default is <see cref="object.ToString"/>,
+/// which is diff-friendly for <c>record</c> types. Supply a custom formatter to project only the fields
+/// you care about and to <em>scrub</em> non-deterministic values (timestamps, GUIDs, auto-increment
+/// IDs) that would otherwise make the snapshot unstable.
+/// </para>
+/// <para>
+/// Timing and progress are intentionally excluded from the snapshot — they are non-deterministic. Set
+/// <see cref="LoaderBase{TDestination,TProgress}.SkipItemCount"/> to skip the first N items and
+/// <see cref="LoaderBase{TDestination,TProgress}.MaximumItemCount"/> to cap how many are captured; each
+/// new <c>LoadAsync</c> call clears the buffer before it begins.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// // In a dedicated net10.0 snapshot test project that references Verify.Xunit:
+/// var loader = new SnapshotTestLoader&lt;OrderRecord&gt;(
+///     o =&gt; $"{o.Id}|{o.Customer}|{o.Total:0.00}");   // project + scrub as needed
+///
+/// await loader.LoadAsync(pipeline.ExtractAsync());
+///
+/// await Verify(loader.Snapshot);   // Verify owns the .verified.txt golden file + diff
+/// </code>
+/// </example>
+public class SnapshotTestLoader<T> : LoaderBase<T, Report>
+    where T : notnull
+{
+    // ------------------------------------------------------------------
+    // Fields
+    // ------------------------------------------------------------------
+
+    private readonly List<T> _buffer = new List<T>();
+    private readonly Func<T, string> _formatter;
+
+
+
+    // ------------------------------------------------------------------
+    // Constructors
+    // ------------------------------------------------------------------
+
+    /// <summary>
+    /// Initializes a new <see cref="SnapshotTestLoader{T}"/> that formats each captured item with
+    /// its <see cref="object.ToString"/> representation.
+    /// </summary>
+    public SnapshotTestLoader()
+        : this(item => item.ToString() ?? string.Empty)
+    {
+    }
+
+
+
+    /// <summary>
+    /// Initializes a new <see cref="SnapshotTestLoader{T}"/> that formats each captured item with the
+    /// supplied delegate.
+    /// </summary>
+    /// <param name="formatter">
+    /// Projects a captured item to the single snapshot line that represents it. Use this to select
+    /// only the fields under test and to scrub non-deterministic values (timestamps, GUIDs,
+    /// auto-increment IDs) so the snapshot stays stable across runs.
+    /// </param>
+    /// <exception cref="ArgumentNullException"><paramref name="formatter"/> is <see langword="null"/>.</exception>
+    public SnapshotTestLoader(Func<T, string> formatter)
+    {
+        _formatter = formatter ?? throw new ArgumentNullException(nameof(formatter));
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // Public API
+    // ------------------------------------------------------------------
+
+    /// <summary>
+    /// Gets the items captured by the most recent load, in the order they were received.
+    /// </summary>
+    /// <returns>
+    /// A point-in-time copy of the captured items. Empty before the first load, and reset at the start
+    /// of every <c>LoadAsync</c> call.
+    /// </returns>
+    public IReadOnlyList<T> LoadedItems => _buffer.ToArray();
+
+
+
+    /// <summary>
+    /// Gets the deterministic snapshot of the captured items: one formatted line per item, joined by a
+    /// line feed (<c>\n</c>). Hand this to a snapshot / approval framework to lock in the pipeline's output.
+    /// </summary>
+    /// <value>
+    /// The formatted, newline-joined snapshot, or <see cref="string.Empty"/> when no items have been
+    /// captured.
+    /// </value>
+    public string Snapshot => string.Join("\n", _buffer.Select(_formatter));
+
+
+
+    // ------------------------------------------------------------------
+    // LoaderBase overrides
+    // ------------------------------------------------------------------
+
+    /// <inheritdoc/>
+    protected override Report CreateProgressReport() =>
+        new(CurrentItemCount, StartedAt, Elapsed);
+
+
+
+    /// <inheritdoc/>
+    protected override async Task LoadWorkerAsync
+    (
+        IAsyncEnumerable<T> items,
+        CancellationToken token
+    )
+    {
+        token.ThrowIfCancellationRequested();
+
+        _buffer.Clear();
+
+        await foreach (var item in items.WithCancellation(token).ConfigureAwait(false))
+        {
+            token.ThrowIfCancellationRequested();
+
+            if (CurrentSkippedItemCount < SkipItemCount)
+            {
+                IncrementCurrentSkippedItemCount();
+                continue;
+            }
+
+            if (CurrentItemCount >= MaximumItemCount)
+            {
+                break;
+            }
+
+            _buffer.Add(item);
+
+            IncrementCurrentItemCount();
+        }
+    }
+}

--- a/tests/Wolfgang.Etl.TestKit.Tests.Unit/SnapshotTestLoaderTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Unit/SnapshotTestLoaderTests.cs
@@ -1,0 +1,200 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Wolfgang.Etl.TestKit;
+using Xunit;
+
+namespace Wolfgang.Etl.TestKit.Tests.Unit;
+
+public class SnapshotTestLoaderTests
+{
+    // A plain class (not a record) so the test project compiles on the full framework
+    // matrix — positional records need IsExternalInit, absent on net47x.
+    private sealed class Order
+    {
+        public Order(int id, string customer)
+        {
+            Id       = id;
+            Customer = customer;
+        }
+
+
+
+        public int Id { get; }
+
+
+
+        public string Customer { get; }
+
+
+
+        public override string ToString() => $"Order {{ Id = {Id}, Customer = {Customer} }}";
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // Constructor — argument validation
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void Constructor_when_formatter_is_null_throws_ArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>
+        (
+            () => new SnapshotTestLoader<int>(null!)
+        );
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // Snapshot / LoadedItems before any load
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void Snapshot_before_any_load_is_empty()
+    {
+        var loader = new SnapshotTestLoader<int>();
+
+        Assert.Equal(string.Empty, loader.Snapshot);
+    }
+
+
+
+    [Fact]
+    public void LoadedItems_before_any_load_is_empty()
+    {
+        var loader = new SnapshotTestLoader<int>();
+
+        Assert.Empty(loader.LoadedItems);
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // Default formatter — ToString per item
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task LoadAsync_default_formatter_renders_one_ToString_line_per_item()
+    {
+        var extractor = new TestExtractor<Order>
+        (
+            new List<Order> { new(1, "alpha"), new(2, "bravo") }
+        );
+        var loader = new SnapshotTestLoader<Order>();
+
+        await loader.LoadAsync(extractor.ExtractAsync());
+
+        Assert.Equal
+        (
+            "Order { Id = 1, Customer = alpha }\nOrder { Id = 2, Customer = bravo }",
+            loader.Snapshot
+        );
+    }
+
+
+
+    [Fact]
+    public async Task LoadAsync_captures_all_items_in_order()
+    {
+        var extractor = new TestExtractor<int>(new List<int> { 3, 1, 2 });
+        var loader    = new SnapshotTestLoader<int>();
+
+        await loader.LoadAsync(extractor.ExtractAsync());
+
+        Assert.Equal(new[] { 3, 1, 2 }, loader.LoadedItems);
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // Custom formatter — projection + scrubbing
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task LoadAsync_custom_formatter_projects_and_scrubs_each_item()
+    {
+        var extractor = new TestExtractor<Order>
+        (
+            new List<Order> { new(1, "alpha"), new(2, "bravo") }
+        );
+
+        // Project only the customer and scrub the (non-deterministic) id to a placeholder.
+        var loader = new SnapshotTestLoader<Order>(o => $"<id>|{o.Customer}");
+
+        await loader.LoadAsync(extractor.ExtractAsync());
+
+        Assert.Equal
+        (
+            "<id>|alpha\n<id>|bravo",
+            loader.Snapshot
+        );
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // Line feed is fixed \n regardless of platform
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task Snapshot_joins_lines_with_a_line_feed_not_Environment_NewLine()
+    {
+        var extractor = new TestExtractor<int>(new List<int> { 1, 2 });
+        var loader    = new SnapshotTestLoader<int>();
+
+        await loader.LoadAsync(extractor.ExtractAsync());
+
+        Assert.Equal("1\n2", loader.Snapshot);
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // SkipItemCount / MaximumItemCount
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task LoadAsync_when_SkipItemCount_is_set_skips_the_first_N_items()
+    {
+        var extractor = new TestExtractor<int>(new List<int> { 1, 2, 3, 4 });
+        var loader    = new SnapshotTestLoader<int> { SkipItemCount = 2 };
+
+        await loader.LoadAsync(extractor.ExtractAsync());
+
+        Assert.Equal(new[] { 3, 4 }, loader.LoadedItems);
+    }
+
+
+
+    [Fact]
+    public async Task LoadAsync_when_MaximumItemCount_is_set_captures_at_most_that_many_items()
+    {
+        var extractor = new TestExtractor<int>(new List<int> { 1, 2, 3, 4 });
+        var loader    = new SnapshotTestLoader<int> { MaximumItemCount = 2 };
+
+        await loader.LoadAsync(extractor.ExtractAsync());
+
+        Assert.Equal(new[] { 1, 2 }, loader.LoadedItems);
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // Buffer reset between runs
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task LoadAsync_clears_the_buffer_before_each_run()
+    {
+        var loader = new SnapshotTestLoader<int>();
+
+        await loader.LoadAsync(new TestExtractor<int>(new List<int> { 1, 2, 3 }).ExtractAsync());
+        await loader.LoadAsync(new TestExtractor<int>(new List<int> { 9 }).ExtractAsync());
+
+        Assert.Equal(new[] { 9 }, loader.LoadedItems);
+        Assert.Equal("9", loader.Snapshot);
+    }
+}


### PR DESCRIPTION
Adds `SnapshotTestLoader<T>` — a loader double that captures every item a pipeline loads and renders them as a single deterministic, diff-friendly `Snapshot` string, ready to hand to an approval / snapshot framework such as [Verify](https://github.com/VerifyTests/Verify).

## Why capture-only (the fleet-precedent finding)

Surveyed the fleet: snapshot testing is standardized on **Verify**, and Verify is a **test-project-only dev dependency everywhere** (ETL-FixedWidth, ETL-DbClient, ETL-Json, D20-Dice, AuditTrail) — **never** in a shipped `src` package. So a `SnapshotTestLoader<T>` that called `Verify(...)` internally would force `Verify.Xunit` as a transitive dependency on *every* TestKit consumer, breaking that convention. #11's own "overlap with Verify" note anticipates exactly this: *"if the value is thin, consider shipping as a Verify adapter instead."*

This PR ships that adapter: the loader does **no file I/O and takes no snapshot-framework dependency** — it just produces the content. The framework (in the consumer's own snapshot test project) owns the golden `.verified.txt`, the diff, and the approval workflow.

```csharp
var loader = new SnapshotTestLoader<OrderRecord>(o => $"<id>|{o.Customer}|{o.Total:0.00}");
await loader.LoadAsync(pipeline.ExtractAsync());
await Verify(loader.Snapshot);   // Verify owns the golden file + diff
```

## What it does

- `Snapshot` — one formatted line per item, joined by a fixed `\n` (not `Environment.NewLine`, so golden files are OS-stable).
- Default ctor formats with `ToString()` (diff-friendly for `record` types); a `Func<T,string>` ctor lets you project the fields under test and **scrub** non-deterministic values (timestamps, GUIDs, auto-increment IDs).
- `LoadedItems` exposes the raw captured items; `SkipItemCount` / `MaximumItemCount` bound the capture; buffer resets each `LoadAsync`.

## #129 folded in

#129 asked for Verify-based snapshot coverage. Rather than a framework-bound contract base (which reintroduces the dependency problem above), this PR delivers the ETL-specific capture helper **plus a README section documenting the fleet convention** (dedicated single-TFM `*.Tests.Snapshot` project, `Verify.Xunit`, `.verified.txt` under `Snapshots/`, `.received.txt` gitignored). That's the reusable, dependency-free way to satisfy #129 for consumers.

## Verification

- Full multi-TFM Release build clean (0 warnings), PublicAPI.Unshipped updated.
- 10 new tests pass on **net10.0 and net48** (default/custom formatter, ordering, skip/max, `\n` join, buffer reset, null-formatter guard, empty-before-load).
- Note: test uses a plain `class` (not a positional `record`) because the core test project spans net47x, which lacks `IsExternalInit` — consistent with every existing core test.

Closes #11
Refs #129 (closed separately as not-applicable — the snapshot capability is delivered here via #11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

