### PR TITLE
Add EtlScenario fluent end-to-end scenario harness (#265)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `EtlScenario` — a fluent end-to-end scenario harness that composes an extract → (transform) → load
+  pipeline from the doubles, optionally injects a fault into the extractor or loader, runs it through
+  `EtlPipeline`, and asserts the final state — loaded items and aggregate `ErrorItemCount`
+  (`RunAndAssertAsync`), or a terminal exception (`RunAndAssertThrowsAsync<TException>`) — in a single
+  expression. Faults default to being skipped (counted as errors); pass `skip: false` to let one
+  propagate. (#265)
 - Kit self-tests covering the Abstractions 0.20 `IReportsItemErrors` aggregation — an `EtlPipeline`
   sums each stage's `CurrentErrorItemCount` into `EtlPipelineProgress.ErrorItemCount`, verified with the
   `Faulty*` doubles skipping a fault in the extractor, transformer, and loader. (Abstractions #335)

--- a/README.md
+++ b/README.md
@@ -442,6 +442,34 @@ public sealed class MyRetryTests : RetryContractTests<RetryingExtractor<int>>
 
 `RetryingExtractor<T>` also serves as a worked example of building stream-level retry on the `WrapWorkerExecution` seam (each retry re-invokes the worker for a fresh stream).
 
+### xUnit — one-liner scenarios with `EtlScenario`
+
+`EtlScenario` composes an extract → (transform) → load pipeline from the doubles — optionally injecting a fault into the extractor or loader — runs it, and asserts the final state (loaded items, aggregate error count, or a terminal exception) in a single fluent expression:
+
+```csharp
+using System;
+using System.Threading.Tasks;
+using Wolfgang.Etl.TestKit;
+using Wolfgang.Etl.TestKit.Xunit;
+
+// A skipped extractor fault drops the item and counts one aggregate error:
+await EtlScenario
+    .From(1, 2, 3, 4)
+    .WithExtractorFault(index: 2, new FormatException("bad row"))
+    .RunAndAssertAsync(expectedLoaded: new[] { 1, 2, 4 }, expectedErrors: 1);
+
+// Insert a transform stage:
+await EtlScenario.From(1, 2, 3).Through(new TestTransformer<int>()).RunAndAssertAsync(new[] { 1, 2, 3 });
+
+// A non-skipped fault propagates:
+await EtlScenario
+    .From(1, 2, 3)
+    .WithExtractorFault(index: 1, new InvalidOperationException("boom"), skip: false)
+    .RunAndAssertThrowsAsync<InvalidOperationException>();
+```
+
+Faults default to being *skipped* (routed through the base error hook and counted in `EtlPipelineProgress.ErrorItemCount`); pass `skip: false` to let one propagate and assert it with `RunAndAssertThrowsAsync<TException>()`.
+
 ### xUnit add-on — contract-testing your own ETL types
 
 Derive your test class from the matching contract base and implement the abstract factory methods. You inherit the complete suite of `ExtractAsync` / `TransformAsync` / `LoadAsync` contract tests — all overloads, cancellation, progress, `SkipItemCount`, and `MaximumItemCount` — with zero boilerplate.

--- a/src/Wolfgang.Etl.TestKit.Xunit/EtlScenario.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/EtlScenario.cs
@@ -1,0 +1,24 @@
+namespace Wolfgang.Etl.TestKit.Xunit;
+
+/// <summary>
+/// Entry point for building a fluent end-to-end ETL scenario over the <c>Wolfgang.Etl.TestKit</c>
+/// doubles and asserting its final state in a single expression. See <see cref="EtlScenario{T}"/>.
+/// </summary>
+/// <example>
+/// <code>
+/// await EtlScenario
+///     .From(1, 2, 3, 4)
+///     .WithExtractorFault(index: 2, new FormatException("bad row"))
+///     .RunAndAssertAsync(expectedLoaded: new[] { 1, 2, 4 }, expectedErrors: 1);
+/// </code>
+/// </example>
+public static class EtlScenario
+{
+    /// <summary>Starts a scenario whose source streams <paramref name="items"/>.</summary>
+    /// <typeparam name="T">The item type flowing through the pipeline.</typeparam>
+    /// <param name="items">The items the source produces.</param>
+    /// <returns>A fluent <see cref="EtlScenario{T}"/> builder.</returns>
+    public static EtlScenario<T> From<T>(params T[] items)
+        where T : notnull =>
+        new EtlScenario<T>(items);
+}

--- a/src/Wolfgang.Etl.TestKit.Xunit/EtlScenarioOfT.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/EtlScenarioOfT.cs
@@ -1,0 +1,166 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+using Wolfgang.Etl.TestKit;
+using Xunit;
+
+namespace Wolfgang.Etl.TestKit.Xunit;
+
+/// <summary>
+/// A fluent builder that composes an extract → (transform) → load pipeline from the
+/// <c>Wolfgang.Etl.TestKit</c> doubles — optionally injecting a fault into the extractor or loader —
+/// runs it through the <c>Wolfgang.Etl.Abstractions</c> <see cref="EtlPipeline"/>, and asserts the
+/// final state (loaded items, aggregate error count, or a terminal exception) in one call.
+/// </summary>
+/// <typeparam name="T">The item type flowing through the pipeline. Must be <c>notnull</c>.</typeparam>
+/// <remarks>
+/// Start one with <see cref="EtlScenario.From{T}(T[])"/>. Injected faults default to being
+/// <em>skipped</em> (routed through the base error hook and counted in
+/// <see cref="EtlPipelineProgress.ErrorItemCount"/>), so the run completes; pass <c>skip: false</c> to
+/// let a fault propagate and assert it with <see cref="RunAndAssertThrowsAsync{TException}"/>.
+/// </remarks>
+public sealed class EtlScenario<T>
+    where T : notnull
+{
+    private readonly T[] _items;
+    private (int Index, Exception Exception, bool Skip)? _extractorFault;
+    private (int Index, Exception Exception, bool Skip)? _loaderFault;
+    private TransformerBase<T, T, Report>? _transformer;
+
+
+
+    internal EtlScenario(T[] items)
+    {
+        _items = items ?? throw new ArgumentNullException(nameof(items));
+    }
+
+
+
+    /// <summary>Injects a fault into the extractor at <paramref name="index"/>.</summary>
+    /// <param name="index">The zero-based item index at which the extractor throws.</param>
+    /// <param name="exception">The exception to throw.</param>
+    /// <param name="skip">
+    /// When <see langword="true"/> (default) the fault is skipped and counted as an error; when
+    /// <see langword="false"/> it propagates and aborts the run.
+    /// </param>
+    /// <exception cref="ArgumentNullException"><paramref name="exception"/> is <see langword="null"/>.</exception>
+    public EtlScenario<T> WithExtractorFault(int index, Exception exception, bool skip = true)
+    {
+        _extractorFault = (index, exception ?? throw new ArgumentNullException(nameof(exception)), skip);
+        return this;
+    }
+
+
+
+    /// <summary>Injects a fault into the loader at <paramref name="index"/>.</summary>
+    /// <param name="index">The zero-based item index at which the loader throws.</param>
+    /// <param name="exception">The exception to throw.</param>
+    /// <param name="skip">
+    /// When <see langword="true"/> (default) the fault is skipped and counted as an error; when
+    /// <see langword="false"/> it propagates and aborts the run.
+    /// </param>
+    /// <exception cref="ArgumentNullException"><paramref name="exception"/> is <see langword="null"/>.</exception>
+    public EtlScenario<T> WithLoaderFault(int index, Exception exception, bool skip = true)
+    {
+        _loaderFault = (index, exception ?? throw new ArgumentNullException(nameof(exception)), skip);
+        return this;
+    }
+
+
+
+    /// <summary>Inserts <paramref name="transformer"/> as a transform stage between source and sink.</summary>
+    /// <param name="transformer">The transformer stage.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="transformer"/> is <see langword="null"/>.</exception>
+    public EtlScenario<T> Through(TransformerBase<T, T, Report> transformer)
+    {
+        _transformer = transformer ?? throw new ArgumentNullException(nameof(transformer));
+        return this;
+    }
+
+
+
+    /// <summary>
+    /// Runs the composed pipeline and asserts the sink received <paramref name="expectedLoaded"/> and
+    /// the pipeline reported <paramref name="expectedErrors"/> aggregate errors.
+    /// </summary>
+    /// <param name="expectedLoaded">The items the loader is expected to have received, in order.</param>
+    /// <param name="expectedErrors">The expected aggregate <see cref="EtlPipelineProgress.ErrorItemCount"/>.</param>
+    public async Task RunAndAssertAsync(IReadOnlyList<T> expectedLoaded, int expectedErrors = 0)
+    {
+        var loader  = BuildLoader();
+        var capture = new ProgressCapture<EtlPipelineProgress>();
+
+        await BuildSink(loader).RunAsync(capture).ConfigureAwait(false);
+
+        Assert.Equal(expectedLoaded, loader.GetCollectedItems());
+        Assert.NotNull(capture.FinalReport);
+        Assert.Equal(expectedErrors, capture.FinalReport!.ErrorItemCount);
+    }
+
+
+
+    /// <summary>
+    /// Runs the composed pipeline and asserts it throws <typeparamref name="TException"/> — use with a
+    /// fault configured with <c>skip: false</c>.
+    /// </summary>
+    /// <typeparam name="TException">The expected terminal exception type.</typeparam>
+    public Task RunAndAssertThrowsAsync<TException>()
+        where TException : Exception
+    {
+        var sink = BuildSink(BuildLoader());
+
+        return Assert.ThrowsAsync<TException>(() => sink.RunAsync());
+    }
+
+
+
+    private FaultyExtractor<T> BuildExtractor()
+    {
+        var extractor = new FaultyExtractor<T>(_items);
+
+        if (_extractorFault is { } fault)
+        {
+            extractor.ThrowAt(fault.Index, fault.Exception);
+
+            if (fault.Skip)
+            {
+                extractor.SkipErrors();
+            }
+        }
+
+        return extractor;
+    }
+
+
+
+    private FaultyLoader<T> BuildLoader()
+    {
+        var loader = new FaultyLoader<T>(collectItems: true);
+
+        if (_loaderFault is { } fault)
+        {
+            loader.ThrowAt(fault.Index, fault.Exception);
+
+            if (fault.Skip)
+            {
+                loader.SkipErrors();
+            }
+        }
+
+        return loader;
+    }
+
+
+
+    private IEtlPipelineSink BuildSink(FaultyLoader<T> loader)
+    {
+        var source = EtlPipeline
+            .Create()
+            .From(BuildExtractor());
+
+        return _transformer is null
+            ? source.To(loader)
+            : source.Through(_transformer).To(loader);
+    }
+}

--- a/src/Wolfgang.Etl.TestKit.Xunit/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.TestKit.Xunit/PublicAPI.Unshipped.txt
@@ -13,3 +13,11 @@ Wolfgang.Etl.TestKit.Xunit.RetryOutcome.RetryOutcome(bool succeeded, int attempt
 Wolfgang.Etl.TestKit.Xunit.RetryOutcome.AttemptCount.get -> int
 Wolfgang.Etl.TestKit.Xunit.RetryOutcome.ItemCount.get -> int
 Wolfgang.Etl.TestKit.Xunit.RetryOutcome.Succeeded.get -> bool
+Wolfgang.Etl.TestKit.Xunit.EtlScenario
+Wolfgang.Etl.TestKit.Xunit.EtlScenario<T>
+Wolfgang.Etl.TestKit.Xunit.EtlScenario<T>.RunAndAssertAsync(System.Collections.Generic.IReadOnlyList<T>! expectedLoaded, int expectedErrors = 0) -> System.Threading.Tasks.Task!
+Wolfgang.Etl.TestKit.Xunit.EtlScenario<T>.RunAndAssertThrowsAsync<TException>() -> System.Threading.Tasks.Task!
+Wolfgang.Etl.TestKit.Xunit.EtlScenario<T>.Through(Wolfgang.Etl.Abstractions.TransformerBase<T, T, Wolfgang.Etl.Abstractions.Report!>! transformer) -> Wolfgang.Etl.TestKit.Xunit.EtlScenario<T>!
+Wolfgang.Etl.TestKit.Xunit.EtlScenario<T>.WithExtractorFault(int index, System.Exception! exception, bool skip = true) -> Wolfgang.Etl.TestKit.Xunit.EtlScenario<T>!
+Wolfgang.Etl.TestKit.Xunit.EtlScenario<T>.WithLoaderFault(int index, System.Exception! exception, bool skip = true) -> Wolfgang.Etl.TestKit.Xunit.EtlScenario<T>!
+static Wolfgang.Etl.TestKit.Xunit.EtlScenario.From<T>(params T[]! items) -> Wolfgang.Etl.TestKit.Xunit.EtlScenario<T>!

--- a/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/EtlScenarioTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Xunit.Tests.Unit/EtlScenarioTests.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Threading.Tasks;
+using Wolfgang.Etl.TestKit;
+using Wolfgang.Etl.TestKit.Xunit;
+using Xunit;
+
+namespace Wolfgang.Etl.TestKit.Xunit.Tests.Unit;
+
+public class EtlScenarioTests
+{
+    [Fact]
+    public async Task Clean_run_loads_every_item_with_no_errors_Async()
+    {
+        await EtlScenario
+            .From(1, 2, 3)
+            .RunAndAssertAsync(new[] { 1, 2, 3 }, expectedErrors: 0)
+            .ConfigureAwait(false);
+    }
+
+
+
+    [Fact]
+    public async Task Skipped_extractor_fault_drops_the_item_and_counts_one_error_Async()
+    {
+        await EtlScenario
+            .From(1, 2, 3, 4)
+            .WithExtractorFault(index: 2, new FormatException("bad row"))
+            .RunAndAssertAsync(new[] { 1, 2, 4 }, expectedErrors: 1)
+            .ConfigureAwait(false);
+    }
+
+
+
+    [Fact]
+    public async Task Skipped_loader_fault_drops_the_item_and_counts_one_error_Async()
+    {
+        await EtlScenario
+            .From(1, 2, 3, 4)
+            .WithLoaderFault(index: 1, new FormatException("bad write"))
+            .RunAndAssertAsync(new[] { 1, 3, 4 }, expectedErrors: 1)
+            .ConfigureAwait(false);
+    }
+
+
+
+    [Fact]
+    public async Task Transform_stage_is_applied_between_source_and_sink_Async()
+    {
+        await EtlScenario
+            .From(1, 2, 3)
+            .Through(new TestTransformer<int>())
+            .RunAndAssertAsync(new[] { 1, 2, 3 }, expectedErrors: 0)
+            .ConfigureAwait(false);
+    }
+
+
+
+    [Fact]
+    public async Task Non_skipped_fault_propagates_as_the_expected_exception_Async()
+    {
+        await EtlScenario
+            .From(1, 2, 3)
+            .WithExtractorFault(index: 1, new InvalidOperationException("boom"), skip: false)
+            .RunAndAssertThrowsAsync<InvalidOperationException>()
+            .ConfigureAwait(false);
+    }
+}


### PR DESCRIPTION
Folds the deferred fluent scenario harness into the **0.13.0 cycle** — no Abstractions dependency beyond what's already present.

> **Stacked on #272 (#335)** → auto-promotes toward `vNext-0.20.0` as the stack merges. Review the [#265-only diff](https://github.com/Chris-Wolfgang/ETL-Test-Kit/compare/feat/aggregate-errors-335...feat/etl-scenario-265).

## What's new
- **`EtlScenario` / `EtlScenario<T>`** (xunit) — a fluent builder that composes an extract → (transform) → load pipeline from the doubles, optionally injects a fault into the extractor or loader (skipped by default), runs it through `EtlPipeline`, and asserts the final state in one call:
  - `RunAndAssertAsync(expectedLoaded, expectedErrors)` — loaded items + aggregate `ErrorItemCount`;
  - `RunAndAssertThrowsAsync<TException>()` — a propagating (`skip: false`) fault.
  - `Through(transformer)` inserts a transform stage.

```csharp
await EtlScenario
    .From(1, 2, 3, 4)
    .WithExtractorFault(index: 2, new FormatException("bad row"))
    .RunAndAssertAsync(expectedLoaded: new[] { 1, 2, 4 }, expectedErrors: 1);
```

## Verification
- Full multi-TFM Release build clean (0 warnings) against local `C:\Nuget-local` 0.20.0.
- 5 tests pass **net10.0 + net48** (clean run, skipped extractor/loader faults, transform stage, propagating fault).

Closes #265.

🤖 Generated with [Claude Code](https://claude.com/claude-code)