### PR TITLE
Add DelayingExtractor + CancellationContractTests for prompt cancellation (#264)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,15 @@ New opt-in contract-test bases. New public API only — no breaking change.
   count. Uses the process-wide `GC.GetTotalAllocatedBytes`, so derived tests **must be
   serialized** (documented; a `[Collection("Allocation")]` example is provided). Skips on
   frameworks without the counter (net462 / netstandard2.0). (#245)
+- `DelayingExtractor<T>` — an extractor double that waits a configurable delay (a fixed `TimeSpan` or
+  a per-index `Func<int, TimeSpan>`) before yielding each item, simulating a latent / backpressured
+  source. The delay is awaited with `Task.Delay(..., token)`, so a cancel interrupts the wait and the
+  extractor stops promptly. Honours `SkipItemCount` / `MaximumItemCount`. (#264)
+- `CancellationContractTests<TSut>` + `CancellationOutcome` — an opt-in xUnit contract-test base that
+  verifies a stage cancels *promptly*: a mid-stream cancel stops within `PromptStopSlack` items (not a
+  full drain) and throws `OperationCanceledException`, and an already-cancelled token processes nothing.
+  The derived class drives its own stage and reports a `CancellationOutcome` (no SUT is passed to the
+  override). (#264)
 
 ## [0.11.0] - 2026-07-26
 

--- a/README.md
+++ b/README.md
@@ -302,6 +302,53 @@ public sealed class MyExtractorAllocationTests
 
 `CreateSut(itemCount)` runs outside the measurement window (its cost is excluded); exercise the harness-supplied `Sut`. The test skips on frameworks without `GC.GetTotalAllocatedBytes` (net462 / netstandard2.0).
 
+### xUnit — verifying prompt cancellation
+
+Derive from `CancellationContractTests<TSut>` to verify a stage honours cancellation **promptly** — it stops shortly after the token is cancelled (rather than draining its source), throws `OperationCanceledException`, and processes nothing when handed an already-cancelled token. Pair it with a latent source such as the core-package `DelayingExtractor<T>` so a cancel interrupts an in-flight wait:
+
+```csharp
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Wolfgang.Etl.TestKit;
+using Wolfgang.Etl.TestKit.Xunit;
+
+public sealed class MyExtractorCancellationTests
+    : CancellationContractTests<DelayingExtractor<int>>
+{
+    protected override async Task<CancellationOutcome> RunAndCancelMidStreamAsync(int itemCount, int cancelAfter)
+    {
+        var sut = new DelayingExtractor<int>(Enumerable.Range(0, itemCount).ToArray(), TimeSpan.FromMilliseconds(5));
+        using var cts = new CancellationTokenSource();
+        var processed = 0; var canceled = false;
+        try
+        {
+            await foreach (var _ in sut.ExtractAsync(cts.Token))
+            {
+                if (++processed == cancelAfter) cts.Cancel();
+            }
+        }
+        catch (OperationCanceledException) { canceled = true; }
+        return new CancellationOutcome(canceled, processed);
+    }
+
+    protected override async Task<CancellationOutcome> RunWithPreCancelledTokenAsync(int itemCount)
+    {
+        var sut = new DelayingExtractor<int>(Enumerable.Range(0, itemCount).ToArray(), TimeSpan.FromMilliseconds(5));
+        var processed = 0; var canceled = false;
+        try
+        {
+            await foreach (var _ in sut.ExtractAsync(new CancellationToken(canceled: true))) processed++;
+        }
+        catch (OperationCanceledException) { canceled = true; }
+        return new CancellationOutcome(canceled, processed);
+    }
+}
+```
+
+The derived class owns and drives its stage (the base never receives the SUT, so no null-argument boilerplate); override `ItemCount` / `CancelAfter` / `PromptStopSlack` to tune. `DelayingExtractor<T>` waits a fixed `TimeSpan` — or a per-index `Func<int, TimeSpan>` — before each item, and honours `SkipItemCount` / `MaximumItemCount`.
+
 ### xUnit add-on — contract-testing your own ETL types
 
 Derive your test class from the matching contract base and implement the abstract factory methods. You inherit the complete suite of `ExtractAsync` / `TransformAsync` / `LoadAsync` contract tests — all overloads, cancellation, progress, `SkipItemCount`, and `MaximumItemCount` — with zero boilerplate.

--- a/src/Wolfgang.Etl.TestKit.Xunit/CancellationContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/CancellationContractTests.cs
@@ -1,0 +1,152 @@
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Wolfgang.Etl.TestKit.Xunit;
+
+/// <summary>
+/// Abstract base class providing xUnit contract tests that verify a stage honours cancellation
+/// <em>promptly</em> — it stops shortly after the token is cancelled rather than draining its source,
+/// throws <see cref="System.OperationCanceledException"/>, and processes nothing when handed an
+/// already-cancelled token.
+/// </summary>
+/// <typeparam name="TSut">The system under test (an extractor, loader, or transformer).</typeparam>
+/// <remarks>
+/// <para>
+/// This complements the per-overload cancellation checks on the extractor/loader/transformer contract
+/// bases (which assert that cancellation eventually throws) by asserting the stronger property that a
+/// mid-stream cancel takes effect <em>quickly</em> and leaves the processed-item count consistent.
+/// Pair it with a latent source such as <c>DelayingExtractor&lt;T&gt;</c> so a cancel interrupts an
+/// in-flight wait.
+/// </para>
+/// <para>
+/// The derived class owns and drives its stage — the base never receives the SUT, so overrides need
+/// no null-argument validation. Implement <see cref="RunAndCancelMidStreamAsync"/> (drive the stage
+/// over <c>itemCount</c> items, cancel once <c>cancelAfter</c> items have been
+/// processed, and report the <see cref="CancellationOutcome"/>) and
+/// <see cref="RunWithPreCancelledTokenAsync"/> (drive the stage with an already-cancelled token).
+/// Both must let <see cref="System.OperationCanceledException"/> propagate out of the run so the
+/// harness can observe it via the reported outcome.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// public sealed class MyExtractorCancellationTests
+///     : CancellationContractTests&lt;MyExtractor&gt;
+/// {
+///     protected override async Task&lt;CancellationOutcome&gt; RunAndCancelMidStreamAsync(int itemCount, int cancelAfter)
+///     {
+///         var sut = new MyExtractor(source, count: itemCount);
+///         using var cts = new CancellationTokenSource();
+///         var processed = 0;
+///         var canceled = false;
+///         try
+///         {
+///             await foreach (var _ in sut.ExtractAsync(cts.Token))
+///             {
+///                 processed++;
+///                 if (processed == cancelAfter) cts.Cancel();
+///             }
+///         }
+///         catch (OperationCanceledException) { canceled = true; }
+///         return new CancellationOutcome(canceled, processed);
+///     }
+///     // ... RunWithPreCancelledTokenAsync ...
+/// }
+/// </code>
+/// </example>
+public abstract class CancellationContractTests<TSut>
+{
+    /// <summary>The number of items the stage's source should make available for the run.</summary>
+    protected virtual int ItemCount => 100;
+
+
+
+    /// <summary>The number of processed items after which the mid-stream run cancels its token.</summary>
+    protected virtual int CancelAfter => 5;
+
+
+
+    /// <summary>
+    /// The tolerance, in items, allowed between the cancel signal and the stage actually stopping. The
+    /// default of 1 permits the item whose processing was already in flight when the token was cancelled.
+    /// </summary>
+    protected virtual int PromptStopSlack => 1;
+
+
+
+    /// <summary>
+    /// Drives the stage over <paramref name="itemCount"/> items and cancels the token once
+    /// <paramref name="cancelAfter"/> items have been fully processed, letting
+    /// <see cref="System.OperationCanceledException"/> propagate.
+    /// </summary>
+    /// <returns>The observed outcome — whether cancellation threw and how many items were processed.</returns>
+    protected abstract Task<CancellationOutcome> RunAndCancelMidStreamAsync(int itemCount, int cancelAfter);
+
+
+
+    /// <summary>
+    /// Drives the stage over <paramref name="itemCount"/> items with an already-cancelled token,
+    /// letting <see cref="System.OperationCanceledException"/> propagate.
+    /// </summary>
+    /// <returns>The observed outcome — whether cancellation threw and how many items were processed.</returns>
+    protected abstract Task<CancellationOutcome> RunWithPreCancelledTokenAsync(int itemCount);
+
+
+
+    /// <summary>
+    /// Verifies that cancelling mid-stream surfaces <see cref="System.OperationCanceledException"/>.
+    /// </summary>
+    [Fact]
+    public async Task Mid_stream_cancellation_throws_OperationCanceledException_Async()
+    {
+        var outcome = await RunAndCancelMidStreamAsync(ItemCount, CancelAfter).ConfigureAwait(false);
+
+        Assert.True
+        (
+            outcome.Canceled,
+            "Cancelling the token mid-stream should surface an OperationCanceledException."
+        );
+    }
+
+
+
+    /// <summary>
+    /// Verifies that the stage stops promptly after cancellation — within
+    /// <see cref="PromptStopSlack"/> items of the cancel signal, and well before the source is drained.
+    /// </summary>
+    [Fact]
+    public async Task Mid_stream_cancellation_stops_promptly_Async()
+    {
+        Assert.True(ItemCount > CancelAfter + PromptStopSlack, "ItemCount must exceed CancelAfter + slack for this test to be meaningful.");
+
+        var outcome = await RunAndCancelMidStreamAsync(ItemCount, CancelAfter).ConfigureAwait(false);
+
+        Assert.True
+        (
+            outcome.ProcessedItemCount <= CancelAfter + PromptStopSlack,
+            $"Expected the stage to stop within {PromptStopSlack} item(s) of cancellation " +
+            $"(≤ {CancelAfter + PromptStopSlack}), but it processed {outcome.ProcessedItemCount}."
+        );
+
+        Assert.True
+        (
+            outcome.ProcessedItemCount < ItemCount,
+            $"The stage drained all {ItemCount} items instead of stopping on cancellation."
+        );
+    }
+
+
+
+    /// <summary>
+    /// Verifies that an already-cancelled token makes the stage process nothing and throw
+    /// <see cref="System.OperationCanceledException"/>.
+    /// </summary>
+    [Fact]
+    public async Task Pre_cancelled_token_processes_nothing_and_throws_Async()
+    {
+        var outcome = await RunWithPreCancelledTokenAsync(ItemCount).ConfigureAwait(false);
+
+        Assert.True(outcome.Canceled, "An already-cancelled token should surface an OperationCanceledException.");
+        Assert.Equal(0, outcome.ProcessedItemCount);
+    }
+}

--- a/src/Wolfgang.Etl.TestKit.Xunit/CancellationOutcome.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/CancellationOutcome.cs
@@ -1,0 +1,39 @@
+namespace Wolfgang.Etl.TestKit.Xunit;
+
+/// <summary>
+/// The result a derived <see cref="CancellationContractTests{TSut}"/> reports back to the base after
+/// driving its stage under cancellation.
+/// </summary>
+public sealed class CancellationOutcome
+{
+    /// <summary>
+    /// Initializes a new <see cref="CancellationOutcome"/>.
+    /// </summary>
+    /// <param name="canceled">
+    /// <see langword="true"/> if the run threw <see cref="System.OperationCanceledException"/>
+    /// (or a derived type such as <see cref="System.Threading.Tasks.TaskCanceledException"/>).
+    /// </param>
+    /// <param name="processedItemCount">
+    /// The number of items the stage fully processed before it stopped.
+    /// </param>
+    public CancellationOutcome(bool canceled, int processedItemCount)
+    {
+        Canceled          = canceled;
+        ProcessedItemCount = processedItemCount;
+    }
+
+
+
+    /// <summary>
+    /// Gets a value indicating whether the run threw
+    /// <see cref="System.OperationCanceledException"/> (or a derived type).
+    /// </summary>
+    public bool Canceled { get; }
+
+
+
+    /// <summary>
+    /// Gets the number of items the stage fully processed before it stopped.
+    /// </summary>
+    public int ProcessedItemCount { get; }
+}

--- a/src/Wolfgang.Etl.TestKit.Xunit/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.TestKit.Xunit/PublicAPI.Unshipped.txt
@@ -8,3 +8,17 @@ abstract Wolfgang.Etl.TestKit.Xunit.AllocationBudgetContractTests<TSut>.Exercise
 virtual Wolfgang.Etl.TestKit.Xunit.AllocationBudgetContractTests<TSut>.Attempts.get -> int
 virtual Wolfgang.Etl.TestKit.Xunit.AllocationBudgetContractTests<TSut>.BaseItemCount.get -> int
 virtual Wolfgang.Etl.TestKit.Xunit.AllocationBudgetContractTests<TSut>.MaxBytesPerItem.get -> double
+Wolfgang.Etl.TestKit.Xunit.CancellationContractTests<TSut>
+Wolfgang.Etl.TestKit.Xunit.CancellationContractTests<TSut>.CancellationContractTests() -> void
+Wolfgang.Etl.TestKit.Xunit.CancellationContractTests<TSut>.Mid_stream_cancellation_stops_promptly_Async() -> System.Threading.Tasks.Task!
+Wolfgang.Etl.TestKit.Xunit.CancellationContractTests<TSut>.Mid_stream_cancellation_throws_OperationCanceledException_Async() -> System.Threading.Tasks.Task!
+Wolfgang.Etl.TestKit.Xunit.CancellationContractTests<TSut>.Pre_cancelled_token_processes_nothing_and_throws_Async() -> System.Threading.Tasks.Task!
+abstract Wolfgang.Etl.TestKit.Xunit.CancellationContractTests<TSut>.RunAndCancelMidStreamAsync(int itemCount, int cancelAfter) -> System.Threading.Tasks.Task<Wolfgang.Etl.TestKit.Xunit.CancellationOutcome!>!
+abstract Wolfgang.Etl.TestKit.Xunit.CancellationContractTests<TSut>.RunWithPreCancelledTokenAsync(int itemCount) -> System.Threading.Tasks.Task<Wolfgang.Etl.TestKit.Xunit.CancellationOutcome!>!
+virtual Wolfgang.Etl.TestKit.Xunit.CancellationContractTests<TSut>.CancelAfter.get -> int
+virtual Wolfgang.Etl.TestKit.Xunit.CancellationContractTests<TSut>.ItemCount.get -> int
+virtual Wolfgang.Etl.TestKit.Xunit.CancellationContractTests<TSut>.PromptStopSlack.get -> int
+Wolfgang.Etl.TestKit.Xunit.CancellationOutcome
+Wolfgang.Etl.TestKit.Xunit.CancellationOutcome.CancellationOutcome(bool canceled, int processedItemCount) -> void
+Wolfgang.Etl.TestKit.Xunit.CancellationOutcome.Canceled.get -> bool
+Wolfgang.Etl.TestKit.Xunit.CancellationOutcome.ProcessedItemCount.get -> int

--- a/src/Wolfgang.Etl.TestKit/DelayingExtractor.cs
+++ b/src/Wolfgang.Etl.TestKit/DelayingExtractor.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+
+namespace Wolfgang.Etl.TestKit;
+
+/// <summary>
+/// An extractor double that waits a configurable delay before yielding each item, simulating a
+/// latent / backpressured source. Useful for exercising timeout, cancellation-promptness, and
+/// progress-cadence behaviour that an instantaneous in-memory source cannot.
+/// </summary>
+/// <typeparam name="T">The type of item to extract. Must be <c>notnull</c>.</typeparam>
+/// <remarks>
+/// <para>
+/// The delay is awaited with <see cref="Task.Delay(TimeSpan, CancellationToken)"/> <em>before</em>
+/// each item is yielded, so a cancelled token interrupts the wait and the extractor stops promptly
+/// (throwing <see cref="OperationCanceledException"/>) rather than draining the source. Pair it with
+/// <c>CancellationContractTests</c> (in <c>Wolfgang.Etl.TestKit.Xunit</c>) to verify a stage cancels
+/// quickly and leaves its counters consistent.
+/// </para>
+/// <para>
+/// Supply a single <see cref="TimeSpan"/> for a uniform delay, or a <c>Func&lt;int, TimeSpan&gt;</c>
+/// to vary the delay by zero-based item index. <see cref="LoaderBase{TDestination,TProgress}"/>-style
+/// <see cref="ExtractorBase{TSource,TProgress}.SkipItemCount"/> /
+/// <see cref="ExtractorBase{TSource,TProgress}.MaximumItemCount"/> bounds are honoured.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// // Each item arrives 20 ms apart:
+/// var extractor = new DelayingExtractor&lt;int&gt;(Enumerable.Range(0, 100), TimeSpan.FromMilliseconds(20));
+/// using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(50));
+/// // Enumerating with cts.Token throws OperationCanceledException after ~2-3 items.
+/// </code>
+/// </example>
+public class DelayingExtractor<T> : ExtractorBase<T, Report>
+    where T : notnull
+{
+    // ------------------------------------------------------------------
+    // Fields
+    // ------------------------------------------------------------------
+
+    private readonly IEnumerable<T> _items;
+    private readonly Func<int, TimeSpan> _delaySelector;
+
+
+
+    // ------------------------------------------------------------------
+    // Constructors
+    // ------------------------------------------------------------------
+
+    /// <summary>
+    /// Initializes a new <see cref="DelayingExtractor{T}"/> that waits <paramref name="delay"/> before
+    /// yielding every item.
+    /// </summary>
+    /// <param name="items">The items to extract.</param>
+    /// <param name="delay">The delay to await before each item.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="items"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="delay"/> is negative.</exception>
+    public DelayingExtractor(IEnumerable<T> items, TimeSpan delay)
+        : this(items, ValidatedConstantDelay(delay))
+    {
+    }
+
+
+
+    /// <summary>
+    /// Initializes a new <see cref="DelayingExtractor{T}"/> that waits the delay returned by
+    /// <paramref name="delaySelector"/> (given the zero-based item index) before yielding each item.
+    /// </summary>
+    /// <param name="items">The items to extract.</param>
+    /// <param name="delaySelector">Maps a zero-based item index to the delay to await before it.</param>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="items"/> or <paramref name="delaySelector"/> is <see langword="null"/>.
+    /// </exception>
+    public DelayingExtractor(IEnumerable<T> items, Func<int, TimeSpan> delaySelector)
+    {
+        _items         = items ?? throw new ArgumentNullException(nameof(items));
+        _delaySelector = delaySelector ?? throw new ArgumentNullException(nameof(delaySelector));
+    }
+
+
+
+    private static Func<int, TimeSpan> ValidatedConstantDelay(TimeSpan delay)
+    {
+        if (delay < TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(delay), delay, "Delay must not be negative.");
+        }
+
+        return _ => delay;
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // ExtractorBase overrides
+    // ------------------------------------------------------------------
+
+    /// <inheritdoc/>
+    protected override Report CreateProgressReport() =>
+        new(CurrentItemCount, StartedAt, Elapsed, (_items as ICollection<T>)?.Count);
+
+
+
+    /// <inheritdoc/>
+    protected override async IAsyncEnumerable<T> ExtractWorkerAsync
+    (
+        [EnumeratorCancellation] CancellationToken token
+    )
+    {
+        token.ThrowIfCancellationRequested();
+
+        var index = 0;
+
+        foreach (var item in _items)
+        {
+            token.ThrowIfCancellationRequested();
+
+            if (CurrentSkippedItemCount < SkipItemCount)
+            {
+                IncrementCurrentSkippedItemCount();
+                index++;
+                continue;
+            }
+
+            if (CurrentItemCount >= MaximumItemCount)
+            {
+                yield break;
+            }
+
+            await Task.Delay(_delaySelector(index), token).ConfigureAwait(false);
+
+            IncrementCurrentItemCount();
+            index++;
+            yield return item;
+        }
+    }
+}

--- a/src/Wolfgang.Etl.TestKit/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.TestKit/PublicAPI.Unshipped.txt
@@ -1,4 +1,9 @@
 #nullable enable
+Wolfgang.Etl.TestKit.DelayingExtractor<T>
+Wolfgang.Etl.TestKit.DelayingExtractor<T>.DelayingExtractor(System.Collections.Generic.IEnumerable<T>! items, System.Func<int, System.TimeSpan>! delaySelector) -> void
+Wolfgang.Etl.TestKit.DelayingExtractor<T>.DelayingExtractor(System.Collections.Generic.IEnumerable<T>! items, System.TimeSpan delay) -> void
+override Wolfgang.Etl.TestKit.DelayingExtractor<T>.CreateProgressReport() -> Wolfgang.Etl.Abstractions.Report!
+override Wolfgang.Etl.TestKit.DelayingExtractor<T>.ExtractWorkerAsync(System.Threading.CancellationToken token) -> System.Collections.Generic.IAsyncEnumerable<T>!
 Wolfgang.Etl.TestKit.SnapshotTestLoader<T>
 Wolfgang.Etl.TestKit.SnapshotTestLoader<T>.SnapshotTestLoader() -> void
 Wolfgang.Etl.TestKit.SnapshotTestLoader<T>.SnapshotTestLoader(System.Func<T, string!>! formatter) -> void

--- a/tests/Wolfgang.Etl.TestKit.Tests.Unit/DelayingExtractorTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Unit/DelayingExtractorTests.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Wolfgang.Etl.TestKit;
+using Xunit;
+
+namespace Wolfgang.Etl.TestKit.Tests.Unit;
+
+public class DelayingExtractorTests
+{
+    // ------------------------------------------------------------------
+    // Constructor — argument validation
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void Constructor_when_items_is_null_throws_ArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>
+        (
+            () => new DelayingExtractor<int>(null!, TimeSpan.Zero)
+        );
+    }
+
+
+
+    [Fact]
+    public void Constructor_when_delaySelector_is_null_throws_ArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>
+        (
+            () => new DelayingExtractor<int>(new[] { 1 }, (Func<int, TimeSpan>)null!)
+        );
+    }
+
+
+
+    [Fact]
+    public void Constructor_when_delay_is_negative_throws_ArgumentOutOfRangeException()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>
+        (
+            () => new DelayingExtractor<int>(new[] { 1 }, TimeSpan.FromMilliseconds(-1))
+        );
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // Extraction behaviour
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task ExtractAsync_yields_all_items_in_order()
+    {
+        var sut = new DelayingExtractor<int>(new[] { 1, 2, 3 }, TimeSpan.Zero);
+
+        var actual = await sut.ExtractAsync(CancellationToken.None).ToListAsync().ConfigureAwait(false);
+
+        Assert.Equal(new[] { 1, 2, 3 }, actual);
+    }
+
+
+
+    [Fact]
+    public async Task ExtractAsync_when_MaximumItemCount_is_set_stops_at_the_limit()
+    {
+        var sut = new DelayingExtractor<int>(new[] { 1, 2, 3, 4, 5 }, TimeSpan.Zero) { MaximumItemCount = 2 };
+
+        var actual = await sut.ExtractAsync(CancellationToken.None).ToListAsync().ConfigureAwait(false);
+
+        Assert.Equal(new[] { 1, 2 }, actual);
+    }
+
+
+
+    [Fact]
+    public async Task ExtractAsync_when_SkipItemCount_is_set_skips_the_first_N_items()
+    {
+        var sut = new DelayingExtractor<int>(new[] { 1, 2, 3, 4 }, TimeSpan.Zero) { SkipItemCount = 2 };
+
+        var actual = await sut.ExtractAsync(CancellationToken.None).ToListAsync().ConfigureAwait(false);
+
+        Assert.Equal(new[] { 3, 4 }, actual);
+    }
+
+
+
+    [Fact]
+    public async Task ExtractAsync_per_index_delay_selector_yields_all_items()
+    {
+        var sut = new DelayingExtractor<int>(new[] { 10, 20, 30 }, i => TimeSpan.FromMilliseconds(i));
+
+        var actual = await sut.ExtractAsync(CancellationToken.None).ToListAsync().ConfigureAwait(false);
+
+        Assert.Equal(new[] { 10, 20, 30 }, actual);
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // Cancellation
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task ExtractAsync_with_already_cancelled_token_throws_and_yields_nothing()
+    {
+        var sut   = new DelayingExtractor<int>(Enumerable.Range(0, 100).ToArray(), TimeSpan.FromMilliseconds(5));
+        var token = new CancellationToken(canceled: true);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>
+        (
+            async () =>
+            {
+                await foreach (var _ in sut.ExtractAsync(token).ConfigureAwait(false))
+                {
+                }
+            }
+        ).ConfigureAwait(false);
+
+        Assert.Equal(0, sut.CurrentItemCount);
+    }
+
+
+
+    [Fact]
+    public async Task ExtractAsync_cancelling_mid_stream_stops_promptly()
+    {
+        var sut = new DelayingExtractor<int>(Enumerable.Range(0, 100).ToArray(), TimeSpan.FromMilliseconds(5));
+        using var cts = new CancellationTokenSource();
+
+        var processed = 0;
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>
+        (
+            async () =>
+            {
+                await foreach (var _ in sut.ExtractAsync(cts.Token).ConfigureAwait(false))
+                {
+                    processed++;
+                    if (processed == 3)
+                    {
+#pragma warning disable CA1849, VSTHRD103 // sync Cancel() — CancelAsync is net8+ only
+                        cts.Cancel();
+#pragma warning restore CA1849, VSTHRD103
+                    }
+                }
+            }
+        ).ConfigureAwait(false);
+
+        // Stopped near the cancel point rather than draining all 100.
+        Assert.True(processed <= 4, $"Expected a prompt stop (≤ 4), but processed {processed}.");
+    }
+}

--- a/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/DelayingExtractorCancellationContractTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/DelayingExtractorCancellationContractTests.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Wolfgang.Etl.TestKit;
+using Wolfgang.Etl.TestKit.Xunit;
+
+namespace Wolfgang.Etl.TestKit.Xunit.Tests.Unit;
+
+/// <summary>
+/// Exercises <see cref="CancellationContractTests{TSut}"/> by driving a <see cref="DelayingExtractor{T}"/>,
+/// confirming the base's prompt-cancellation contract holds against a genuinely latent source.
+/// </summary>
+public sealed class DelayingExtractorCancellationContractTests
+    : CancellationContractTests<DelayingExtractor<int>>
+{
+    private static readonly TimeSpan PerItemDelay = TimeSpan.FromMilliseconds(5);
+
+
+
+    protected override async Task<CancellationOutcome> RunAndCancelMidStreamAsync(int itemCount, int cancelAfter)
+    {
+        var sut = new DelayingExtractor<int>(Enumerable.Range(0, itemCount).ToArray(), PerItemDelay);
+        using var cts = new CancellationTokenSource();
+
+        var processed = 0;
+        var canceled  = false;
+
+        try
+        {
+            await foreach (var _ in sut.ExtractAsync(cts.Token).ConfigureAwait(false))
+            {
+                processed++;
+
+                if (processed == cancelAfter)
+                {
+#pragma warning disable CA1849, VSTHRD103 // sync Cancel() — CancelAsync is net8+ only
+                    cts.Cancel();
+#pragma warning restore CA1849, VSTHRD103
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            canceled = true;
+        }
+
+        return new CancellationOutcome(canceled, processed);
+    }
+
+
+
+    protected override async Task<CancellationOutcome> RunWithPreCancelledTokenAsync(int itemCount)
+    {
+        var sut   = new DelayingExtractor<int>(Enumerable.Range(0, itemCount).ToArray(), PerItemDelay);
+        var token = new CancellationToken(canceled: true);
+
+        var processed = 0;
+        var canceled  = false;
+
+        try
+        {
+            await foreach (var _ in sut.ExtractAsync(token).ConfigureAwait(false))
+            {
+                processed++;
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            canceled = true;
+        }
+
+        return new CancellationOutcome(canceled, processed);
+    }
+}


### PR DESCRIPTION
Adds a latency-injecting extractor double and an opt-in xUnit contract base that verifies a stage cancels **promptly** — the property the existing per-overload cancel checks don't assert.

## What's new
- **`DelayingExtractor<T>`** (core) — waits a configurable delay (fixed `TimeSpan` or per-index `Func<int, TimeSpan>`) before yielding each item, via `Task.Delay(..., token)`. A cancel interrupts the in-flight wait so the extractor stops promptly instead of draining the source. Honours `SkipItemCount` / `MaximumItemCount`. Simulates a latent / backpressured source (also useful for timeout / progress-cadence tests).
- **`CancellationContractTests<TSut>` + `CancellationOutcome`** (xunit) — asserts:
  - a mid-stream cancel **stops within `PromptStopSlack` items** (default 1) and well before the source is drained;
  - it throws `OperationCanceledException`;
  - an already-cancelled token **processes nothing** and throws.

## Design
The derived class owns and drives its own stage and reports a `CancellationOutcome` — **no SUT is passed to the override** (CA1062-safe, the same self-report pattern as `ErrorHandlingOutcome`). `ItemCount` / `CancelAfter` / `PromptStopSlack` are virtual for tuning.

## Verification
- Full multi-TFM Release build clean (0 warnings; PublicAPI updated for both packages).
- Tests pass **net10.0 and net48**: 9 `DelayingExtractor` unit tests (skip/max, per-index delay, pre-cancel yields nothing, prompt stop) + the `CancellationContractTests` wired against `DelayingExtractor`.
- Self-contained — no Abstractions dependency (uses `CancellationToken`, already in every stage signature).

Closes #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)