### PR TITLE
build-pr.ps1: select gitleaks arch for Linux arm64 (#206)

### DIFF
--- a/scripts/build-pr.ps1
+++ b/scripts/build-pr.ps1
@@ -295,18 +295,14 @@ if (-not $SkipSecurity) {
             $env:PATH = "$dest;$env:PATH"
         }
         else {
-            # gitleaks ships separate darwin / linux builds, and on macOS we
-            # also have to pick between x64 (Intel) and arm64 (Apple Silicon).
-            # Without this branch the macOS path would download the Linux
-            # tarball and either fail to install or install an incompatible
-            # binary.
-            if ($IsMacOS) {
-                $arch = if ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture -eq 'Arm64') { 'arm64' } else { 'x64' }
-                $archive = "gitleaks_${version}_darwin_${arch}.tar.gz"
-            }
-            else {
-                $archive = "gitleaks_${version}_linux_x64.tar.gz"
-            }
+            # gitleaks ships separate darwin / linux builds, each in x64 (Intel)
+            # and arm64 (Apple Silicon / AWS Graviton / ARM CI runners) flavours.
+            # Resolve os × arch in one selector so the correct binary is fetched
+            # on every non-Windows platform; hard-coding linux_x64 would install
+            # an incompatible binary on ARM64 Linux.
+            $arch = if ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture -eq 'Arm64') { 'arm64' } else { 'x64' }
+            $os = if ($IsMacOS) { 'darwin' } else { 'linux' }
+            $archive = "gitleaks_${version}_${os}_${arch}.tar.gz"
             $url = "https://github.com/gitleaks/gitleaks/releases/download/v${version}/$archive"
             # Install to a user-writable location instead of /usr/local/bin
             # (which would require sudo for most local dev shells). $HOME/.local/bin


### PR DESCRIPTION
The non-Windows gitleaks install in `scripts/build-pr.ps1` hard-coded `linux_x64`, so on **ARM64 Linux** (AWS Graviton, ARM CI runners) it fetched an incompatible binary. This replaces the darwin/linux branch with the canonical all-arch selector used in ETL-FixedWidth — resolving `linux`/`darwin` × `x64`/`arm64` in one place:

```powershell
$arch = if ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture -eq 'Arm64') { 'arm64' } else { 'x64' }
$os = if ($IsMacOS) { 'darwin' } else { 'linux' }
$archive = "gitleaks_${version}_${os}_${arch}.tar.gz"
```

The `tar -xz -f -` stdin hardening and the user-writable install dir were already present, so this is a one-block change. Dev-tooling script only — no build/test surface; `scripts/build-pr.ps1` is **not** a protected file, so no admin-bypass needed. Parse-verified with the PowerShell parser.

Closes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)