### PR TITLE
Add EtlPipeline error-aggregation coverage (Abstractions #335)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Kit self-tests covering the Abstractions 0.20 `IReportsItemErrors` aggregation — an `EtlPipeline`
+  sums each stage's `CurrentErrorItemCount` into `EtlPipelineProgress.ErrorItemCount`, verified with the
+  `Faulty*` doubles skipping a fault in the extractor, transformer, and loader. (Abstractions #335)
 - `RecordingMiddleware<T>` — a test `IItemMiddleware<T>` (Abstractions 0.20) that records every item it
   is handed (`Observed`) and, by default, keeps each one flowing; supply a `Func<T, MiddlewareResult<T>>`
   policy to transform or drop items. Apply it with the `WithMiddleware(...)` extension to assert exactly

--- a/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/EtlPipelineErrorAggregationTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/EtlPipelineErrorAggregationTests.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+using Wolfgang.Etl.TestKit;
+using Xunit;
+
+namespace Wolfgang.Etl.TestKit.Xunit.Tests.Unit;
+
+/// <summary>
+/// Kit self-tests for the Abstractions 0.20 <c>IReportsItemErrors</c> aggregation: an
+/// <see cref="EtlPipeline"/> sums each stage's <c>CurrentErrorItemCount</c> into
+/// <see cref="EtlPipelineProgress.ErrorItemCount"/>, so a skipped fault in any stage — extractor,
+/// transformer, or loader — is reflected in the pipeline's progress.
+/// </summary>
+public class EtlPipelineErrorAggregationTests
+{
+    [Fact]
+    public async Task Pipeline_ErrorItemCount_sums_errors_across_extractor_and_loader_Async()
+    {
+        var source = new FaultyExtractor<int>(new[] { 0, 1, 2, 3, 4 })
+            .ThrowAt(2, new FormatException("extractor fault"))
+            .SkipErrors();
+        var sink = new FaultyLoader<int>(collectItems: true)
+            .ThrowAt(1, new FormatException("loader fault"))
+            .SkipErrors();
+        var capture = new ProgressCapture<EtlPipelineProgress>();
+
+        await EtlPipeline
+            .Create()
+            .From(source)
+            .To(sink)
+            .RunAsync(capture)
+            .ConfigureAwait(false);
+
+        var final = capture.FinalReport;
+        Assert.NotNull(final);
+        // One error skipped in the extractor + one in the loader.
+        Assert.Equal(2, final!.ErrorItemCount);
+    }
+
+
+
+    [Fact]
+    public async Task Pipeline_ErrorItemCount_sums_errors_across_all_three_stages_Async()
+    {
+        var source = new FaultyExtractor<int>(new[] { 0, 1, 2, 3, 4 })
+            .ThrowAt(2, new FormatException("extractor fault"))
+            .SkipErrors();
+        var transformer = new FaultyTransformer<int>()
+            .ThrowAt(1, new FormatException("transformer fault"))
+            .SkipErrors();
+        var sink = new FaultyLoader<int>(collectItems: true)
+            .ThrowAt(1, new FormatException("loader fault"))
+            .SkipErrors();
+        var capture = new ProgressCapture<EtlPipelineProgress>();
+
+        await EtlPipeline
+            .Create()
+            .From(source)
+            .Through(transformer)
+            .To(sink)
+            .RunAsync(capture)
+            .ConfigureAwait(false);
+
+        var final = capture.FinalReport;
+        Assert.NotNull(final);
+        // One error skipped in each of the extractor, transformer, and loader.
+        Assert.Equal(3, final!.ErrorItemCount);
+    }
+}


### PR DESCRIPTION
Fourth and final feature of the **0.13.0 cycle** — verifies the Abstractions 0.20 `IReportsItemErrors` aggregation: an `EtlPipeline` sums each stage's `CurrentErrorItemCount` into `EtlPipelineProgress.ErrorItemCount`.

> **Stacked on #271 (#93)** → auto-promotes toward `vNext-0.20.0` as the stack merges. Review the [#335-only diff](https://github.com/Chris-Wolfgang/ETL-Test-Kit/compare/feat/middleware-coverage-93...feat/aggregate-errors-335).

## Coverage
Kit self-tests compose the `Faulty*` doubles (each `ThrowAt(...).SkipErrors()`) and assert the pipeline's `ErrorItemCount` equals the total skipped across stages:
- extractor + loader → **2**
- extractor + transformer + loader → **3**

Test-only — **no public API change**.

## Verification
- Full multi-TFM Release build clean (0 warnings) against local `C:\Nuget-local` 0.20.0.
- Both aggregation tests pass net10.0.

Covers Abstractions #335. Completes the four-feature 0.13.0 cycle (#268).

🤖 Generated with [Claude Code](https://claude.com/claude-code)