### PR TITLE
Add ManualTimeSource for deterministic Report timing (#262)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `ManualTimeSource` + `WithTimeSource(...)` extensions — a controllable clock that freezes time until
+  `Advance` is called, making a stage's `Report` timing metrics (`Elapsed`, `ItemsPerSecond`,
+  `PercentComplete`, `EstimatedRemaining`) deterministic instead of wall-clock-dependent. Attach it to
+  an extractor / loader / transformer before the run, then advance by a known amount. Uses the internal
+  `ITimeSource` clock seam (Abstractions 0.20) via the `Wolfgang.Etl.TestKit` friend relationship, so
+  production code is unchanged. (#262)
 - `RetryingExtractor<T>` — an extractor double that throws a transient fault on its first
   `failFirstAttempts` worker invocations and then succeeds, driven through a retry override of the
   Abstractions 0.20 `WrapWorkerExecution` resilience seam (each retry re-invokes the worker for a fresh

--- a/README.md
+++ b/README.md
@@ -184,6 +184,26 @@ await Verify(loader.Snapshot);   // Verify owns the .verified.txt golden file + 
 
 **The fleet convention** (see ETL-FixedWidth, ETL-DbClient, ETL-Json): put snapshot tests in a **dedicated `*.Tests.Snapshot` project targeting a single modern TFM** (e.g. `net10.0` — Verify needs net6+ and the output is TFM-agnostic, which keeps snapshot filenames stable), reference `Verify.Xunit`, commit the `.verified.txt` golden files under `Snapshots/`, and gitignore the `.received.txt` files written during local iteration.
 
+### Core — deterministic `Report` timing with `ManualTimeSource`
+
+A stage's `Report` timing metrics — `Elapsed`, `ItemsPerSecond`, `PercentComplete`, `EstimatedRemaining` (Abstractions 0.14) — are normally driven by wall-clock time, so they can't be asserted on exactly. `ManualTimeSource` freezes time until you `Advance` it, making them deterministic. Attach it with `WithTimeSource(...)` **before** the run (the stage captures its start timestamp when the run begins), then advance by a known amount:
+
+```csharp
+using System;
+using System.Linq;
+using Wolfgang.Etl.TestKit;
+
+var clock = new ManualTimeSource();
+var extractor = new TestExtractor<int>(Enumerable.Range(0, 50).ToArray()).WithTimeSource(clock);
+
+await extractor.ExtractAsync().ToListAsync();   // start timestamp captured from the frozen clock
+clock.Advance(TimeSpan.FromSeconds(10));
+
+// A report built now has Elapsed == 10s exactly and ItemsPerSecond == 5.
+```
+
+`WithTimeSource` has extractor, loader, and transformer overloads. It works because `Wolfgang.Etl.TestKit` is an internals-visible friend of `Wolfgang.Etl.Abstractions`, so it can supply the internal clock seam the base classes read — no change to your production code.
+
 ### xUnit — capturing and asserting on progress
 
 `ProgressCapture<T>` is an `IProgress<T>` that records every report; pass it straight to any progress-aware overload, then assert with `ProgressAssert`:

--- a/src/Wolfgang.Etl.TestKit/ManualTimeSource.cs
+++ b/src/Wolfgang.Etl.TestKit/ManualTimeSource.cs
@@ -1,0 +1,97 @@
+using System;
+using Wolfgang.Etl.Abstractions;
+
+namespace Wolfgang.Etl.TestKit;
+
+/// <summary>
+/// A controllable time source for tests: time stands still until <see cref="Advance"/> is called,
+/// making a stage's <see cref="Report"/> timing metrics — <see cref="Report.Elapsed"/>,
+/// <see cref="Report.ItemsPerSecond"/>, <see cref="Report.PercentComplete"/>, and
+/// <see cref="Report.EstimatedRemaining"/> — deterministic rather than wall-clock-dependent.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Attach it to an extractor / loader / transformer with
+/// <see cref="TimeSourceExtensions.WithTimeSource{TSource, TProgress}(ExtractorBase{TSource, TProgress}, ManualTimeSource)"/>
+/// (and its loader / transformer overloads) <em>before</em> the run starts, then call
+/// <see cref="Advance"/> to move the clock forward by a known amount. The stage reads its start
+/// timestamp when the run begins, so a subsequent <c>Advance(TimeSpan.FromSeconds(10))</c> makes
+/// <see cref="Report.Elapsed"/> report exactly ten seconds.
+/// </para>
+/// <para>
+/// This works because <c>Wolfgang.Etl.TestKit</c> is an internals-visible friend of
+/// <c>Wolfgang.Etl.Abstractions</c>, so it can supply the internal time-source seam the base classes
+/// read. The default epoch is a fixed constant so <see cref="Report.StartedAt"/> is reproducible too.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// var clock = new ManualTimeSource();
+/// var extractor = new TestExtractor&lt;int&gt;(Enumerable.Range(0, 50).ToArray()).WithTimeSource(clock);
+/// await extractor.ExtractAsync().ToListAsync();   // start timestamp captured from the frozen clock
+/// clock.Advance(TimeSpan.FromSeconds(10));
+/// // A report built now has Elapsed == 10s and ItemsPerSecond == 5.
+/// </code>
+/// </example>
+public sealed class ManualTimeSource : ITimeSource
+{
+    private static readonly DateTimeOffset DefaultEpoch = new DateTimeOffset(2000, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+    // The base classes treat a captured start timestamp of 0 as the "run has not started" sentinel,
+    // so the source must never report 0 — begin one second in and only ever move forward.
+    private const long InitialTimestamp = TimeSpan.TicksPerSecond;
+
+    private DateTimeOffset _utcNow;
+    private long _timestamp;
+
+
+
+    /// <summary>Initializes a new <see cref="ManualTimeSource"/> at a fixed default epoch.</summary>
+    public ManualTimeSource()
+        : this(DefaultEpoch)
+    {
+    }
+
+
+
+    /// <summary>Initializes a new <see cref="ManualTimeSource"/> at <paramref name="start"/>.</summary>
+    /// <param name="start">The initial wall-clock value reported by the source.</param>
+    public ManualTimeSource(DateTimeOffset start)
+    {
+        _utcNow    = start;
+        _timestamp = InitialTimestamp;
+    }
+
+
+
+    /// <summary>Moves the clock forward by <paramref name="delta"/>.</summary>
+    /// <param name="delta">The non-negative amount of time to advance.</param>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="delta"/> is negative.</exception>
+    public void Advance(TimeSpan delta)
+    {
+        if (delta < TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(delta), delta, "Cannot advance time by a negative amount.");
+        }
+
+        _utcNow    += delta;
+        _timestamp += delta.Ticks;
+    }
+
+
+
+    // ITimeSource is internal to Abstractions (visible here via InternalsVisibleTo). Implement it
+    // explicitly so these members stay off ManualTimeSource's public surface — callers only need
+    // the constructors and Advance. The timestamp frequency is one tick per 100 ns
+    // (TimeSpan.TicksPerSecond), so Advance can add TimeSpan.Ticks directly.
+
+    DateTimeOffset ITimeSource.UtcNow => _utcNow;
+
+
+
+    long ITimeSource.GetTimestamp() => _timestamp;
+
+
+
+    long ITimeSource.TimestampFrequency => TimeSpan.TicksPerSecond;
+}

--- a/src/Wolfgang.Etl.TestKit/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.TestKit/PublicAPI.Unshipped.txt
@@ -5,3 +5,11 @@ Wolfgang.Etl.TestKit.RetryingExtractor<T>.AttemptCount.get -> int
 override Wolfgang.Etl.TestKit.RetryingExtractor<T>.CreateProgressReport() -> Wolfgang.Etl.Abstractions.Report!
 override Wolfgang.Etl.TestKit.RetryingExtractor<T>.ExtractWorkerAsync(System.Threading.CancellationToken token) -> System.Collections.Generic.IAsyncEnumerable<T>!
 override Wolfgang.Etl.TestKit.RetryingExtractor<T>.WrapWorkerExecution(System.Func<System.Threading.CancellationToken, System.Collections.Generic.IAsyncEnumerable<T>!>! workerFactory, System.Threading.CancellationToken token) -> System.Collections.Generic.IAsyncEnumerable<T>!
+Wolfgang.Etl.TestKit.ManualTimeSource
+Wolfgang.Etl.TestKit.ManualTimeSource.ManualTimeSource() -> void
+Wolfgang.Etl.TestKit.ManualTimeSource.ManualTimeSource(System.DateTimeOffset start) -> void
+Wolfgang.Etl.TestKit.ManualTimeSource.Advance(System.TimeSpan delta) -> void
+Wolfgang.Etl.TestKit.TimeSourceExtensions
+static Wolfgang.Etl.TestKit.TimeSourceExtensions.WithTimeSource<TSource, TProgress>(this Wolfgang.Etl.Abstractions.ExtractorBase<TSource, TProgress>! extractor, Wolfgang.Etl.TestKit.ManualTimeSource! timeSource) -> Wolfgang.Etl.Abstractions.ExtractorBase<TSource, TProgress>!
+static Wolfgang.Etl.TestKit.TimeSourceExtensions.WithTimeSource<TDestination, TProgress>(this Wolfgang.Etl.Abstractions.LoaderBase<TDestination, TProgress>! loader, Wolfgang.Etl.TestKit.ManualTimeSource! timeSource) -> Wolfgang.Etl.Abstractions.LoaderBase<TDestination, TProgress>!
+static Wolfgang.Etl.TestKit.TimeSourceExtensions.WithTimeSource<TSource, TDestination, TProgress>(this Wolfgang.Etl.Abstractions.TransformerBase<TSource, TDestination, TProgress>! transformer, Wolfgang.Etl.TestKit.ManualTimeSource! timeSource) -> Wolfgang.Etl.Abstractions.TransformerBase<TSource, TDestination, TProgress>!

--- a/src/Wolfgang.Etl.TestKit/TimeSourceExtensions.cs
+++ b/src/Wolfgang.Etl.TestKit/TimeSourceExtensions.cs
@@ -1,0 +1,96 @@
+using System;
+using Wolfgang.Etl.Abstractions;
+
+namespace Wolfgang.Etl.TestKit;
+
+/// <summary>
+/// Extension methods that attach a <see cref="ManualTimeSource"/> to a stage so its
+/// <see cref="Report"/> timing metrics can be driven deterministically in tests.
+/// </summary>
+/// <remarks>
+/// These reach the internal time-source seam on the base classes via the friend relationship between
+/// <c>Wolfgang.Etl.TestKit</c> and <c>Wolfgang.Etl.Abstractions</c>. Attach the clock before the run
+/// starts; the stage captures its start timestamp when the run begins.
+/// </remarks>
+public static class TimeSourceExtensions
+{
+    /// <summary>Attaches <paramref name="timeSource"/> to <paramref name="extractor"/>.</summary>
+    /// <returns><paramref name="extractor"/>, for chaining.</returns>
+    /// <exception cref="ArgumentNullException">Either argument is <see langword="null"/>.</exception>
+    public static ExtractorBase<TSource, TProgress> WithTimeSource<TSource, TProgress>
+    (
+        this ExtractorBase<TSource, TProgress> extractor,
+        ManualTimeSource timeSource
+    )
+        where TSource : notnull
+        where TProgress : notnull
+    {
+        if (extractor is null)
+        {
+            throw new ArgumentNullException(nameof(extractor));
+        }
+
+        if (timeSource is null)
+        {
+            throw new ArgumentNullException(nameof(timeSource));
+        }
+
+        extractor.TimeSource = timeSource;
+        return extractor;
+    }
+
+
+
+    /// <summary>Attaches <paramref name="timeSource"/> to <paramref name="loader"/>.</summary>
+    /// <returns><paramref name="loader"/>, for chaining.</returns>
+    /// <exception cref="ArgumentNullException">Either argument is <see langword="null"/>.</exception>
+    public static LoaderBase<TDestination, TProgress> WithTimeSource<TDestination, TProgress>
+    (
+        this LoaderBase<TDestination, TProgress> loader,
+        ManualTimeSource timeSource
+    )
+        where TDestination : notnull
+        where TProgress : notnull
+    {
+        if (loader is null)
+        {
+            throw new ArgumentNullException(nameof(loader));
+        }
+
+        if (timeSource is null)
+        {
+            throw new ArgumentNullException(nameof(timeSource));
+        }
+
+        loader.TimeSource = timeSource;
+        return loader;
+    }
+
+
+
+    /// <summary>Attaches <paramref name="timeSource"/> to <paramref name="transformer"/>.</summary>
+    /// <returns><paramref name="transformer"/>, for chaining.</returns>
+    /// <exception cref="ArgumentNullException">Either argument is <see langword="null"/>.</exception>
+    public static TransformerBase<TSource, TDestination, TProgress> WithTimeSource<TSource, TDestination, TProgress>
+    (
+        this TransformerBase<TSource, TDestination, TProgress> transformer,
+        ManualTimeSource timeSource
+    )
+        where TSource : notnull
+        where TDestination : notnull
+        where TProgress : notnull
+    {
+        if (transformer is null)
+        {
+            throw new ArgumentNullException(nameof(transformer));
+        }
+
+        if (timeSource is null)
+        {
+            throw new ArgumentNullException(nameof(timeSource));
+        }
+
+        transformer.TimeSource = timeSource;
+        return transformer;
+    }
+}

--- a/tests/Wolfgang.Etl.TestKit.Tests.Unit/ManualTimeSourceTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Unit/ManualTimeSourceTests.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+using Wolfgang.Etl.TestKit;
+using Xunit;
+
+namespace Wolfgang.Etl.TestKit.Tests.Unit;
+
+public class ManualTimeSourceTests
+{
+    [Fact]
+    public void Advance_when_delta_is_negative_throws_ArgumentOutOfRangeException()
+    {
+        var clock = new ManualTimeSource();
+
+        Assert.Throws<ArgumentOutOfRangeException>
+        (
+            () => clock.Advance(TimeSpan.FromSeconds(-1))
+        );
+    }
+
+
+
+    [Fact]
+    public void WithTimeSource_when_timeSource_is_null_throws_ArgumentNullException()
+    {
+        var extractor = new TestExtractor<int>(new[] { 1 });
+
+        Assert.Throws<ArgumentNullException>
+        (
+            () => extractor.WithTimeSource(null!)
+        );
+    }
+
+
+
+    [Fact]
+    public async Task Report_Elapsed_reflects_the_advanced_time_deterministically()
+    {
+        var clock = new ManualTimeSource();
+        var sut   = new ExposedExtractor<int>(Enumerable.Range(0, 50).ToArray());
+        sut.WithTimeSource(clock);
+
+        await sut.ExtractAsync(CancellationToken.None).ToListAsync().ConfigureAwait(false);
+        clock.Advance(TimeSpan.FromSeconds(10));
+
+        var report = sut.GetProgressReport();
+
+        Assert.Equal(TimeSpan.FromSeconds(10), report.Elapsed);
+    }
+
+
+
+    [Fact]
+    public async Task Report_StartedAt_is_reported_once_a_run_has_begun()
+    {
+        var clock = new ManualTimeSource();
+        var sut   = new ExposedExtractor<int>(new[] { 1, 2, 3 });
+        sut.WithTimeSource(clock);
+
+        await sut.ExtractAsync(CancellationToken.None).ToListAsync().ConfigureAwait(false);
+
+        var report = sut.GetProgressReport();
+
+        Assert.NotNull(report.StartedAt);
+    }
+
+
+
+    [Fact]
+    public async Task Report_ItemsPerSecond_computes_deterministically()
+    {
+        var clock = new ManualTimeSource();
+        var sut   = new ExposedExtractor<int>(Enumerable.Range(0, 50).ToArray());
+        sut.WithTimeSource(clock);
+
+        await sut.ExtractAsync(CancellationToken.None).ToListAsync().ConfigureAwait(false);
+        clock.Advance(TimeSpan.FromSeconds(10));
+
+        var report = sut.GetProgressReport();
+
+        // 50 items over 10 deterministic seconds.
+        Assert.Equal(5.0, report.ItemsPerSecond);
+    }
+
+
+
+    private sealed class ExposedExtractor<T> : TestExtractor<T>
+        where T : notnull
+    {
+        public ExposedExtractor(IEnumerable<T> items)
+            : base(items)
+        {
+        }
+
+
+
+        public Report GetProgressReport() => CreateProgressReport();
+    }
+}


### PR DESCRIPTION
Second feature of the **0.13.0 cycle** — makes a stage's `Report` timing metrics assertable by freezing and advancing time. Uses the internal `ITimeSource` clock seam added in Abstractions 0.20 (ETL-Abstractions#338).

> **Stacked on #269 (#261).** Base is `feat/retry-contract-261`; it auto-promotes to `vNext-0.20.0` when #269 merges. Review the [#262-only diff](https://github.com/Chris-Wolfgang/ETL-Test-Kit/compare/feat/retry-contract-261...feat/deterministic-time-262).

## What's new
- **`ManualTimeSource`** (core) — a controllable clock implementing the **internal** `ITimeSource` seam. It's accessible because `Wolfgang.Etl.TestKit` is an `InternalsVisibleTo` friend of `Wolfgang.Etl.Abstractions`, so **production code needs no change**. Time stands still until `Advance(TimeSpan)`. (Starts one second in so the base's "start timestamp == 0 ⇒ not started" sentinel is never hit.)
- **`WithTimeSource(...)`** (core) — extractor / loader / transformer overloads that attach the clock to a stage before the run.

```csharp
var clock = new ManualTimeSource();
var extractor = new TestExtractor<int>(Enumerable.Range(0, 50).ToArray()).WithTimeSource(clock);
await extractor.ExtractAsync().ToListAsync();     // start timestamp captured from the frozen clock
clock.Advance(TimeSpan.FromSeconds(10));
// A report now has Elapsed == 10s exactly and ItemsPerSecond == 5.
```

## Verification
- Full multi-TFM Release build clean (0 warnings) against local `C:\Nuget-local` 0.20.0.
- 5 self-tests pass **net10.0 + net48**, including deterministic `Elapsed == 10s` and `ItemsPerSecond == 5.0`.

Closes #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)