### PR TITLE
Add RetryingExtractor + RetryContractTests for the 0.20 retry seam (#261)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `RetryingExtractor<T>` — an extractor double that throws a transient fault on its first
+  `failFirstAttempts` worker invocations and then succeeds, driven through a retry override of the
+  Abstractions 0.20 `WrapWorkerExecution` resilience seam (each retry re-invokes the worker for a fresh
+  stream). Exposes `AttemptCount`. Serves as both a reference retry implementation and the component
+  the retry contract tests drive. (#261)
+- `RetryContractTests<TSut>` + `RetryOutcome` — an opt-in xUnit contract-test base that verifies a
+  stage's `WrapWorkerExecution` retry strategy: a transient fault clearing within the retry budget
+  completes the run (with the expected attempt count and items), and a fault that never clears fails
+  after the maximum number of attempts (no infinite loop). The derived class drives its own stage and
+  reports a `RetryOutcome` (no SUT is passed to the override). (#261)
+
 ### Changed
 
 - Built against `Wolfgang.Etl.Abstractions` 0.19.0 → **0.20.0** (adds the `WrapWorkerExecution` retry

--- a/README.md
+++ b/README.md
@@ -371,6 +371,37 @@ public sealed class MyLoaderPipelineTests
 }
 ```
 
+### xUnit — verifying retry / resilience
+
+Derive from `CancellationContractTests<TSut>`'s sibling `RetryContractTests<TSut>` to verify a stage whose `Wolfgang.Etl.Abstractions` 0.20 `WrapWorkerExecution` override adds a retry strategy: a transient fault that clears within the retry budget completes the run, and a fault that never clears fails after the maximum number of attempts (no infinite loop). The core package ships `RetryingExtractor<T>` — a ready-made component that fails its first `failFirstAttempts` worker invocations then succeeds, retrying up to `maxAttempts` — which your override can drive:
+
+```csharp
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Wolfgang.Etl.TestKit;
+using Wolfgang.Etl.TestKit.Xunit;
+
+public sealed class MyRetryTests : RetryContractTests<RetryingExtractor<int>>
+{
+    protected override Task<RetryOutcome> RunWithTransientFaultAsync(int failFirstAttempts, int maxAttempts) =>
+        Drive(new RetryingExtractor<int>(Enumerable.Range(0, 5).ToArray(), failFirstAttempts, maxAttempts));
+
+    protected override Task<RetryOutcome> RunWithPermanentFaultAsync(int maxAttempts) =>
+        Drive(new RetryingExtractor<int>(Enumerable.Range(0, 5).ToArray(), failFirstAttempts: maxAttempts, maxAttempts: maxAttempts));
+
+    static async Task<RetryOutcome> Drive(RetryingExtractor<int> sut)
+    {
+        var items = 0; var ok = false;
+        try { await foreach (var _ in sut.ExtractAsync(CancellationToken.None)) items++; ok = true; }
+        catch (System.InvalidOperationException) { ok = false; }
+        return new RetryOutcome(ok, sut.AttemptCount, items);
+    }
+}
+```
+
+`RetryingExtractor<T>` also serves as a worked example of building stream-level retry on the `WrapWorkerExecution` seam (each retry re-invokes the worker for a fresh stream).
+
 ### xUnit add-on — contract-testing your own ETL types
 
 Derive your test class from the matching contract base and implement the abstract factory methods. You inherit the complete suite of `ExtractAsync` / `TransformAsync` / `LoadAsync` contract tests — all overloads, cancellation, progress, `SkipItemCount`, and `MaximumItemCount` — with zero boilerplate.

--- a/src/Wolfgang.Etl.TestKit.Xunit/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.TestKit.Xunit/PublicAPI.Unshipped.txt
@@ -1,1 +1,15 @@
 #nullable enable
+Wolfgang.Etl.TestKit.Xunit.RetryContractTests<TSut>
+Wolfgang.Etl.TestKit.Xunit.RetryContractTests<TSut>.RetryContractTests() -> void
+Wolfgang.Etl.TestKit.Xunit.RetryContractTests<TSut>.Permanent_fault_fails_after_max_attempts_Async() -> System.Threading.Tasks.Task!
+Wolfgang.Etl.TestKit.Xunit.RetryContractTests<TSut>.Transient_fault_causes_more_than_one_attempt_Async() -> System.Threading.Tasks.Task!
+Wolfgang.Etl.TestKit.Xunit.RetryContractTests<TSut>.Transient_fault_within_budget_eventually_succeeds_Async() -> System.Threading.Tasks.Task!
+abstract Wolfgang.Etl.TestKit.Xunit.RetryContractTests<TSut>.RunWithPermanentFaultAsync(int maxAttempts) -> System.Threading.Tasks.Task<Wolfgang.Etl.TestKit.Xunit.RetryOutcome!>!
+abstract Wolfgang.Etl.TestKit.Xunit.RetryContractTests<TSut>.RunWithTransientFaultAsync(int failFirstAttempts, int maxAttempts) -> System.Threading.Tasks.Task<Wolfgang.Etl.TestKit.Xunit.RetryOutcome!>!
+virtual Wolfgang.Etl.TestKit.Xunit.RetryContractTests<TSut>.FailFirstAttempts.get -> int
+virtual Wolfgang.Etl.TestKit.Xunit.RetryContractTests<TSut>.MaxAttempts.get -> int
+Wolfgang.Etl.TestKit.Xunit.RetryOutcome
+Wolfgang.Etl.TestKit.Xunit.RetryOutcome.RetryOutcome(bool succeeded, int attemptCount, int itemCount) -> void
+Wolfgang.Etl.TestKit.Xunit.RetryOutcome.AttemptCount.get -> int
+Wolfgang.Etl.TestKit.Xunit.RetryOutcome.ItemCount.get -> int
+Wolfgang.Etl.TestKit.Xunit.RetryOutcome.Succeeded.get -> bool

--- a/src/Wolfgang.Etl.TestKit.Xunit/RetryContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/RetryContractTests.cs
@@ -1,0 +1,96 @@
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Wolfgang.Etl.TestKit.Xunit;
+
+/// <summary>
+/// Abstract base class providing xUnit contract tests for a stage whose
+/// <see cref="Wolfgang.Etl.Abstractions"/> 0.20 <c>WrapWorkerExecution</c> override adds a retry /
+/// resilience strategy: a transient fault that clears within the retry budget completes the run, and a
+/// fault that never clears fails after the maximum number of attempts (no infinite loop).
+/// </summary>
+/// <typeparam name="TSut">The system under test (an extractor, loader, or transformer with retry).</typeparam>
+/// <remarks>
+/// <para>
+/// The derived class owns and drives its stage — the base never receives the SUT, so overrides need no
+/// null-argument validation. Implement <see cref="RunWithTransientFaultAsync"/> (a stage that throws on
+/// its first <c>failFirstAttempts</c> worker invocations and then succeeds, with a retry budget of
+/// <c>maxAttempts</c>) and <see cref="RunWithPermanentFaultAsync"/> (a stage whose fault never clears),
+/// each reporting a <see cref="RetryOutcome"/>. <c>RetryingExtractor&lt;T&gt;</c> (in the core package)
+/// is a ready-made component these overrides can drive.
+/// </para>
+/// </remarks>
+public abstract class RetryContractTests<TSut>
+{
+    /// <summary>The number of leading worker invocations that fail before one succeeds, for the transient case.</summary>
+    protected virtual int FailFirstAttempts => 2;
+
+
+
+    /// <summary>The maximum number of worker invocations (initial try plus retries).</summary>
+    protected virtual int MaxAttempts => 5;
+
+
+
+    /// <summary>
+    /// Drives a stage that throws a transient fault on its first <paramref name="failFirstAttempts"/>
+    /// worker invocations and then succeeds, with a retry budget of <paramref name="maxAttempts"/>.
+    /// </summary>
+    /// <returns>The observed outcome — whether it succeeded, how many attempts, and how many items.</returns>
+    protected abstract Task<RetryOutcome> RunWithTransientFaultAsync(int failFirstAttempts, int maxAttempts);
+
+
+
+    /// <summary>
+    /// Drives a stage whose fault never clears, with a retry budget of <paramref name="maxAttempts"/>,
+    /// letting the final fault propagate.
+    /// </summary>
+    /// <returns>The observed outcome — it should not have succeeded, having made <paramref name="maxAttempts"/> attempts.</returns>
+    protected abstract Task<RetryOutcome> RunWithPermanentFaultAsync(int maxAttempts);
+
+
+
+    /// <summary>
+    /// Verifies that a transient fault clearing within the retry budget lets the run complete, having
+    /// retried exactly as many times as the fault required and still delivered its items.
+    /// </summary>
+    [Fact]
+    public async Task Transient_fault_within_budget_eventually_succeeds_Async()
+    {
+        Assert.True(FailFirstAttempts < MaxAttempts, "FailFirstAttempts must be less than MaxAttempts for this test to be meaningful.");
+
+        var outcome = await RunWithTransientFaultAsync(FailFirstAttempts, MaxAttempts).ConfigureAwait(false);
+
+        Assert.True(outcome.Succeeded, "A transient fault clearing within the retry budget should let the run complete.");
+        Assert.Equal(FailFirstAttempts + 1, outcome.AttemptCount);
+        Assert.True(outcome.ItemCount > 0, "The successful attempt should have delivered items.");
+    }
+
+
+
+    /// <summary>
+    /// Verifies that retry actually happened (more than a single attempt) for the transient case.
+    /// </summary>
+    [Fact]
+    public async Task Transient_fault_causes_more_than_one_attempt_Async()
+    {
+        var outcome = await RunWithTransientFaultAsync(FailFirstAttempts, MaxAttempts).ConfigureAwait(false);
+
+        Assert.True(outcome.AttemptCount > 1, "A transient fault should have triggered at least one retry.");
+    }
+
+
+
+    /// <summary>
+    /// Verifies that a fault that never clears fails after the maximum number of attempts — the retry
+    /// gives up rather than looping forever.
+    /// </summary>
+    [Fact]
+    public async Task Permanent_fault_fails_after_max_attempts_Async()
+    {
+        var outcome = await RunWithPermanentFaultAsync(MaxAttempts).ConfigureAwait(false);
+
+        Assert.False(outcome.Succeeded, "A fault that never clears should not complete the run.");
+        Assert.Equal(MaxAttempts, outcome.AttemptCount);
+    }
+}

--- a/src/Wolfgang.Etl.TestKit.Xunit/RetryOutcome.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/RetryOutcome.cs
@@ -1,0 +1,38 @@
+namespace Wolfgang.Etl.TestKit.Xunit;
+
+/// <summary>
+/// The result a derived <see cref="RetryContractTests{TSut}"/> reports back to the base after driving
+/// its stage under a fault with a retry policy.
+/// </summary>
+public sealed class RetryOutcome
+{
+    /// <summary>
+    /// Initializes a new <see cref="RetryOutcome"/>.
+    /// </summary>
+    /// <param name="succeeded">
+    /// <see langword="true"/> if the run completed without the fault propagating out.
+    /// </param>
+    /// <param name="attemptCount">The number of worker invocations (initial try plus retries) made.</param>
+    /// <param name="itemCount">The number of items the run produced.</param>
+    public RetryOutcome(bool succeeded, int attemptCount, int itemCount)
+    {
+        Succeeded    = succeeded;
+        AttemptCount = attemptCount;
+        ItemCount    = itemCount;
+    }
+
+
+
+    /// <summary>Gets a value indicating whether the run completed without the fault propagating out.</summary>
+    public bool Succeeded { get; }
+
+
+
+    /// <summary>Gets the number of worker invocations (initial try plus retries) the run made.</summary>
+    public int AttemptCount { get; }
+
+
+
+    /// <summary>Gets the number of items the run produced.</summary>
+    public int ItemCount { get; }
+}

--- a/src/Wolfgang.Etl.TestKit/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.TestKit/PublicAPI.Unshipped.txt
@@ -1,1 +1,7 @@
 #nullable enable
+Wolfgang.Etl.TestKit.RetryingExtractor<T>
+Wolfgang.Etl.TestKit.RetryingExtractor<T>.RetryingExtractor(System.Collections.Generic.IEnumerable<T>! items, int failFirstAttempts, int maxAttempts) -> void
+Wolfgang.Etl.TestKit.RetryingExtractor<T>.AttemptCount.get -> int
+override Wolfgang.Etl.TestKit.RetryingExtractor<T>.CreateProgressReport() -> Wolfgang.Etl.Abstractions.Report!
+override Wolfgang.Etl.TestKit.RetryingExtractor<T>.ExtractWorkerAsync(System.Threading.CancellationToken token) -> System.Collections.Generic.IAsyncEnumerable<T>!
+override Wolfgang.Etl.TestKit.RetryingExtractor<T>.WrapWorkerExecution(System.Func<System.Threading.CancellationToken, System.Collections.Generic.IAsyncEnumerable<T>!>! workerFactory, System.Threading.CancellationToken token) -> System.Collections.Generic.IAsyncEnumerable<T>!

--- a/src/Wolfgang.Etl.TestKit/RetryingExtractor.cs
+++ b/src/Wolfgang.Etl.TestKit/RetryingExtractor.cs
@@ -1,0 +1,219 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+
+namespace Wolfgang.Etl.TestKit;
+
+/// <summary>
+/// An extractor double that throws a transient fault on its first <c>failFirstAttempts</c> worker
+/// invocations and then succeeds, driven through a retry override of the
+/// <see cref="Wolfgang.Etl.Abstractions"/> 0.20 <c>WrapWorkerExecution</c> resilience seam. It both
+/// demonstrates how to build stream-level retry on a stage and serves as the reference component
+/// exercised by <c>RetryContractTests</c> (in <c>Wolfgang.Etl.TestKit.Xunit</c>).
+/// </summary>
+/// <typeparam name="T">The type of item to extract. Must be <c>notnull</c>.</typeparam>
+/// <remarks>
+/// <para>
+/// Each retry re-invokes the worker from the start (stream-level resilience, per the base contract).
+/// Because the transient fault is thrown at the <em>start</em> of the worker — before any item is
+/// yielded — a retried attempt never double-yields. After <c>failFirstAttempts</c> failures the
+/// worker yields every item; if the retry budget (<c>maxAttempts</c>) is exhausted first, the last
+/// fault propagates. <see cref="AttemptCount"/> records how many worker invocations occurred.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// // Fails twice, then succeeds on the third attempt (budget of 5):
+/// var extractor = new RetryingExtractor&lt;int&gt;(Enumerable.Range(0, 10), failFirstAttempts: 2, maxAttempts: 5);
+/// var items = await extractor.ExtractAsync().ToListAsync();   // succeeds; extractor.AttemptCount == 3
+/// </code>
+/// </example>
+public class RetryingExtractor<T> : ExtractorBase<T, Report>
+    where T : notnull
+{
+    // ------------------------------------------------------------------
+    // Fields
+    // ------------------------------------------------------------------
+
+    private readonly IEnumerable<T> _items;
+    private readonly int _failFirstAttempts;
+    private readonly int _maxAttempts;
+    private int _attemptCount;
+
+
+
+    // ------------------------------------------------------------------
+    // Constructor
+    // ------------------------------------------------------------------
+
+    /// <summary>
+    /// Initializes a new <see cref="RetryingExtractor{T}"/>.
+    /// </summary>
+    /// <param name="items">The items to extract once a worker invocation succeeds.</param>
+    /// <param name="failFirstAttempts">
+    /// The number of leading worker invocations that throw a transient fault before one succeeds.
+    /// Use a value ≥ <paramref name="maxAttempts"/> to model a permanent fault.
+    /// </param>
+    /// <param name="maxAttempts">The maximum number of worker invocations (initial try plus retries).</param>
+    /// <exception cref="ArgumentNullException"><paramref name="items"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="failFirstAttempts"/> is negative, or <paramref name="maxAttempts"/> is less than 1.
+    /// </exception>
+    public RetryingExtractor(IEnumerable<T> items, int failFirstAttempts, int maxAttempts)
+    {
+        _items = items ?? throw new ArgumentNullException(nameof(items));
+
+        if (failFirstAttempts < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(failFirstAttempts), failFirstAttempts, "Must not be negative.");
+        }
+
+        if (maxAttempts < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maxAttempts), maxAttempts, "Must be at least 1.");
+        }
+
+        _failFirstAttempts = failFirstAttempts;
+        _maxAttempts       = maxAttempts;
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // Public API
+    // ------------------------------------------------------------------
+
+    /// <summary>Gets the number of worker invocations (attempts) made by the most recent run.</summary>
+    public int AttemptCount => _attemptCount;
+
+
+
+    // ------------------------------------------------------------------
+    // ExtractorBase overrides
+    // ------------------------------------------------------------------
+
+    /// <inheritdoc/>
+    protected override Report CreateProgressReport() =>
+        new(CurrentItemCount, StartedAt, Elapsed, (_items as ICollection<T>)?.Count);
+
+
+
+    /// <inheritdoc/>
+    protected override async IAsyncEnumerable<T> ExtractWorkerAsync
+    (
+        [EnumeratorCancellation] CancellationToken token
+    )
+    {
+        var attempt = Interlocked.Increment(ref _attemptCount);
+
+        token.ThrowIfCancellationRequested();
+
+        await Task.Yield();
+
+        if (attempt <= _failFirstAttempts)
+        {
+            throw new InvalidOperationException($"Transient fault on attempt {attempt}.");
+        }
+
+        foreach (var item in _items)
+        {
+            token.ThrowIfCancellationRequested();
+
+            if (CurrentSkippedItemCount < SkipItemCount)
+            {
+                IncrementCurrentSkippedItemCount();
+                continue;
+            }
+
+            if (CurrentItemCount >= MaximumItemCount)
+            {
+                yield break;
+            }
+
+            IncrementCurrentItemCount();
+            yield return item;
+        }
+    }
+
+
+
+    /// <summary>
+    /// Retries the worker up to <c>maxAttempts</c> times: each attempt re-invokes
+    /// <paramref name="workerFactory"/> to produce a fresh stream, and a failed attempt is retried
+    /// until the budget is exhausted, at which point the last fault propagates. Cancellation is never
+    /// retried.
+    /// </summary>
+    /// <param name="workerFactory">A factory producing a fresh worker stream for the supplied token.</param>
+    /// <param name="token">A token to observe.</param>
+    /// <returns>The retried stream of extracted items.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="workerFactory"/> is <see langword="null"/>.</exception>
+    protected override async IAsyncEnumerable<T> WrapWorkerExecution
+    (
+        Func<CancellationToken, IAsyncEnumerable<T>> workerFactory,
+        [EnumeratorCancellation] CancellationToken token
+    )
+    {
+        if (workerFactory is null)
+        {
+            throw new ArgumentNullException(nameof(workerFactory));
+        }
+
+        for (var attempt = 1; ; attempt++)
+        {
+            var buffer  = new List<T>();
+            ExceptionDispatchInfo? failure = null;
+
+            var enumerator = workerFactory(token).GetAsyncEnumerator(token);
+            try
+            {
+                while (true)
+                {
+                    try
+                    {
+                        if (!await enumerator.MoveNextAsync().ConfigureAwait(false))
+                        {
+                            break;
+                        }
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        throw;
+                    }
+#pragma warning disable CA1031 // a test double deliberately captures any worker fault to drive retry
+                    catch (Exception ex)
+                    {
+                        failure = ExceptionDispatchInfo.Capture(ex);
+                        break;
+                    }
+#pragma warning restore CA1031
+
+                    buffer.Add(enumerator.Current);
+                }
+            }
+            finally
+            {
+                await enumerator.DisposeAsync().ConfigureAwait(false);
+            }
+
+            if (failure is null)
+            {
+                foreach (var item in buffer)
+                {
+                    yield return item;
+                }
+
+                yield break;
+            }
+
+            if (attempt >= _maxAttempts)
+            {
+                failure.Throw();
+            }
+        }
+    }
+}

--- a/tests/Wolfgang.Etl.TestKit.Tests.Unit/RetryingExtractorTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Unit/RetryingExtractorTests.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Wolfgang.Etl.TestKit;
+using Xunit;
+
+namespace Wolfgang.Etl.TestKit.Tests.Unit;
+
+public class RetryingExtractorTests
+{
+    // ------------------------------------------------------------------
+    // Constructor — argument validation
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void Constructor_when_items_is_null_throws_ArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>
+        (
+            () => new RetryingExtractor<int>(null!, failFirstAttempts: 0, maxAttempts: 1)
+        );
+    }
+
+
+
+    [Fact]
+    public void Constructor_when_failFirstAttempts_is_negative_throws_ArgumentOutOfRangeException()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>
+        (
+            () => new RetryingExtractor<int>(new[] { 1 }, failFirstAttempts: -1, maxAttempts: 1)
+        );
+    }
+
+
+
+    [Fact]
+    public void Constructor_when_maxAttempts_is_less_than_one_throws_ArgumentOutOfRangeException()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>
+        (
+            () => new RetryingExtractor<int>(new[] { 1 }, failFirstAttempts: 0, maxAttempts: 0)
+        );
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // Retry behaviour
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task ExtractAsync_when_no_fault_configured_succeeds_on_the_first_attempt()
+    {
+        var sut = new RetryingExtractor<int>(new[] { 1, 2, 3 }, failFirstAttempts: 0, maxAttempts: 5);
+
+        var items = await sut.ExtractAsync(CancellationToken.None).ToListAsync().ConfigureAwait(false);
+
+        Assert.Equal(new[] { 1, 2, 3 }, items);
+        Assert.Equal(1, sut.AttemptCount);
+    }
+
+
+
+    [Fact]
+    public async Task ExtractAsync_when_transient_fault_clears_within_budget_succeeds_after_retries()
+    {
+        var sut = new RetryingExtractor<int>(new[] { 1, 2, 3 }, failFirstAttempts: 2, maxAttempts: 5);
+
+        var items = await sut.ExtractAsync(CancellationToken.None).ToListAsync().ConfigureAwait(false);
+
+        Assert.Equal(new[] { 1, 2, 3 }, items);
+        Assert.Equal(3, sut.AttemptCount);
+    }
+
+
+
+    [Fact]
+    public async Task ExtractAsync_when_fault_never_clears_throws_after_max_attempts()
+    {
+        var sut = new RetryingExtractor<int>(new[] { 1, 2, 3 }, failFirstAttempts: 5, maxAttempts: 3);
+
+        await Assert.ThrowsAsync<InvalidOperationException>
+        (
+            async () =>
+            {
+                await foreach (var _ in sut.ExtractAsync(CancellationToken.None).ConfigureAwait(false))
+                {
+                }
+            }
+        ).ConfigureAwait(false);
+
+        Assert.Equal(3, sut.AttemptCount);
+    }
+}

--- a/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/RetryingExtractorRetryContractTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/RetryingExtractorRetryContractTests.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Wolfgang.Etl.TestKit;
+using Wolfgang.Etl.TestKit.Xunit;
+
+namespace Wolfgang.Etl.TestKit.Xunit.Tests.Unit;
+
+/// <summary>
+/// Exercises <see cref="RetryContractTests{TSut}"/> by driving a <see cref="RetryingExtractor{T}"/>,
+/// confirming the retry contract holds against the reference retry double.
+/// </summary>
+public sealed class RetryingExtractorRetryContractTests
+    : RetryContractTests<RetryingExtractor<int>>
+{
+    protected override Task<RetryOutcome> RunWithTransientFaultAsync(int failFirstAttempts, int maxAttempts) =>
+        DriveAsync(new RetryingExtractor<int>(Enumerable.Range(0, 5).ToArray(), failFirstAttempts, maxAttempts));
+
+
+
+    protected override Task<RetryOutcome> RunWithPermanentFaultAsync(int maxAttempts) =>
+        DriveAsync(new RetryingExtractor<int>(Enumerable.Range(0, 5).ToArray(), failFirstAttempts: maxAttempts, maxAttempts: maxAttempts));
+
+
+
+    private static async Task<RetryOutcome> DriveAsync(RetryingExtractor<int> sut)
+    {
+        var itemCount = 0;
+        var succeeded = false;
+
+        try
+        {
+            await foreach (var _ in sut.ExtractAsync(CancellationToken.None).ConfigureAwait(false))
+            {
+                itemCount++;
+            }
+
+            succeeded = true;
+        }
+        catch (InvalidOperationException)
+        {
+            succeeded = false;
+        }
+
+        return new RetryOutcome(succeeded, sut.AttemptCount, itemCount);
+    }
+}


### PR DESCRIPTION
First feature of the **0.13.0 cycle** (Abstractions 0.20.0), the companion to the `WrapWorkerExecution` retry seam (ETL-Abstractions#94).

## What's new
- **`RetryingExtractor<T>`** (core) — throws a transient fault on its first `failFirstAttempts` worker invocations, then succeeds, via a retry override of `WrapWorkerExecution`. Each retry re-invokes the worker for a fresh stream (stream-level resilience per the base contract); the fault is thrown at worker start so retries never double-yield. Exposes `AttemptCount`. Doubles as a worked example of building retry on the seam.
- **`RetryContractTests<TSut>` + `RetryOutcome`** (xunit) — verifies a stage's retry strategy:
  - a transient fault clearing within the budget → run succeeds, with the expected attempt count and items;
  - retry actually happened (attempts > 1);
  - a fault that never clears → fails after `MaxAttempts` (no infinite loop).

## Design
Self-report pattern — the derived class drives its own stage and returns a `RetryOutcome`; **no SUT is passed to the override** (CA1062-safe, consistent with `ErrorHandlingOutcome` / `CancellationOutcome`).

## Verification
- Full multi-TFM Release build clean (0 warnings; confirms `WrapWorkerExecution` is an overridable seam in 0.20) against local `C:\Nuget-local` 0.20.0.
- Retry tests pass **net10.0 + net48**: 6 `RetryingExtractor` unit tests + 3 contract tests.

## Note on base branch / CI
Targets **`vNext-0.20.0`** (the 0.13.0 integration branch). CI restore needs Abstractions 0.20.0 on nuget.org, which isn't published yet (vnext-plus-one) — verified locally. This cycle releases as TestKit 0.13.0 once Abstractions 0.20.0 publishes. See #268.

Closes #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)