### PR TITLE
Release 0.14.0 — ManualProgressTimerCore progress-timer harness (deprecates CreateSutWithTimer)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [0.14.0] - 2026-08-03
+
+Minor release: a manually-driven progress timer (`ManualProgressTimerCore` + `WithManualProgressTimer`)
+so any component is timer-testable without per-type `IProgressTimer` plumbing; the contract-test bases
+adopt it and no longer require `CreateSutWithTimer`. Purely additive — validates against the 0.13.0
+baseline.
+
+### Added
+
 - **`ManualProgressTimerCore` + `WithManualProgressTimer` extensions (#352):** a manually-driven progress
   timer for tests. Attach it to any extractor / loader / transformer with `.WithManualProgressTimer(timer)`
   and fire the stage's progress callback deterministically with `timer.Tick()` — no per-component

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`ManualProgressTimerCore` + `WithManualProgressTimer` extensions (#352):** a manually-driven progress
+  timer for tests. Attach it to any extractor / loader / transformer with `.WithManualProgressTimer(timer)`
+  and fire the stage's progress callback deterministically with `timer.Tick()` — no per-component
+  `IProgressTimer`-injection plumbing required. Drives the base's internal timer-core seam via the
+  `Wolfgang.Etl.TestKit` ⇆ `Wolfgang.Etl.Abstractions` friend relationship.
+
 ### Changed
 
+- **Contract-test bases now drive progress timing via `ManualProgressTimerCore` (#352).** The
+  `ExtractorBaseContractTests` / `LoaderBaseContractTests` / `TransformerBaseContractTests` timer tests
+  build the SUT with the standard `CreateSut(...)` factory and attach a `ManualProgressTimerCore` — they
+  no longer require `CreateSutWithTimer`. That member is now **`virtual`** (was `abstract`) and throws if
+  the base implementation is invoked; existing overrides still compile. Additive — no downstream change
+  required to adopt the new TestKit.
+
 ### Deprecated
+
+- **`*BaseContractTests.CreateSutWithTimer(IProgressTimer)` (#352):** no longer called by the contract.
+  Remove your override (and the component's `IProgressTimer`-injection constructor); it will be dropped in
+  a future major version.
 
 ### Removed
 

--- a/src/Wolfgang.Etl.TestKit.Xunit/ExtractorBaseContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/ExtractorBaseContractTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Wolfgang.Etl.Abstractions;
+using Wolfgang.Etl.TestKit;
 using Xunit;
 
 namespace Wolfgang.Etl.TestKit.Xunit;
@@ -51,9 +52,6 @@ namespace Wolfgang.Etl.TestKit.Xunit;
 ///
 ///     protected override IReadOnlyList&lt;MyRecord&gt; CreateExpectedItems() =>
 ///         new List&lt;MyRecord&gt; { new("a"), new("b"), new("c"), new("d"), new("e") };
-///
-///     protected override MyExtractor CreateSutWithTimer(IProgressTimer timer) =>
-///         new MyExtractor("path/to/test-data.csv", timer);
 /// }
 /// </code>
 /// </example>
@@ -91,22 +89,23 @@ public abstract class ExtractorBaseContractTests<TSut, TItem, TProgress>
     protected abstract IReadOnlyList<TItem> CreateExpectedItems();
 
     /// <summary>
-    /// Creates the system under test with the supplied <see cref="IProgressTimer"/>
-    /// injected via the derived class's protected constructor.
+    /// <b>Deprecated.</b> The contract now drives progress timing via
+    /// <see cref="ManualProgressTimerCore"/> and <c>WithManualProgressTimer</c>, which need no
+    /// per-component timer plumbing — so overriding this is no longer required. Retained for source
+    /// compatibility with existing overrides; remove your override (and the component's
+    /// <c>IProgressTimer</c>-injection ctor) and it will be dropped in a future major version.
     /// </summary>
-    /// <param name="timer">
-    /// The <see cref="IProgressTimer"/> to inject. Typically a
-    /// <see cref="ManualProgressTimer"/> so that progress callbacks can be fired
-    /// on demand during tests.
-    /// </param>
-    /// <returns>A new, fully initialised instance of <typeparamref name="TSut"/>.</returns>
-    /// <example>
-    /// <code>
-    /// protected override MyExtractor CreateSutWithTimer(IProgressTimer timer) =>
-    ///     new MyExtractor(sourceData, timer);
-    /// </code>
-    /// </example>
-    protected abstract TSut CreateSutWithTimer(IProgressTimer timer);
+    /// <param name="timer">Unused by the contract.</param>
+    /// <returns>A new instance of <typeparamref name="TSut"/> (in existing overrides only).</returns>
+    /// <exception cref="NotSupportedException">
+    /// Always, if the base (non-overridden) implementation is invoked — the contract no longer calls it.
+    /// </exception>
+    protected virtual TSut CreateSutWithTimer(IProgressTimer timer) =>
+        throw new NotSupportedException
+        (
+            "CreateSutWithTimer is no longer used by the contract; progress timing is driven via " +
+            "ManualProgressTimerCore + WithManualProgressTimer. Remove this override."
+        );
 
 
 
@@ -378,14 +377,15 @@ public abstract class ExtractorBaseContractTests<TSut, TItem, TProgress>
     [Fact]
     public async Task ExtractAsync_with_progress_invokes_callback_when_timer_fires_Async()
     {
-        using var timer = new ManualProgressTimer();
-        var sut = CreateSutWithTimer(timer);
+        var timer = new ManualProgressTimerCore();
+        var sut = CreateSut();
+        sut.WithManualProgressTimer(timer);
         TProgress? captured = default;
         var progress = new SynchronousProgress<TProgress>(r => captured = r);
 
         await using var enumerator = sut.ExtractAsync(progress).GetAsyncEnumerator();
         await enumerator.MoveNextAsync().ConfigureAwait(false);
-        timer.Fire();
+        timer.Tick();
 
         Assert.NotNull(captured);
     }
@@ -527,14 +527,15 @@ public abstract class ExtractorBaseContractTests<TSut, TItem, TProgress>
     [Fact]
     public async Task ExtractAsync_with_progress_and_token_invokes_callback_when_timer_fires_Async()
     {
-        using var timer = new ManualProgressTimer();
-        var sut = CreateSutWithTimer(timer);
+        var timer = new ManualProgressTimerCore();
+        var sut = CreateSut();
+        sut.WithManualProgressTimer(timer);
         TProgress? captured = default;
         var progress = new SynchronousProgress<TProgress>(r => captured = r);
 
         await using var enumerator = sut.ExtractAsync(progress, CancellationToken.None).GetAsyncEnumerator();
         await enumerator.MoveNextAsync().ConfigureAwait(false);
-        timer.Fire();
+        timer.Tick();
 
         Assert.NotNull(captured);
     }

--- a/src/Wolfgang.Etl.TestKit.Xunit/LoaderBaseContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/LoaderBaseContractTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Wolfgang.Etl.Abstractions;
+using Wolfgang.Etl.TestKit;
 using Xunit;
 
 namespace Wolfgang.Etl.TestKit.Xunit;
@@ -50,9 +51,6 @@ namespace Wolfgang.Etl.TestKit.Xunit;
 ///
 ///     protected override IReadOnlyList&lt;MyRecord&gt; CreateSourceItems() =>
 ///         new List&lt;MyRecord&gt; { new("a"), new("b"), new("c"), new("d"), new("e") };
-///
-///     protected override MyLoader CreateSutWithTimer(IProgressTimer timer) =>
-///         new MyLoader(connectionString, timer);
 /// }
 /// </code>
 /// </example>
@@ -74,15 +72,23 @@ public abstract class LoaderBaseContractTests<TSut, TItem, TProgress>
     protected abstract TSut CreateSut(int itemCount);
 
     /// <summary>
-    /// Creates a <typeparamref name="TSut"/> with the supplied <see cref="IProgressTimer"/>
-    /// injected via the derived class's protected constructor.
+    /// <b>Deprecated.</b> The contract now drives progress timing via
+    /// <see cref="ManualProgressTimerCore"/> and <c>WithManualProgressTimer</c>, which need no
+    /// per-component timer plumbing — so overriding this is no longer required. Retained for source
+    /// compatibility with existing overrides; remove your override (and the component's
+    /// <c>IProgressTimer</c>-injection ctor) and it will be dropped in a future major version.
     /// </summary>
-    /// <param name="timer">
-    /// The <see cref="IProgressTimer"/> to inject. Typically a
-    /// <see cref="ManualProgressTimer"/> so that progress callbacks can be fired
-    /// on demand during tests.
-    /// </param>
-    protected abstract TSut CreateSutWithTimer(IProgressTimer timer);
+    /// <param name="timer">Unused by the contract.</param>
+    /// <returns>A new instance of <typeparamref name="TSut"/> (in existing overrides only).</returns>
+    /// <exception cref="NotSupportedException">
+    /// Always, if the base (non-overridden) implementation is invoked — the contract no longer calls it.
+    /// </exception>
+    protected virtual TSut CreateSutWithTimer(IProgressTimer timer) =>
+        throw new NotSupportedException
+        (
+            "CreateSutWithTimer is no longer used by the contract; progress timing is driven via " +
+            "ManualProgressTimerCore + WithManualProgressTimer. Remove this override."
+        );
 
     /// <summary>
     /// Returns the source items used to feed the loader. Must return at least 5 items.
@@ -107,7 +113,7 @@ public abstract class LoaderBaseContractTests<TSut, TItem, TProgress>
     /// <summary>
     /// Returns an input sequence that pauses after the first item until
     /// <paramref name="gate"/> is released, keeping the load pipeline alive
-    /// so the test can call <see cref="ManualProgressTimer.Fire"/> mid-flight.
+    /// so the test can call <see cref="ManualProgressTimerCore.Tick"/> mid-flight.
     /// </summary>
     private async IAsyncEnumerable<TItem> CreateGatedInputItemsAsync(TaskCompletionSource<bool> gate)
     {
@@ -400,14 +406,15 @@ public abstract class LoaderBaseContractTests<TSut, TItem, TProgress>
     [Fact]
     public async Task LoadAsync_with_progress_invokes_callback_when_timer_fires_Async()
     {
-        using var timer = new ManualProgressTimer();
-        var sut = CreateSutWithTimer(timer);
+        var timer = new ManualProgressTimerCore();
+        var sut = CreateSut();
+        sut.WithManualProgressTimer(timer);
         TProgress? captured = default;
         var progress = new SynchronousProgress<TProgress>(r => captured = r);
         var gate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
         var task = sut.LoadAsync(CreateGatedInputItemsAsync(gate), progress);
-        timer.Fire();
+        timer.Tick();
         gate.SetResult(true);
         await task.ConfigureAwait(false);
 
@@ -554,14 +561,15 @@ public abstract class LoaderBaseContractTests<TSut, TItem, TProgress>
     [Fact]
     public async Task LoadAsync_with_progress_and_token_invokes_callback_when_timer_fires_Async()
     {
-        using var timer = new ManualProgressTimer();
-        var sut = CreateSutWithTimer(timer);
+        var timer = new ManualProgressTimerCore();
+        var sut = CreateSut();
+        sut.WithManualProgressTimer(timer);
         TProgress? captured = default;
         var progress = new SynchronousProgress<TProgress>(r => captured = r);
         var gate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
         var task = sut.LoadAsync(CreateGatedInputItemsAsync(gate), progress, CancellationToken.None);
-        timer.Fire();
+        timer.Tick();
         gate.SetResult(true);
         await task.ConfigureAwait(false);
 

--- a/src/Wolfgang.Etl.TestKit.Xunit/PublicAPI.Shipped.txt
+++ b/src/Wolfgang.Etl.TestKit.Xunit/PublicAPI.Shipped.txt
@@ -255,7 +255,7 @@ abstract Wolfgang.Etl.TestKit.Xunit.ExtractWithProgressAsyncContractTests<TSut, 
 abstract Wolfgang.Etl.TestKit.Xunit.ExtractWithProgressAsyncContractTests<TSut, TItem, TProgress>.CreateSut(int itemCount) -> TSut
 abstract Wolfgang.Etl.TestKit.Xunit.ExtractorBaseContractTests<TSut, TItem, TProgress>.CreateExpectedItems() -> System.Collections.Generic.IReadOnlyList<TItem>
 abstract Wolfgang.Etl.TestKit.Xunit.ExtractorBaseContractTests<TSut, TItem, TProgress>.CreateSut(int itemCount) -> TSut
-abstract Wolfgang.Etl.TestKit.Xunit.ExtractorBaseContractTests<TSut, TItem, TProgress>.CreateSutWithTimer(Wolfgang.Etl.Abstractions.IProgressTimer timer) -> TSut
+virtual Wolfgang.Etl.TestKit.Xunit.ExtractorBaseContractTests<TSut, TItem, TProgress>.CreateSutWithTimer(Wolfgang.Etl.Abstractions.IProgressTimer timer) -> TSut
 abstract Wolfgang.Etl.TestKit.Xunit.IdempotentExtractorContractTests<TSut, TItem, TProgress>.CreateExpectedItems() -> System.Collections.Generic.IReadOnlyList<TItem>!
 abstract Wolfgang.Etl.TestKit.Xunit.IdempotentExtractorContractTests<TSut, TItem, TProgress>.CreateSut(int itemCount) -> TSut
 abstract Wolfgang.Etl.TestKit.Xunit.IdempotentLoaderContractTests<TSut, TItem>.CreateSourceItems() -> System.Collections.Generic.IReadOnlyList<TItem>!
@@ -273,7 +273,7 @@ abstract Wolfgang.Etl.TestKit.Xunit.LoadWithProgressAsyncContractTests<TSut, TIt
 abstract Wolfgang.Etl.TestKit.Xunit.LoadWithProgressAsyncContractTests<TSut, TItem, TProgress>.CreateSut(int itemCount) -> TSut
 abstract Wolfgang.Etl.TestKit.Xunit.LoaderBaseContractTests<TSut, TItem, TProgress>.CreateSourceItems() -> System.Collections.Generic.IReadOnlyList<TItem>
 abstract Wolfgang.Etl.TestKit.Xunit.LoaderBaseContractTests<TSut, TItem, TProgress>.CreateSut(int itemCount) -> TSut
-abstract Wolfgang.Etl.TestKit.Xunit.LoaderBaseContractTests<TSut, TItem, TProgress>.CreateSutWithTimer(Wolfgang.Etl.Abstractions.IProgressTimer timer) -> TSut
+virtual Wolfgang.Etl.TestKit.Xunit.LoaderBaseContractTests<TSut, TItem, TProgress>.CreateSutWithTimer(Wolfgang.Etl.Abstractions.IProgressTimer timer) -> TSut
 abstract Wolfgang.Etl.TestKit.Xunit.TransformAsyncContractTests<TSut, TItem>.CreateExpectedItems() -> System.Collections.Generic.IReadOnlyList<TItem>
 abstract Wolfgang.Etl.TestKit.Xunit.TransformAsyncContractTests<TSut, TItem>.CreateSut(int itemCount) -> TSut
 abstract Wolfgang.Etl.TestKit.Xunit.TransformWithCancellationAsyncContractTests<TSut, TItem>.CreateExpectedItems() -> System.Collections.Generic.IReadOnlyList<TItem>
@@ -284,7 +284,7 @@ abstract Wolfgang.Etl.TestKit.Xunit.TransformWithProgressAsyncContractTests<TSut
 abstract Wolfgang.Etl.TestKit.Xunit.TransformWithProgressAsyncContractTests<TSut, TItem, TProgress>.CreateSut(int itemCount) -> TSut
 abstract Wolfgang.Etl.TestKit.Xunit.TransformerBaseContractTests<TSut, TItem, TProgress>.CreateExpectedItems() -> System.Collections.Generic.IReadOnlyList<TItem>
 abstract Wolfgang.Etl.TestKit.Xunit.TransformerBaseContractTests<TSut, TItem, TProgress>.CreateSut(int itemCount) -> TSut
-abstract Wolfgang.Etl.TestKit.Xunit.TransformerBaseContractTests<TSut, TItem, TProgress>.CreateSutWithTimer(Wolfgang.Etl.Abstractions.IProgressTimer timer) -> TSut
+virtual Wolfgang.Etl.TestKit.Xunit.TransformerBaseContractTests<TSut, TItem, TProgress>.CreateSutWithTimer(Wolfgang.Etl.Abstractions.IProgressTimer timer) -> TSut
 static Wolfgang.Etl.TestKit.Xunit.ProgressAssert.AllReportsSatisfy<T>(Wolfgang.Etl.TestKit.Xunit.ProgressCapture<T>! capture, System.Func<T, bool>! predicate) -> void
 static Wolfgang.Etl.TestKit.Xunit.ProgressAssert.FinalReportSatisfies<T>(Wolfgang.Etl.TestKit.Xunit.ProgressCapture<T>! capture, System.Func<T, bool>! predicate) -> void
 static Wolfgang.Etl.TestKit.Xunit.ProgressAssert.HasExactly<T>(Wolfgang.Etl.TestKit.Xunit.ProgressCapture<T>! capture, int count) -> void

--- a/src/Wolfgang.Etl.TestKit.Xunit/TransformerBaseContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/TransformerBaseContractTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Wolfgang.Etl.Abstractions;
+using Wolfgang.Etl.TestKit;
 using Xunit;
 
 namespace Wolfgang.Etl.TestKit.Xunit;
@@ -52,9 +53,6 @@ namespace Wolfgang.Etl.TestKit.Xunit;
 ///
 ///     protected override IReadOnlyList&lt;MyRecord&gt; CreateExpectedItems() =>
 ///         new List&lt;MyRecord&gt; { new("a"), new("b"), new("c"), new("d"), new("e") };
-///
-///     protected override MyTransformer CreateSutWithTimer(IProgressTimer timer) =>
-///         new MyTransformer(timer);
 /// }
 /// </code>
 /// </example>
@@ -74,15 +72,23 @@ public abstract class TransformerBaseContractTests<TSut, TItem, TProgress>
     protected abstract TSut CreateSut(int itemCount);
 
     /// <summary>
-    /// Creates a <typeparamref name="TSut"/> with the supplied <see cref="IProgressTimer"/>
-    /// injected via the derived class's protected constructor.
+    /// <b>Deprecated.</b> The contract now drives progress timing via
+    /// <see cref="ManualProgressTimerCore"/> and <c>WithManualProgressTimer</c>, which need no
+    /// per-component timer plumbing — so overriding this is no longer required. Retained for source
+    /// compatibility with existing overrides; remove your override (and the component's
+    /// <c>IProgressTimer</c>-injection ctor) and it will be dropped in a future major version.
     /// </summary>
-    /// <param name="timer">
-    /// The <see cref="IProgressTimer"/> to inject. Typically a
-    /// <see cref="ManualProgressTimer"/> so that progress callbacks can be fired
-    /// on demand during tests.
-    /// </param>
-    protected abstract TSut CreateSutWithTimer(IProgressTimer timer);
+    /// <param name="timer">Unused by the contract.</param>
+    /// <returns>A new instance of <typeparamref name="TSut"/> (in existing overrides only).</returns>
+    /// <exception cref="NotSupportedException">
+    /// Always, if the base (non-overridden) implementation is invoked — the contract no longer calls it.
+    /// </exception>
+    protected virtual TSut CreateSutWithTimer(IProgressTimer timer) =>
+        throw new NotSupportedException
+        (
+            "CreateSutWithTimer is no longer used by the contract; progress timing is driven via " +
+            "ManualProgressTimerCore + WithManualProgressTimer. Remove this override."
+        );
 
 
     private const int DefaultItemCount = 5;
@@ -423,14 +429,15 @@ public abstract class TransformerBaseContractTests<TSut, TItem, TProgress>
     [Fact]
     public async Task TransformAsync_with_progress_invokes_callback_when_timer_fires_Async()
     {
-        using var timer = new ManualProgressTimer();
-        var sut = CreateSutWithTimer(timer);
+        var timer = new ManualProgressTimerCore();
+        var sut = CreateSut();
+        sut.WithManualProgressTimer(timer);
         TProgress? captured = default;
         var progress = new SynchronousProgress<TProgress>(r => captured = r);
 
         await using var enumerator = sut.TransformAsync(CreateInputItemsAsync(), progress).GetAsyncEnumerator();
         await enumerator.MoveNextAsync().ConfigureAwait(false);
-        timer.Fire();
+        timer.Tick();
 
         Assert.NotNull(captured);
     }
@@ -589,14 +596,15 @@ public abstract class TransformerBaseContractTests<TSut, TItem, TProgress>
     [Fact]
     public async Task TransformAsync_with_progress_and_token_invokes_callback_when_timer_fires_Async()
     {
-        using var timer = new ManualProgressTimer();
-        var sut = CreateSutWithTimer(timer);
+        var timer = new ManualProgressTimerCore();
+        var sut = CreateSut();
+        sut.WithManualProgressTimer(timer);
         TProgress? captured = default;
         var progress = new SynchronousProgress<TProgress>(r => captured = r);
 
         await using var enumerator = sut.TransformAsync(CreateInputItemsAsync(), progress, CancellationToken.None).GetAsyncEnumerator();
         await enumerator.MoveNextAsync().ConfigureAwait(false);
-        timer.Fire();
+        timer.Tick();
 
         Assert.NotNull(captured);
     }

--- a/src/Wolfgang.Etl.TestKit.Xunit/Wolfgang.Etl.TestKit.Xunit.csproj
+++ b/src/Wolfgang.Etl.TestKit.Xunit/Wolfgang.Etl.TestKit.Xunit.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net462;net481;netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>
-    <Version>0.13.0</Version>
+    <Version>0.14.0</Version>
     <!-- Pin AssemblyVersion to a fixed binding-stability baseline so consumers
          do not need to recompile / add binding redirects on every minor/patch
          bump. Bump only on a deliberate breaking API change. FileVersion +
@@ -21,7 +21,7 @@
          is live on NuGet (otherwise pack fails NU1102). Intentional breaks in a
          MAJOR bump are recorded via a generated CompatibilitySuppressions.xml. -->
     <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>0.12.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>0.13.0</PackageValidationBaselineVersion>
     <Title>Wolfgang.Etl.TestKit.Xunit</Title>
     <Description>Abstract xUnit contract test base classes for verifying custom ETL extractors, transformers, and loaders built on Wolfgang.Etl.Abstractions.</Description>
     <PackageProjectUrl>https://github.com/Chris-Wolfgang/ETL-Test-Kit</PackageProjectUrl>

--- a/src/Wolfgang.Etl.TestKit/ManualProgressTimerCore.cs
+++ b/src/Wolfgang.Etl.TestKit/ManualProgressTimerCore.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Threading;
+using Wolfgang.Etl.Abstractions;
+
+namespace Wolfgang.Etl.TestKit;
+
+/// <summary>
+/// A manually-driven progress timer for tests: instead of a real <see cref="System.Threading.Timer"/>
+/// firing on an interval, the stage's progress callback fires only when <see cref="Tick"/> is called,
+/// making progress-callback assertions deterministic. Attach it to a stage with
+/// <see cref="ProgressTimerExtensions.WithManualProgressTimer{TSource, TProgress}(ExtractorBase{TSource, TProgress}, ManualProgressTimerCore)"/>
+/// (and the loader / transformer overloads).
+/// </summary>
+/// <remarks>
+/// This drives the internal timer-core seam on the base classes (the same seam the base's own
+/// <c>CreateProgressTimer</c> uses), reachable here because <c>Wolfgang.Etl.TestKit</c> is an
+/// internals-visible friend of <c>Wolfgang.Etl.Abstractions</c> — so a component needs <b>no</b>
+/// per-type timer-injection plumbing to be timer-testable. Attach it before the run starts; the stage
+/// builds its progress timer when the run begins.
+/// <example><code>
+/// var timer = new ManualProgressTimerCore();
+/// var extractor = new TestExtractor&lt;int&gt;(new[] { 1, 2, 3 }).WithManualProgressTimer(timer);
+///
+/// await using var e = extractor.ExtractAsync(progress).GetAsyncEnumerator();
+/// await e.MoveNextAsync();
+/// timer.Tick();            // fires the progress callback exactly once
+/// </code></example>
+/// </remarks>
+public sealed class ManualProgressTimerCore
+{
+    private TimerCallback? _onTick;
+
+    // Consumed by ProgressTimerExtensions to set the base's internal TimerCoreFactory. The base calls
+    // this with the per-tick callback when it builds its progress timer; we capture the callback so
+    // Tick() can invoke it on demand and return a no-op core (interval timing is irrelevant here).
+    internal Func<TimerCallback, ITimerCore> CoreFactory =>
+        onTick =>
+        {
+            _onTick = onTick;
+            return new Core();
+        };
+
+
+
+    /// <summary>
+    /// Fires a single timer tick, synchronously invoking the stage's progress callback exactly once.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// The stage's progress timer has not been built yet — begin the run (start enumeration, or invoke
+    /// the loader) before calling <see cref="Tick"/>.
+    /// </exception>
+    public void Tick()
+    {
+        var onTick = _onTick
+            ?? throw new InvalidOperationException
+            (
+                "The progress timer has not started. Begin the run (start enumeration / invoke the " +
+                "loader) before calling Tick()."
+            );
+
+        onTick(state: null);
+    }
+
+
+
+    // A do-nothing ITimerCore: a manual timer never schedules real callbacks, so Change is a no-op.
+    private sealed class Core : ITimerCore
+    {
+        public void Change(int dueTime, int period)
+        {
+        }
+
+
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/src/Wolfgang.Etl.TestKit/ProgressTimerExtensions.cs
+++ b/src/Wolfgang.Etl.TestKit/ProgressTimerExtensions.cs
@@ -1,0 +1,98 @@
+using System;
+using Wolfgang.Etl.Abstractions;
+
+namespace Wolfgang.Etl.TestKit;
+
+/// <summary>
+/// Extension methods that attach a <see cref="ManualProgressTimerCore"/> to a stage so its progress
+/// callback fires deterministically (on <see cref="ManualProgressTimerCore.Tick"/>) instead of on a
+/// real timer interval.
+/// </summary>
+/// <remarks>
+/// These reach the internal timer-core seam on the base classes via the friend relationship between
+/// <c>Wolfgang.Etl.TestKit</c> and <c>Wolfgang.Etl.Abstractions</c>, so a component needs no
+/// per-type timer-injection plumbing. Attach the timer before the run starts; the stage builds its
+/// progress timer when the run begins.
+/// </remarks>
+public static class ProgressTimerExtensions
+{
+    /// <summary>Attaches <paramref name="timer"/> to <paramref name="extractor"/>.</summary>
+    /// <returns><paramref name="extractor"/>, for chaining.</returns>
+    /// <exception cref="ArgumentNullException">Either argument is <see langword="null"/>.</exception>
+    public static ExtractorBase<TSource, TProgress> WithManualProgressTimer<TSource, TProgress>
+    (
+        this ExtractorBase<TSource, TProgress> extractor,
+        ManualProgressTimerCore timer
+    )
+        where TSource : notnull
+        where TProgress : notnull
+    {
+        if (extractor is null)
+        {
+            throw new ArgumentNullException(nameof(extractor));
+        }
+
+        if (timer is null)
+        {
+            throw new ArgumentNullException(nameof(timer));
+        }
+
+        extractor.TimerCoreFactory = timer.CoreFactory;
+        return extractor;
+    }
+
+
+
+    /// <summary>Attaches <paramref name="timer"/> to <paramref name="loader"/>.</summary>
+    /// <returns><paramref name="loader"/>, for chaining.</returns>
+    /// <exception cref="ArgumentNullException">Either argument is <see langword="null"/>.</exception>
+    public static LoaderBase<TDestination, TProgress> WithManualProgressTimer<TDestination, TProgress>
+    (
+        this LoaderBase<TDestination, TProgress> loader,
+        ManualProgressTimerCore timer
+    )
+        where TDestination : notnull
+        where TProgress : notnull
+    {
+        if (loader is null)
+        {
+            throw new ArgumentNullException(nameof(loader));
+        }
+
+        if (timer is null)
+        {
+            throw new ArgumentNullException(nameof(timer));
+        }
+
+        loader.TimerCoreFactory = timer.CoreFactory;
+        return loader;
+    }
+
+
+
+    /// <summary>Attaches <paramref name="timer"/> to <paramref name="transformer"/>.</summary>
+    /// <returns><paramref name="transformer"/>, for chaining.</returns>
+    /// <exception cref="ArgumentNullException">Either argument is <see langword="null"/>.</exception>
+    public static TransformerBase<TSource, TDestination, TProgress> WithManualProgressTimer<TSource, TDestination, TProgress>
+    (
+        this TransformerBase<TSource, TDestination, TProgress> transformer,
+        ManualProgressTimerCore timer
+    )
+        where TSource : notnull
+        where TDestination : notnull
+        where TProgress : notnull
+    {
+        if (transformer is null)
+        {
+            throw new ArgumentNullException(nameof(transformer));
+        }
+
+        if (timer is null)
+        {
+            throw new ArgumentNullException(nameof(timer));
+        }
+
+        transformer.TimerCoreFactory = timer.CoreFactory;
+        return transformer;
+    }
+}

--- a/src/Wolfgang.Etl.TestKit/PublicAPI.Shipped.txt
+++ b/src/Wolfgang.Etl.TestKit/PublicAPI.Shipped.txt
@@ -1,23 +1,56 @@
 #nullable enable
+Wolfgang.Etl.TestKit.DelayingExtractor<T>
+Wolfgang.Etl.TestKit.DelayingExtractor<T>.DelayingExtractor(System.Collections.Generic.IEnumerable<T>! items, System.Func<int, System.TimeSpan>! delaySelector) -> void
+Wolfgang.Etl.TestKit.DelayingExtractor<T>.DelayingExtractor(System.Collections.Generic.IEnumerable<T>! items, System.TimeSpan delay) -> void
 Wolfgang.Etl.TestKit.FaultyExtractor<T>
+Wolfgang.Etl.TestKit.FaultyExtractor<T>.CapturedErrors.get -> System.Collections.Generic.IReadOnlyList<Wolfgang.Etl.Abstractions.ItemErrorContext!>!
 Wolfgang.Etl.TestKit.FaultyExtractor<T>.DuplicateAt(int index) -> Wolfgang.Etl.TestKit.FaultyExtractor<T>!
 Wolfgang.Etl.TestKit.FaultyExtractor<T>.FaultyExtractor(System.Collections.Generic.IEnumerable<T>! items) -> void
 Wolfgang.Etl.TestKit.FaultyExtractor<T>.FaultyExtractor(System.Collections.Generic.IEnumerable<T>! items, Wolfgang.Etl.Abstractions.IProgressTimer! timer) -> void
+Wolfgang.Etl.TestKit.FaultyExtractor<T>.HandleErrorsWith(System.Func<Wolfgang.Etl.Abstractions.ItemErrorContext!, Wolfgang.Etl.Abstractions.ItemErrorAction>! policy) -> Wolfgang.Etl.TestKit.FaultyExtractor<T>!
+Wolfgang.Etl.TestKit.FaultyExtractor<T>.SkipErrors() -> Wolfgang.Etl.TestKit.FaultyExtractor<T>!
 Wolfgang.Etl.TestKit.FaultyExtractor<T>.ThrowAfterCompletion(System.Exception! exception) -> Wolfgang.Etl.TestKit.FaultyExtractor<T>!
 Wolfgang.Etl.TestKit.FaultyExtractor<T>.ThrowAt(int index, System.Exception! exception) -> Wolfgang.Etl.TestKit.FaultyExtractor<T>!
 Wolfgang.Etl.TestKit.FaultyLoader<T>
+Wolfgang.Etl.TestKit.FaultyLoader<T>.CapturedErrors.get -> System.Collections.Generic.IReadOnlyList<Wolfgang.Etl.Abstractions.ItemErrorContext!>!
 Wolfgang.Etl.TestKit.FaultyLoader<T>.DuplicateAt(int index) -> Wolfgang.Etl.TestKit.FaultyLoader<T>!
 Wolfgang.Etl.TestKit.FaultyLoader<T>.FaultyLoader(bool collectItems) -> void
 Wolfgang.Etl.TestKit.FaultyLoader<T>.FaultyLoader(bool collectItems, Wolfgang.Etl.Abstractions.IProgressTimer! timer) -> void
 Wolfgang.Etl.TestKit.FaultyLoader<T>.GetCollectedItems() -> System.Collections.Generic.IReadOnlyList<T>?
+Wolfgang.Etl.TestKit.FaultyLoader<T>.HandleErrorsWith(System.Func<Wolfgang.Etl.Abstractions.ItemErrorContext!, Wolfgang.Etl.Abstractions.ItemErrorAction>! policy) -> Wolfgang.Etl.TestKit.FaultyLoader<T>!
+Wolfgang.Etl.TestKit.FaultyLoader<T>.SkipErrors() -> Wolfgang.Etl.TestKit.FaultyLoader<T>!
 Wolfgang.Etl.TestKit.FaultyLoader<T>.ThrowAfterCompletion(System.Exception! exception) -> Wolfgang.Etl.TestKit.FaultyLoader<T>!
 Wolfgang.Etl.TestKit.FaultyLoader<T>.ThrowAt(int index, System.Exception! exception) -> Wolfgang.Etl.TestKit.FaultyLoader<T>!
 Wolfgang.Etl.TestKit.FaultyTransformer<T>
+Wolfgang.Etl.TestKit.FaultyTransformer<T>.CapturedErrors.get -> System.Collections.Generic.IReadOnlyList<Wolfgang.Etl.Abstractions.ItemErrorContext!>!
 Wolfgang.Etl.TestKit.FaultyTransformer<T>.DuplicateAt(int index) -> Wolfgang.Etl.TestKit.FaultyTransformer<T>!
 Wolfgang.Etl.TestKit.FaultyTransformer<T>.FaultyTransformer() -> void
 Wolfgang.Etl.TestKit.FaultyTransformer<T>.FaultyTransformer(Wolfgang.Etl.Abstractions.IProgressTimer! timer) -> void
+Wolfgang.Etl.TestKit.FaultyTransformer<T>.HandleErrorsWith(System.Func<Wolfgang.Etl.Abstractions.ItemErrorContext!, Wolfgang.Etl.Abstractions.ItemErrorAction>! policy) -> Wolfgang.Etl.TestKit.FaultyTransformer<T>!
+Wolfgang.Etl.TestKit.FaultyTransformer<T>.SkipErrors() -> Wolfgang.Etl.TestKit.FaultyTransformer<T>!
 Wolfgang.Etl.TestKit.FaultyTransformer<T>.ThrowAfterCompletion(System.Exception! exception) -> Wolfgang.Etl.TestKit.FaultyTransformer<T>!
 Wolfgang.Etl.TestKit.FaultyTransformer<T>.ThrowAt(int index, System.Exception! exception) -> Wolfgang.Etl.TestKit.FaultyTransformer<T>!
+Wolfgang.Etl.TestKit.ManualProgressTimerCore
+Wolfgang.Etl.TestKit.ManualProgressTimerCore.ManualProgressTimerCore() -> void
+Wolfgang.Etl.TestKit.ManualProgressTimerCore.Tick() -> void
+Wolfgang.Etl.TestKit.ManualTimeSource
+Wolfgang.Etl.TestKit.ManualTimeSource.Advance(System.TimeSpan delta) -> void
+Wolfgang.Etl.TestKit.ManualTimeSource.ManualTimeSource() -> void
+Wolfgang.Etl.TestKit.ManualTimeSource.ManualTimeSource(System.DateTimeOffset start) -> void
+Wolfgang.Etl.TestKit.ProgressTimerExtensions
+Wolfgang.Etl.TestKit.RecordingMiddleware<T>
+Wolfgang.Etl.TestKit.RecordingMiddleware<T>.Observed.get -> System.Collections.Generic.IReadOnlyList<T>!
+Wolfgang.Etl.TestKit.RecordingMiddleware<T>.OnItemAsync(T item, System.Threading.CancellationToken token) -> System.Threading.Tasks.ValueTask<Wolfgang.Etl.Abstractions.MiddlewareResult<T>>
+Wolfgang.Etl.TestKit.RecordingMiddleware<T>.RecordingMiddleware() -> void
+Wolfgang.Etl.TestKit.RecordingMiddleware<T>.RecordingMiddleware(System.Func<T, Wolfgang.Etl.Abstractions.MiddlewareResult<T>>! policy) -> void
+Wolfgang.Etl.TestKit.RetryingExtractor<T>
+Wolfgang.Etl.TestKit.RetryingExtractor<T>.AttemptCount.get -> int
+Wolfgang.Etl.TestKit.RetryingExtractor<T>.RetryingExtractor(System.Collections.Generic.IEnumerable<T>! items, int failFirstAttempts, int maxAttempts) -> void
+Wolfgang.Etl.TestKit.SnapshotTestLoader<T>
+Wolfgang.Etl.TestKit.SnapshotTestLoader<T>.LoadedItems.get -> System.Collections.Generic.IReadOnlyList<T>!
+Wolfgang.Etl.TestKit.SnapshotTestLoader<T>.Snapshot.get -> string!
+Wolfgang.Etl.TestKit.SnapshotTestLoader<T>.SnapshotTestLoader() -> void
+Wolfgang.Etl.TestKit.SnapshotTestLoader<T>.SnapshotTestLoader(System.Func<T, string!>! formatter) -> void
 Wolfgang.Etl.TestKit.TestExtractor<T>
 Wolfgang.Etl.TestKit.TestExtractor<T>.TestExtractor(System.Collections.Generic.IEnumerable<T> items) -> void
 Wolfgang.Etl.TestKit.TestExtractor<T>.TestExtractor(System.Collections.Generic.IEnumerable<T> items, Wolfgang.Etl.Abstractions.IProgressTimer timer) -> void
@@ -33,23 +66,36 @@ Wolfgang.Etl.TestKit.TestExtractor<T>.TestExtractor(System.Func<int, T> factory,
 Wolfgang.Etl.TestKit.TestExtractor<T>.TestExtractor(System.Func<int, T> factory, int count, Wolfgang.Etl.Abstractions.IProgressTimer timer) -> void
 Wolfgang.Etl.TestKit.TestLoader<T>
 Wolfgang.Etl.TestKit.TestLoader<T>.GetCollectedItems() -> System.Collections.Generic.IReadOnlyList<T>?
+Wolfgang.Etl.TestKit.TestLoader<T>.IsDryRun.get -> bool
+Wolfgang.Etl.TestKit.TestLoader<T>.IsDryRun.set -> void
 Wolfgang.Etl.TestKit.TestLoader<T>.TestLoader(bool collectItems) -> void
 Wolfgang.Etl.TestKit.TestLoader<T>.TestLoader(bool collectItems, Wolfgang.Etl.Abstractions.IProgressTimer timer) -> void
 Wolfgang.Etl.TestKit.TestTransformer<T>
 Wolfgang.Etl.TestKit.TestTransformer<T>.TestTransformer() -> void
 Wolfgang.Etl.TestKit.TestTransformer<T>.TestTransformer(Wolfgang.Etl.Abstractions.IProgressTimer timer) -> void
+Wolfgang.Etl.TestKit.TimeSourceExtensions
+override Wolfgang.Etl.TestKit.DelayingExtractor<T>.CreateProgressReport() -> Wolfgang.Etl.Abstractions.Report!
+override Wolfgang.Etl.TestKit.DelayingExtractor<T>.ExtractWorkerAsync(System.Threading.CancellationToken token) -> System.Collections.Generic.IAsyncEnumerable<T>!
 override Wolfgang.Etl.TestKit.FaultyExtractor<T>.CreateProgressReport() -> Wolfgang.Etl.Abstractions.Report!
 override Wolfgang.Etl.TestKit.FaultyExtractor<T>.CreateProgressTimer(System.IProgress<Wolfgang.Etl.Abstractions.Report!>! progress) -> Wolfgang.Etl.Abstractions.IProgressTimer!
 override Wolfgang.Etl.TestKit.FaultyExtractor<T>.Dispose(bool disposing) -> void
 override Wolfgang.Etl.TestKit.FaultyExtractor<T>.ExtractWorkerAsync(System.Threading.CancellationToken token) -> System.Collections.Generic.IAsyncEnumerable<T>!
+override Wolfgang.Etl.TestKit.FaultyExtractor<T>.OnItemError(Wolfgang.Etl.Abstractions.ItemErrorContext! context) -> Wolfgang.Etl.Abstractions.ItemErrorAction
 override Wolfgang.Etl.TestKit.FaultyLoader<T>.CreateProgressReport() -> Wolfgang.Etl.Abstractions.Report!
 override Wolfgang.Etl.TestKit.FaultyLoader<T>.CreateProgressTimer(System.IProgress<Wolfgang.Etl.Abstractions.Report!>! progress) -> Wolfgang.Etl.Abstractions.IProgressTimer!
 override Wolfgang.Etl.TestKit.FaultyLoader<T>.Dispose(bool disposing) -> void
 override Wolfgang.Etl.TestKit.FaultyLoader<T>.LoadWorkerAsync(System.Collections.Generic.IAsyncEnumerable<T>! items, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task!
+override Wolfgang.Etl.TestKit.FaultyLoader<T>.OnItemError(Wolfgang.Etl.Abstractions.ItemErrorContext! context) -> Wolfgang.Etl.Abstractions.ItemErrorAction
 override Wolfgang.Etl.TestKit.FaultyTransformer<T>.CreateProgressReport() -> Wolfgang.Etl.Abstractions.Report!
 override Wolfgang.Etl.TestKit.FaultyTransformer<T>.CreateProgressTimer(System.IProgress<Wolfgang.Etl.Abstractions.Report!>! progress) -> Wolfgang.Etl.Abstractions.IProgressTimer!
 override Wolfgang.Etl.TestKit.FaultyTransformer<T>.Dispose(bool disposing) -> void
+override Wolfgang.Etl.TestKit.FaultyTransformer<T>.OnItemError(Wolfgang.Etl.Abstractions.ItemErrorContext! context) -> Wolfgang.Etl.Abstractions.ItemErrorAction
 override Wolfgang.Etl.TestKit.FaultyTransformer<T>.TransformWorkerAsync(System.Collections.Generic.IAsyncEnumerable<T>! items, System.Threading.CancellationToken token) -> System.Collections.Generic.IAsyncEnumerable<T>!
+override Wolfgang.Etl.TestKit.RetryingExtractor<T>.CreateProgressReport() -> Wolfgang.Etl.Abstractions.Report!
+override Wolfgang.Etl.TestKit.RetryingExtractor<T>.ExtractWorkerAsync(System.Threading.CancellationToken token) -> System.Collections.Generic.IAsyncEnumerable<T>!
+override Wolfgang.Etl.TestKit.RetryingExtractor<T>.WrapWorkerExecution(System.Func<System.Threading.CancellationToken, System.Collections.Generic.IAsyncEnumerable<T>!>! workerFactory, System.Threading.CancellationToken token) -> System.Collections.Generic.IAsyncEnumerable<T>!
+override Wolfgang.Etl.TestKit.SnapshotTestLoader<T>.CreateProgressReport() -> Wolfgang.Etl.Abstractions.Report!
+override Wolfgang.Etl.TestKit.SnapshotTestLoader<T>.LoadWorkerAsync(System.Collections.Generic.IAsyncEnumerable<T>! items, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task!
 override Wolfgang.Etl.TestKit.TestExtractor<T>.CreateProgressReport() -> Wolfgang.Etl.Abstractions.Report
 override Wolfgang.Etl.TestKit.TestExtractor<T>.CreateProgressTimer(System.IProgress<Wolfgang.Etl.Abstractions.Report> progress) -> Wolfgang.Etl.Abstractions.IProgressTimer
 override Wolfgang.Etl.TestKit.TestExtractor<T>.Dispose(bool disposing) -> void
@@ -62,48 +108,9 @@ override Wolfgang.Etl.TestKit.TestTransformer<T>.CreateProgressReport() -> Wolfg
 override Wolfgang.Etl.TestKit.TestTransformer<T>.CreateProgressTimer(System.IProgress<Wolfgang.Etl.Abstractions.Report> progress) -> Wolfgang.Etl.Abstractions.IProgressTimer
 override Wolfgang.Etl.TestKit.TestTransformer<T>.Dispose(bool disposing) -> void
 override Wolfgang.Etl.TestKit.TestTransformer<T>.TransformWorkerAsync(System.Collections.Generic.IAsyncEnumerable<T> items, System.Threading.CancellationToken token) -> System.Collections.Generic.IAsyncEnumerable<T>
-Wolfgang.Etl.TestKit.TestLoader<T>.IsDryRun.get -> bool
-Wolfgang.Etl.TestKit.TestLoader<T>.IsDryRun.set -> void
-Wolfgang.Etl.TestKit.FaultyExtractor<T>.SkipErrors() -> Wolfgang.Etl.TestKit.FaultyExtractor<T>!
-Wolfgang.Etl.TestKit.FaultyExtractor<T>.HandleErrorsWith(System.Func<Wolfgang.Etl.Abstractions.ItemErrorContext!, Wolfgang.Etl.Abstractions.ItemErrorAction>! policy) -> Wolfgang.Etl.TestKit.FaultyExtractor<T>!
-Wolfgang.Etl.TestKit.FaultyExtractor<T>.CapturedErrors.get -> System.Collections.Generic.IReadOnlyList<Wolfgang.Etl.Abstractions.ItemErrorContext!>!
-override Wolfgang.Etl.TestKit.FaultyExtractor<T>.OnItemError(Wolfgang.Etl.Abstractions.ItemErrorContext! context) -> Wolfgang.Etl.Abstractions.ItemErrorAction
-Wolfgang.Etl.TestKit.FaultyLoader<T>.SkipErrors() -> Wolfgang.Etl.TestKit.FaultyLoader<T>!
-Wolfgang.Etl.TestKit.FaultyLoader<T>.HandleErrorsWith(System.Func<Wolfgang.Etl.Abstractions.ItemErrorContext!, Wolfgang.Etl.Abstractions.ItemErrorAction>! policy) -> Wolfgang.Etl.TestKit.FaultyLoader<T>!
-Wolfgang.Etl.TestKit.FaultyLoader<T>.CapturedErrors.get -> System.Collections.Generic.IReadOnlyList<Wolfgang.Etl.Abstractions.ItemErrorContext!>!
-override Wolfgang.Etl.TestKit.FaultyLoader<T>.OnItemError(Wolfgang.Etl.Abstractions.ItemErrorContext! context) -> Wolfgang.Etl.Abstractions.ItemErrorAction
-Wolfgang.Etl.TestKit.FaultyTransformer<T>.SkipErrors() -> Wolfgang.Etl.TestKit.FaultyTransformer<T>!
-Wolfgang.Etl.TestKit.FaultyTransformer<T>.HandleErrorsWith(System.Func<Wolfgang.Etl.Abstractions.ItemErrorContext!, Wolfgang.Etl.Abstractions.ItemErrorAction>! policy) -> Wolfgang.Etl.TestKit.FaultyTransformer<T>!
-Wolfgang.Etl.TestKit.FaultyTransformer<T>.CapturedErrors.get -> System.Collections.Generic.IReadOnlyList<Wolfgang.Etl.Abstractions.ItemErrorContext!>!
-override Wolfgang.Etl.TestKit.FaultyTransformer<T>.OnItemError(Wolfgang.Etl.Abstractions.ItemErrorContext! context) -> Wolfgang.Etl.Abstractions.ItemErrorAction
-Wolfgang.Etl.TestKit.DelayingExtractor<T>
-Wolfgang.Etl.TestKit.DelayingExtractor<T>.DelayingExtractor(System.Collections.Generic.IEnumerable<T>! items, System.Func<int, System.TimeSpan>! delaySelector) -> void
-Wolfgang.Etl.TestKit.DelayingExtractor<T>.DelayingExtractor(System.Collections.Generic.IEnumerable<T>! items, System.TimeSpan delay) -> void
-override Wolfgang.Etl.TestKit.DelayingExtractor<T>.CreateProgressReport() -> Wolfgang.Etl.Abstractions.Report!
-override Wolfgang.Etl.TestKit.DelayingExtractor<T>.ExtractWorkerAsync(System.Threading.CancellationToken token) -> System.Collections.Generic.IAsyncEnumerable<T>!
-Wolfgang.Etl.TestKit.SnapshotTestLoader<T>
-Wolfgang.Etl.TestKit.SnapshotTestLoader<T>.SnapshotTestLoader() -> void
-Wolfgang.Etl.TestKit.SnapshotTestLoader<T>.SnapshotTestLoader(System.Func<T, string!>! formatter) -> void
-Wolfgang.Etl.TestKit.SnapshotTestLoader<T>.LoadedItems.get -> System.Collections.Generic.IReadOnlyList<T>!
-Wolfgang.Etl.TestKit.SnapshotTestLoader<T>.Snapshot.get -> string!
-override Wolfgang.Etl.TestKit.SnapshotTestLoader<T>.CreateProgressReport() -> Wolfgang.Etl.Abstractions.Report!
-override Wolfgang.Etl.TestKit.SnapshotTestLoader<T>.LoadWorkerAsync(System.Collections.Generic.IAsyncEnumerable<T>! items, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task!
-Wolfgang.Etl.TestKit.RetryingExtractor<T>
-Wolfgang.Etl.TestKit.RetryingExtractor<T>.RetryingExtractor(System.Collections.Generic.IEnumerable<T>! items, int failFirstAttempts, int maxAttempts) -> void
-Wolfgang.Etl.TestKit.RetryingExtractor<T>.AttemptCount.get -> int
-override Wolfgang.Etl.TestKit.RetryingExtractor<T>.CreateProgressReport() -> Wolfgang.Etl.Abstractions.Report!
-override Wolfgang.Etl.TestKit.RetryingExtractor<T>.ExtractWorkerAsync(System.Threading.CancellationToken token) -> System.Collections.Generic.IAsyncEnumerable<T>!
-override Wolfgang.Etl.TestKit.RetryingExtractor<T>.WrapWorkerExecution(System.Func<System.Threading.CancellationToken, System.Collections.Generic.IAsyncEnumerable<T>!>! workerFactory, System.Threading.CancellationToken token) -> System.Collections.Generic.IAsyncEnumerable<T>!
-Wolfgang.Etl.TestKit.ManualTimeSource
-Wolfgang.Etl.TestKit.ManualTimeSource.ManualTimeSource() -> void
-Wolfgang.Etl.TestKit.ManualTimeSource.ManualTimeSource(System.DateTimeOffset start) -> void
-Wolfgang.Etl.TestKit.ManualTimeSource.Advance(System.TimeSpan delta) -> void
-Wolfgang.Etl.TestKit.TimeSourceExtensions
-static Wolfgang.Etl.TestKit.TimeSourceExtensions.WithTimeSource<TSource, TProgress>(this Wolfgang.Etl.Abstractions.ExtractorBase<TSource, TProgress>! extractor, Wolfgang.Etl.TestKit.ManualTimeSource! timeSource) -> Wolfgang.Etl.Abstractions.ExtractorBase<TSource, TProgress>!
+static Wolfgang.Etl.TestKit.ProgressTimerExtensions.WithManualProgressTimer<TDestination, TProgress>(this Wolfgang.Etl.Abstractions.LoaderBase<TDestination, TProgress>! loader, Wolfgang.Etl.TestKit.ManualProgressTimerCore! timer) -> Wolfgang.Etl.Abstractions.LoaderBase<TDestination, TProgress>!
+static Wolfgang.Etl.TestKit.ProgressTimerExtensions.WithManualProgressTimer<TSource, TDestination, TProgress>(this Wolfgang.Etl.Abstractions.TransformerBase<TSource, TDestination, TProgress>! transformer, Wolfgang.Etl.TestKit.ManualProgressTimerCore! timer) -> Wolfgang.Etl.Abstractions.TransformerBase<TSource, TDestination, TProgress>!
+static Wolfgang.Etl.TestKit.ProgressTimerExtensions.WithManualProgressTimer<TSource, TProgress>(this Wolfgang.Etl.Abstractions.ExtractorBase<TSource, TProgress>! extractor, Wolfgang.Etl.TestKit.ManualProgressTimerCore! timer) -> Wolfgang.Etl.Abstractions.ExtractorBase<TSource, TProgress>!
 static Wolfgang.Etl.TestKit.TimeSourceExtensions.WithTimeSource<TDestination, TProgress>(this Wolfgang.Etl.Abstractions.LoaderBase<TDestination, TProgress>! loader, Wolfgang.Etl.TestKit.ManualTimeSource! timeSource) -> Wolfgang.Etl.Abstractions.LoaderBase<TDestination, TProgress>!
 static Wolfgang.Etl.TestKit.TimeSourceExtensions.WithTimeSource<TSource, TDestination, TProgress>(this Wolfgang.Etl.Abstractions.TransformerBase<TSource, TDestination, TProgress>! transformer, Wolfgang.Etl.TestKit.ManualTimeSource! timeSource) -> Wolfgang.Etl.Abstractions.TransformerBase<TSource, TDestination, TProgress>!
-Wolfgang.Etl.TestKit.RecordingMiddleware<T>
-Wolfgang.Etl.TestKit.RecordingMiddleware<T>.RecordingMiddleware() -> void
-Wolfgang.Etl.TestKit.RecordingMiddleware<T>.RecordingMiddleware(System.Func<T, Wolfgang.Etl.Abstractions.MiddlewareResult<T>>! policy) -> void
-Wolfgang.Etl.TestKit.RecordingMiddleware<T>.Observed.get -> System.Collections.Generic.IReadOnlyList<T>!
-Wolfgang.Etl.TestKit.RecordingMiddleware<T>.OnItemAsync(T item, System.Threading.CancellationToken token) -> System.Threading.Tasks.ValueTask<Wolfgang.Etl.Abstractions.MiddlewareResult<T>>
+static Wolfgang.Etl.TestKit.TimeSourceExtensions.WithTimeSource<TSource, TProgress>(this Wolfgang.Etl.Abstractions.ExtractorBase<TSource, TProgress>! extractor, Wolfgang.Etl.TestKit.ManualTimeSource! timeSource) -> Wolfgang.Etl.Abstractions.ExtractorBase<TSource, TProgress>!

--- a/src/Wolfgang.Etl.TestKit/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.TestKit/PublicAPI.Unshipped.txt
@@ -1,8 +1,1 @@
 #nullable enable
-Wolfgang.Etl.TestKit.ManualProgressTimerCore
-Wolfgang.Etl.TestKit.ManualProgressTimerCore.ManualProgressTimerCore() -> void
-Wolfgang.Etl.TestKit.ManualProgressTimerCore.Tick() -> void
-Wolfgang.Etl.TestKit.ProgressTimerExtensions
-static Wolfgang.Etl.TestKit.ProgressTimerExtensions.WithManualProgressTimer<TDestination, TProgress>(this Wolfgang.Etl.Abstractions.LoaderBase<TDestination, TProgress>! loader, Wolfgang.Etl.TestKit.ManualProgressTimerCore! timer) -> Wolfgang.Etl.Abstractions.LoaderBase<TDestination, TProgress>!
-static Wolfgang.Etl.TestKit.ProgressTimerExtensions.WithManualProgressTimer<TSource, TDestination, TProgress>(this Wolfgang.Etl.Abstractions.TransformerBase<TSource, TDestination, TProgress>! transformer, Wolfgang.Etl.TestKit.ManualProgressTimerCore! timer) -> Wolfgang.Etl.Abstractions.TransformerBase<TSource, TDestination, TProgress>!
-static Wolfgang.Etl.TestKit.ProgressTimerExtensions.WithManualProgressTimer<TSource, TProgress>(this Wolfgang.Etl.Abstractions.ExtractorBase<TSource, TProgress>! extractor, Wolfgang.Etl.TestKit.ManualProgressTimerCore! timer) -> Wolfgang.Etl.Abstractions.ExtractorBase<TSource, TProgress>!

--- a/src/Wolfgang.Etl.TestKit/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.TestKit/PublicAPI.Unshipped.txt
@@ -1,1 +1,8 @@
 #nullable enable
+Wolfgang.Etl.TestKit.ManualProgressTimerCore
+Wolfgang.Etl.TestKit.ManualProgressTimerCore.ManualProgressTimerCore() -> void
+Wolfgang.Etl.TestKit.ManualProgressTimerCore.Tick() -> void
+Wolfgang.Etl.TestKit.ProgressTimerExtensions
+static Wolfgang.Etl.TestKit.ProgressTimerExtensions.WithManualProgressTimer<TDestination, TProgress>(this Wolfgang.Etl.Abstractions.LoaderBase<TDestination, TProgress>! loader, Wolfgang.Etl.TestKit.ManualProgressTimerCore! timer) -> Wolfgang.Etl.Abstractions.LoaderBase<TDestination, TProgress>!
+static Wolfgang.Etl.TestKit.ProgressTimerExtensions.WithManualProgressTimer<TSource, TDestination, TProgress>(this Wolfgang.Etl.Abstractions.TransformerBase<TSource, TDestination, TProgress>! transformer, Wolfgang.Etl.TestKit.ManualProgressTimerCore! timer) -> Wolfgang.Etl.Abstractions.TransformerBase<TSource, TDestination, TProgress>!
+static Wolfgang.Etl.TestKit.ProgressTimerExtensions.WithManualProgressTimer<TSource, TProgress>(this Wolfgang.Etl.Abstractions.ExtractorBase<TSource, TProgress>! extractor, Wolfgang.Etl.TestKit.ManualProgressTimerCore! timer) -> Wolfgang.Etl.Abstractions.ExtractorBase<TSource, TProgress>!

--- a/src/Wolfgang.Etl.TestKit/Wolfgang.Etl.TestKit.csproj
+++ b/src/Wolfgang.Etl.TestKit/Wolfgang.Etl.TestKit.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net462;net481;netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>
-    <Version>0.13.0</Version>
+    <Version>0.14.0</Version>
     <!-- Pin AssemblyVersion to a fixed binding-stability baseline so consumers
          do not need to recompile / add binding redirects on every minor/patch
          bump. Bump only on a deliberate breaking API change. FileVersion +
@@ -21,7 +21,7 @@
          is live on NuGet (otherwise pack fails NU1102). Intentional breaks in a
          MAJOR bump are recorded via a generated CompatibilitySuppressions.xml. -->
     <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>0.12.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>0.13.0</PackageValidationBaselineVersion>
     <Title>Wolfgang.Etl.TestKit</Title>
     <Description>An implementation of Extractor, Transformer and Loader for use in ETL examples and benchmarks. Built on Wolfgang.Etl.Abstractions.</Description>
     <PackageProjectUrl>https://github.com/Chris-Wolfgang/ETL-Test-Kit</PackageProjectUrl>

--- a/tests/Wolfgang.Etl.TestKit.Tests.Unit/ManualProgressTimerCoreTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Unit/ManualProgressTimerCoreTests.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+using Wolfgang.Etl.TestKit;
+using Xunit;
+
+namespace Wolfgang.Etl.TestKit.Tests.Unit;
+
+public class ManualProgressTimerCoreTests
+{
+    [Fact]
+    public void Tick_before_the_run_starts_throws_InvalidOperationException()
+    {
+        var timer = new ManualProgressTimerCore();
+
+        Assert.Throws<InvalidOperationException>
+        (
+            () => timer.Tick()
+        );
+    }
+
+
+
+    [Fact]
+    public async Task Tick_after_the_run_starts_invokes_the_progress_callback_Async()
+    {
+        var timer = new ManualProgressTimerCore();
+        var sut = new TestExtractor<int>(new[] { 1, 2, 3 });
+        sut.WithManualProgressTimer(timer);
+
+        Report? captured = null;
+        var progress = new SyncProgress<Report>(r => captured = r);
+
+        await using var enumerator = sut.ExtractAsync(progress).GetAsyncEnumerator();
+        await enumerator.MoveNextAsync().ConfigureAwait(false);   // starts the run; builds the progress timer
+        timer.Tick();                                            // fires the callback exactly once
+
+        Assert.NotNull(captured);
+    }
+
+
+
+    [Fact]
+    public void WithManualProgressTimer_when_extractor_is_null_throws_ArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>
+        (
+            () => ((ExtractorBase<int, Report>)null!).WithManualProgressTimer(new ManualProgressTimerCore())
+        );
+    }
+
+
+
+    [Fact]
+    public void WithManualProgressTimer_when_extractor_timer_is_null_throws_ArgumentNullException()
+    {
+        var sut = new TestExtractor<int>(new[] { 1 });
+
+        Assert.Throws<ArgumentNullException>
+        (
+            () => sut.WithManualProgressTimer(null!)
+        );
+    }
+
+
+
+    [Fact]
+    public void WithManualProgressTimer_when_loader_timer_is_null_throws_ArgumentNullException()
+    {
+        var sut = new TestLoader<int>(collectItems: false);
+
+        Assert.Throws<ArgumentNullException>
+        (
+            () => sut.WithManualProgressTimer(null!)
+        );
+    }
+
+
+
+    [Fact]
+    public void WithManualProgressTimer_when_transformer_timer_is_null_throws_ArgumentNullException()
+    {
+        var sut = new TestTransformer<int>();
+
+        Assert.Throws<ArgumentNullException>
+        (
+            () => sut.WithManualProgressTimer(null!)
+        );
+    }
+
+
+
+    // A synchronous IProgress<T> so a Tick's callback is observed inline (System.Progress<T> posts async).
+    private sealed class SyncProgress<T> : IProgress<T>
+    {
+        private readonly Action<T> _callback;
+
+        public SyncProgress(Action<T> callback) => _callback = callback;
+
+        public void Report(T value) => _callback(value);
+    }
+}

--- a/tests/Wolfgang.Etl.TestKit.Tests.Unit/ProgressTimerExtensionsTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Unit/ProgressTimerExtensionsTests.cs
@@ -1,0 +1,63 @@
+using System;
+using Wolfgang.Etl.Abstractions;
+using Wolfgang.Etl.TestKit;
+using Xunit;
+
+namespace Wolfgang.Etl.TestKit.Tests.Unit;
+
+public class ProgressTimerExtensionsTests
+{
+    // ------------------------------------------------------------------
+    // Null-argument guards not already covered elsewhere
+    // (the extractor overload + the three timer-null guards live in
+    //  ManualProgressTimerCoreTests).
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void WithManualProgressTimer_when_loader_is_null_throws_ArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>
+        (
+            () => ((LoaderBase<int, Report>)null!).WithManualProgressTimer(new ManualProgressTimerCore())
+        );
+    }
+
+
+
+    [Fact]
+    public void WithManualProgressTimer_when_transformer_is_null_throws_ArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>
+        (
+            () => ((TransformerBase<int, int, Report>)null!).WithManualProgressTimer(new ManualProgressTimerCore())
+        );
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // Loader / transformer overloads attach the timer and return the stage
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void WithManualProgressTimer_loader_overload_attaches_and_returns_the_loader()
+    {
+        var loader = new TestLoader<int>(collectItems: false);
+
+        var returned = loader.WithManualProgressTimer(new ManualProgressTimerCore());
+
+        Assert.Same(loader, returned);
+    }
+
+
+
+    [Fact]
+    public void WithManualProgressTimer_transformer_overload_attaches_and_returns_the_transformer()
+    {
+        var transformer = new TestTransformer<int>();
+
+        var returned = transformer.WithManualProgressTimer(new ManualProgressTimerCore());
+
+        Assert.Same(transformer, returned);
+    }
+}


### PR DESCRIPTION
## Release 0.14.0

Merges the 0.14.0 content from `vNext` to `main`. **Minor, purely additive** — validates against the 0.13.0 baseline.

### What's in it
- **`ManualProgressTimerCore` + `WithManualProgressTimer(...)` (#352):** a manually-driven progress timer so any extractor/loader/transformer is timer-testable via `.WithManualProgressTimer(timer)` + `timer.Tick()` — no per-component `IProgressTimer` plumbing. Drives the base's internal timer-core seam via the TestKit⇆Abstractions friend relationship.
- **Contract bases adopt it:** the timer tests use `CreateSut(...)` + `ManualProgressTimerCore`; `CreateSutWithTimer` demoted `abstract`→`virtual` (existing overrides still compile — additive).

### Release-readiness (verified locally)
- CHANGELOG promoted to `[0.14.0] - 2026-08-03`; PublicAPI Unshipped→Shipped (`Wolfgang.Etl.TestKit`).
- Full Release build clean; **both** packages (`Wolfgang.Etl.TestKit` + `Wolfgang.Etl.TestKit.Xunit`) pack at 0.14.0 with **PackageValidation passing vs 0.13.0**.
- `release.yaml` packs/publishes glob-over-`src/**` → both packages publish.

### After merge
Tag **`v0.14.0`** to fire `release.yaml`. This unblocks the downstream timer-boilerplate cleanup (#352). Post-release: baseline bump to 0.14.0 + branch cleanup.
