### PR TITLE
Add RecordingMiddleware for the 0.20 middleware surface (Abstractions #93)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `RecordingMiddleware<T>` — a test `IItemMiddleware<T>` (Abstractions 0.20) that records every item it
+  is handed (`Observed`) and, by default, keeps each one flowing; supply a `Func<T, MiddlewareResult<T>>`
+  policy to transform or drop items. Apply it with the `WithMiddleware(...)` extension to assert exactly
+  what a pipeline's middleware chain saw and produced. (Abstractions #93)
 - `ManualTimeSource` + `WithTimeSource(...)` extensions — a controllable clock that freezes time until
   `Advance` is called, making a stage's `Report` timing metrics (`Elapsed`, `ItemsPerSecond`,
   `PercentComplete`, `EstimatedRemaining`) deterministic instead of wall-clock-dependent. Attach it to

--- a/README.md
+++ b/README.md
@@ -204,6 +204,26 @@ clock.Advance(TimeSpan.FromSeconds(10));
 
 `WithTimeSource` has extractor, loader, and transformer overloads. It works because `Wolfgang.Etl.TestKit` is an internals-visible friend of `Wolfgang.Etl.Abstractions`, so it can supply the internal clock seam the base classes read — no change to your production code.
 
+### Core — asserting on middleware with `RecordingMiddleware<T>`
+
+`RecordingMiddleware<T>` is a test `IItemMiddleware<T>` (Abstractions 0.20) that records every item it is handed and, by default, keeps each one flowing — so you can assert exactly what reached a stage of the pipeline. Supply a policy to transform or drop items:
+
+```csharp
+using Wolfgang.Etl.Abstractions;
+using Wolfgang.Etl.TestKit;
+
+// Record and pass through:
+var recorder = new RecordingMiddleware<int>();
+var kept = await source.WithMiddleware(recorder).ToListAsync();
+// recorder.Observed lists every item seen; kept == the ones it let through.
+
+// Drop odds, double evens:
+var shaping = new RecordingMiddleware<int>(i =>
+    i % 2 == 0 ? MiddlewareResult.Continue(i * 2) : MiddlewareResult.Drop<int>());
+```
+
+`Observed` reflects every item the middleware received, *including* ones a policy later drops, and composes across a middleware chain (each middleware sees the previous one's output).
+
 ### xUnit — capturing and asserting on progress
 
 `ProgressCapture<T>` is an `IProgress<T>` that records every report; pass it straight to any progress-aware overload, then assert with `ProgressAssert`:

--- a/src/Wolfgang.Etl.TestKit/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.TestKit/PublicAPI.Unshipped.txt
@@ -13,3 +13,8 @@ Wolfgang.Etl.TestKit.TimeSourceExtensions
 static Wolfgang.Etl.TestKit.TimeSourceExtensions.WithTimeSource<TSource, TProgress>(this Wolfgang.Etl.Abstractions.ExtractorBase<TSource, TProgress>! extractor, Wolfgang.Etl.TestKit.ManualTimeSource! timeSource) -> Wolfgang.Etl.Abstractions.ExtractorBase<TSource, TProgress>!
 static Wolfgang.Etl.TestKit.TimeSourceExtensions.WithTimeSource<TDestination, TProgress>(this Wolfgang.Etl.Abstractions.LoaderBase<TDestination, TProgress>! loader, Wolfgang.Etl.TestKit.ManualTimeSource! timeSource) -> Wolfgang.Etl.Abstractions.LoaderBase<TDestination, TProgress>!
 static Wolfgang.Etl.TestKit.TimeSourceExtensions.WithTimeSource<TSource, TDestination, TProgress>(this Wolfgang.Etl.Abstractions.TransformerBase<TSource, TDestination, TProgress>! transformer, Wolfgang.Etl.TestKit.ManualTimeSource! timeSource) -> Wolfgang.Etl.Abstractions.TransformerBase<TSource, TDestination, TProgress>!
+Wolfgang.Etl.TestKit.RecordingMiddleware<T>
+Wolfgang.Etl.TestKit.RecordingMiddleware<T>.RecordingMiddleware() -> void
+Wolfgang.Etl.TestKit.RecordingMiddleware<T>.RecordingMiddleware(System.Func<T, Wolfgang.Etl.Abstractions.MiddlewareResult<T>>! policy) -> void
+Wolfgang.Etl.TestKit.RecordingMiddleware<T>.Observed.get -> System.Collections.Generic.IReadOnlyList<T>!
+Wolfgang.Etl.TestKit.RecordingMiddleware<T>.OnItemAsync(T item, System.Threading.CancellationToken token) -> System.Threading.Tasks.ValueTask<Wolfgang.Etl.Abstractions.MiddlewareResult<T>>

--- a/src/Wolfgang.Etl.TestKit/RecordingMiddleware.cs
+++ b/src/Wolfgang.Etl.TestKit/RecordingMiddleware.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+
+namespace Wolfgang.Etl.TestKit;
+
+/// <summary>
+/// A test <see cref="IItemMiddleware{T}"/> that records every item passed through it and, by default,
+/// keeps each item flowing. Supply a policy to transform or drop items, and inspect
+/// <see cref="Observed"/> to assert exactly what the middleware saw, in order.
+/// </summary>
+/// <typeparam name="T">The type of item flowing through the middleware.</typeparam>
+/// <remarks>
+/// Apply it to a stream with the <c>Wolfgang.Etl.Abstractions</c> 0.20
+/// <see cref="MiddlewareExtensions.WithMiddleware{T}(System.Collections.Generic.IAsyncEnumerable{T}, IItemMiddleware{T}, System.Threading.CancellationToken)"/>
+/// extension. <see cref="Observed"/> reflects every item the middleware was handed (including ones a
+/// policy later drops), so it is a faithful record of what reached this stage of the pipeline.
+/// </remarks>
+/// <example>
+/// <code>
+/// // Record and pass through:
+/// var recorder = new RecordingMiddleware&lt;int&gt;();
+/// var kept = await source.WithMiddleware(recorder).ToListAsync();
+/// // recorder.Observed lists every item; kept == the ones it let through.
+///
+/// // Drop odds, double evens:
+/// var shaping = new RecordingMiddleware&lt;int&gt;(i =&gt;
+///     i % 2 == 0 ? MiddlewareResult.Continue(i * 2) : MiddlewareResult.Drop&lt;int&gt;());
+/// </code>
+/// </example>
+public sealed class RecordingMiddleware<T> : IItemMiddleware<T>
+{
+    private readonly List<T> _observed = new List<T>();
+    private readonly Func<T, MiddlewareResult<T>>? _policy;
+
+
+
+    /// <summary>
+    /// Initializes a new <see cref="RecordingMiddleware{T}"/> that records each item and keeps it flowing.
+    /// </summary>
+    public RecordingMiddleware()
+    {
+    }
+
+
+
+    /// <summary>
+    /// Initializes a new <see cref="RecordingMiddleware{T}"/> that records each item and then applies
+    /// <paramref name="policy"/> to transform or drop it.
+    /// </summary>
+    /// <param name="policy">
+    /// Maps a recorded item to a <see cref="MiddlewareResult{T}"/> — use
+    /// <see cref="MiddlewareResult.Continue{T}(T)"/> to keep (optionally transformed) or
+    /// <see cref="MiddlewareResult.Drop{T}"/> to discard it.
+    /// </param>
+    /// <exception cref="ArgumentNullException"><paramref name="policy"/> is <see langword="null"/>.</exception>
+    public RecordingMiddleware(Func<T, MiddlewareResult<T>> policy)
+    {
+        _policy = policy ?? throw new ArgumentNullException(nameof(policy));
+    }
+
+
+
+    /// <summary>Gets every item this middleware was handed, in order.</summary>
+    public IReadOnlyList<T> Observed => _observed.ToArray();
+
+
+
+    /// <inheritdoc/>
+    public ValueTask<MiddlewareResult<T>> OnItemAsync(T item, CancellationToken token)
+    {
+        token.ThrowIfCancellationRequested();
+
+        _observed.Add(item);
+
+        var result = _policy is null
+            ? MiddlewareResult.Continue(item)
+            : _policy(item);
+
+        return new ValueTask<MiddlewareResult<T>>(result);
+    }
+}

--- a/tests/Wolfgang.Etl.TestKit.Tests.Unit/RecordingMiddlewareTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Unit/RecordingMiddlewareTests.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+using Wolfgang.Etl.TestKit;
+using Xunit;
+
+namespace Wolfgang.Etl.TestKit.Tests.Unit;
+
+public class RecordingMiddlewareTests
+{
+    [Fact]
+    public void Constructor_when_policy_is_null_throws_ArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>
+        (
+            () => new RecordingMiddleware<int>(null!)
+        );
+    }
+
+
+
+    [Fact]
+    public async Task WithMiddleware_default_records_every_item_and_keeps_them_flowing()
+    {
+        var recorder = new RecordingMiddleware<int>();
+        var source   = new[] { 1, 2, 3 }.ToAsyncEnumerable();
+
+        var kept = await source.WithMiddleware(recorder, CancellationToken.None).ToListAsync().ConfigureAwait(false);
+
+        Assert.Equal(new[] { 1, 2, 3 }, kept);
+        Assert.Equal(new[] { 1, 2, 3 }, recorder.Observed);
+    }
+
+
+
+    [Fact]
+    public async Task WithMiddleware_transform_policy_maps_each_item()
+    {
+        var shaping = new RecordingMiddleware<int>(i => MiddlewareResult.Continue(i * 10));
+        var source  = new[] { 1, 2, 3 }.ToAsyncEnumerable();
+
+        var kept = await source.WithMiddleware(shaping, CancellationToken.None).ToListAsync().ConfigureAwait(false);
+
+        Assert.Equal(new[] { 10, 20, 30 }, kept);
+        // Observed reflects the items as received, before transformation.
+        Assert.Equal(new[] { 1, 2, 3 }, shaping.Observed);
+    }
+
+
+
+    [Fact]
+    public async Task WithMiddleware_drop_policy_filters_but_still_observes_all()
+    {
+        var evensOnly = new RecordingMiddleware<int>
+        (
+            i => i % 2 == 0 ? MiddlewareResult.Continue(i) : MiddlewareResult.Drop<int>()
+        );
+        var source = new[] { 1, 2, 3, 4, 5, 6 }.ToAsyncEnumerable();
+
+        var kept = await source.WithMiddleware(evensOnly, CancellationToken.None).ToListAsync().ConfigureAwait(false);
+
+        Assert.Equal(new[] { 2, 4, 6 }, kept);
+        Assert.Equal(new[] { 1, 2, 3, 4, 5, 6 }, evensOnly.Observed);
+    }
+
+
+
+    [Fact]
+    public async Task WithMiddleware_applies_multiple_middlewares_in_order()
+    {
+        var first  = new RecordingMiddleware<int>(i => MiddlewareResult.Continue(i + 1));
+        var second = new RecordingMiddleware<int>();
+        var source = new[] { 1, 2, 3 }.ToAsyncEnumerable();
+
+        var kept = await source
+            .WithMiddleware(new IItemMiddleware<int>[] { first, second }, CancellationToken.None)
+            .ToListAsync()
+            .ConfigureAwait(false);
+
+        Assert.Equal(new[] { 2, 3, 4 }, kept);
+        // `second` sees the output of `first`.
+        Assert.Equal(new[] { 1, 2, 3 }, first.Observed);
+        Assert.Equal(new[] { 2, 3, 4 }, second.Observed);
+    }
+}


### PR DESCRIPTION
Third feature of the **0.13.0 cycle** — coverage for the composable per-item middleware added in Abstractions 0.20.

> **Stacked on #270 (#262)** → auto-promotes toward `vNext-0.20.0` as the stack merges. Review the [#93-only diff](https://github.com/Chris-Wolfgang/ETL-Test-Kit/compare/feat/deterministic-time-262...feat/middleware-coverage-93).

## What's new
- **`RecordingMiddleware<T>`** (core) — a test `IItemMiddleware<T>` that records every item it is handed (`Observed`) and keeps each flowing by default; an optional `Func<T, MiddlewareResult<T>>` policy transforms (`Continue`) or drops (`Drop`) items. Lets a test assert exactly what a `WithMiddleware(...)` chain saw and produced. No friend access needed — the middleware surface is public.

## Coverage
Self-tests: passthrough (records + yields all), transform, drop (filters but still observes all), and multi-middleware ordering (each middleware sees the prior one's output).

## Verification
- Full multi-TFM Release build clean (0 warnings) against local `C:\Nuget-local` 0.20.0.
- 5 tests pass **net10.0 + net48**.

Covers Abstractions #93. See #268.

🤖 Generated with [Claude Code](https://claude.com/claude-code)