### PR TITLE
Drive contract-base progress timing via ManualProgressTimerCore (Part B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`ManualProgressTimerCore` + `WithManualProgressTimer` extensions (#352):** a manually-driven progress
+  timer for tests. Attach it to any extractor / loader / transformer with `.WithManualProgressTimer(timer)`
+  and fire the stage's progress callback deterministically with `timer.Tick()` — no per-component
+  `IProgressTimer`-injection plumbing required. Drives the base's internal timer-core seam via the
+  `Wolfgang.Etl.TestKit` ⇆ `Wolfgang.Etl.Abstractions` friend relationship.
+
 ### Changed
 
+- **Contract-test bases now drive progress timing via `ManualProgressTimerCore` (#352).** The
+  `ExtractorBaseContractTests` / `LoaderBaseContractTests` / `TransformerBaseContractTests` timer tests
+  build the SUT with the standard `CreateSut(...)` factory and attach a `ManualProgressTimerCore` — they
+  no longer require `CreateSutWithTimer`. That member is now **`virtual`** (was `abstract`) and throws if
+  the base implementation is invoked; existing overrides still compile. Additive — no downstream change
+  required to adopt the new TestKit.
+
 ### Deprecated
+
+- **`*BaseContractTests.CreateSutWithTimer(IProgressTimer)` (#352):** no longer called by the contract.
+  Remove your override (and the component's `IProgressTimer`-injection constructor); it will be dropped in
+  a future major version.
 
 ### Removed
 

--- a/src/Wolfgang.Etl.TestKit.Xunit/ExtractorBaseContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/ExtractorBaseContractTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Wolfgang.Etl.Abstractions;
+using Wolfgang.Etl.TestKit;
 using Xunit;
 
 namespace Wolfgang.Etl.TestKit.Xunit;
@@ -51,9 +52,6 @@ namespace Wolfgang.Etl.TestKit.Xunit;
 ///
 ///     protected override IReadOnlyList&lt;MyRecord&gt; CreateExpectedItems() =>
 ///         new List&lt;MyRecord&gt; { new("a"), new("b"), new("c"), new("d"), new("e") };
-///
-///     protected override MyExtractor CreateSutWithTimer(IProgressTimer timer) =>
-///         new MyExtractor("path/to/test-data.csv", timer);
 /// }
 /// </code>
 /// </example>
@@ -91,22 +89,23 @@ public abstract class ExtractorBaseContractTests<TSut, TItem, TProgress>
     protected abstract IReadOnlyList<TItem> CreateExpectedItems();
 
     /// <summary>
-    /// Creates the system under test with the supplied <see cref="IProgressTimer"/>
-    /// injected via the derived class's protected constructor.
+    /// <b>Deprecated.</b> The contract now drives progress timing via
+    /// <see cref="ManualProgressTimerCore"/> and <c>WithManualProgressTimer</c>, which need no
+    /// per-component timer plumbing — so overriding this is no longer required. Retained for source
+    /// compatibility with existing overrides; remove your override (and the component's
+    /// <c>IProgressTimer</c>-injection ctor) and it will be dropped in a future major version.
     /// </summary>
-    /// <param name="timer">
-    /// The <see cref="IProgressTimer"/> to inject. Typically a
-    /// <see cref="ManualProgressTimer"/> so that progress callbacks can be fired
-    /// on demand during tests.
-    /// </param>
-    /// <returns>A new, fully initialised instance of <typeparamref name="TSut"/>.</returns>
-    /// <example>
-    /// <code>
-    /// protected override MyExtractor CreateSutWithTimer(IProgressTimer timer) =>
-    ///     new MyExtractor(sourceData, timer);
-    /// </code>
-    /// </example>
-    protected abstract TSut CreateSutWithTimer(IProgressTimer timer);
+    /// <param name="timer">Unused by the contract.</param>
+    /// <returns>A new instance of <typeparamref name="TSut"/> (in existing overrides only).</returns>
+    /// <exception cref="NotSupportedException">
+    /// Always, if the base (non-overridden) implementation is invoked — the contract no longer calls it.
+    /// </exception>
+    protected virtual TSut CreateSutWithTimer(IProgressTimer timer) =>
+        throw new NotSupportedException
+        (
+            "CreateSutWithTimer is no longer used by the contract; progress timing is driven via " +
+            "ManualProgressTimerCore + WithManualProgressTimer. Remove this override."
+        );
 
 
 
@@ -378,14 +377,15 @@ public abstract class ExtractorBaseContractTests<TSut, TItem, TProgress>
     [Fact]
     public async Task ExtractAsync_with_progress_invokes_callback_when_timer_fires_Async()
     {
-        using var timer = new ManualProgressTimer();
-        var sut = CreateSutWithTimer(timer);
+        var timer = new ManualProgressTimerCore();
+        var sut = CreateSut();
+        sut.WithManualProgressTimer(timer);
         TProgress? captured = default;
         var progress = new SynchronousProgress<TProgress>(r => captured = r);
 
         await using var enumerator = sut.ExtractAsync(progress).GetAsyncEnumerator();
         await enumerator.MoveNextAsync().ConfigureAwait(false);
-        timer.Fire();
+        timer.Tick();
 
         Assert.NotNull(captured);
     }
@@ -527,14 +527,15 @@ public abstract class ExtractorBaseContractTests<TSut, TItem, TProgress>
     [Fact]
     public async Task ExtractAsync_with_progress_and_token_invokes_callback_when_timer_fires_Async()
     {
-        using var timer = new ManualProgressTimer();
-        var sut = CreateSutWithTimer(timer);
+        var timer = new ManualProgressTimerCore();
+        var sut = CreateSut();
+        sut.WithManualProgressTimer(timer);
         TProgress? captured = default;
         var progress = new SynchronousProgress<TProgress>(r => captured = r);
 
         await using var enumerator = sut.ExtractAsync(progress, CancellationToken.None).GetAsyncEnumerator();
         await enumerator.MoveNextAsync().ConfigureAwait(false);
-        timer.Fire();
+        timer.Tick();
 
         Assert.NotNull(captured);
     }

--- a/src/Wolfgang.Etl.TestKit.Xunit/LoaderBaseContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/LoaderBaseContractTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Wolfgang.Etl.Abstractions;
+using Wolfgang.Etl.TestKit;
 using Xunit;
 
 namespace Wolfgang.Etl.TestKit.Xunit;
@@ -50,9 +51,6 @@ namespace Wolfgang.Etl.TestKit.Xunit;
 ///
 ///     protected override IReadOnlyList&lt;MyRecord&gt; CreateSourceItems() =>
 ///         new List&lt;MyRecord&gt; { new("a"), new("b"), new("c"), new("d"), new("e") };
-///
-///     protected override MyLoader CreateSutWithTimer(IProgressTimer timer) =>
-///         new MyLoader(connectionString, timer);
 /// }
 /// </code>
 /// </example>
@@ -74,15 +72,23 @@ public abstract class LoaderBaseContractTests<TSut, TItem, TProgress>
     protected abstract TSut CreateSut(int itemCount);
 
     /// <summary>
-    /// Creates a <typeparamref name="TSut"/> with the supplied <see cref="IProgressTimer"/>
-    /// injected via the derived class's protected constructor.
+    /// <b>Deprecated.</b> The contract now drives progress timing via
+    /// <see cref="ManualProgressTimerCore"/> and <c>WithManualProgressTimer</c>, which need no
+    /// per-component timer plumbing — so overriding this is no longer required. Retained for source
+    /// compatibility with existing overrides; remove your override (and the component's
+    /// <c>IProgressTimer</c>-injection ctor) and it will be dropped in a future major version.
     /// </summary>
-    /// <param name="timer">
-    /// The <see cref="IProgressTimer"/> to inject. Typically a
-    /// <see cref="ManualProgressTimer"/> so that progress callbacks can be fired
-    /// on demand during tests.
-    /// </param>
-    protected abstract TSut CreateSutWithTimer(IProgressTimer timer);
+    /// <param name="timer">Unused by the contract.</param>
+    /// <returns>A new instance of <typeparamref name="TSut"/> (in existing overrides only).</returns>
+    /// <exception cref="NotSupportedException">
+    /// Always, if the base (non-overridden) implementation is invoked — the contract no longer calls it.
+    /// </exception>
+    protected virtual TSut CreateSutWithTimer(IProgressTimer timer) =>
+        throw new NotSupportedException
+        (
+            "CreateSutWithTimer is no longer used by the contract; progress timing is driven via " +
+            "ManualProgressTimerCore + WithManualProgressTimer. Remove this override."
+        );
 
     /// <summary>
     /// Returns the source items used to feed the loader. Must return at least 5 items.
@@ -107,7 +113,7 @@ public abstract class LoaderBaseContractTests<TSut, TItem, TProgress>
     /// <summary>
     /// Returns an input sequence that pauses after the first item until
     /// <paramref name="gate"/> is released, keeping the load pipeline alive
-    /// so the test can call <see cref="ManualProgressTimer.Fire"/> mid-flight.
+    /// so the test can call <see cref="ManualProgressTimerCore.Tick"/> mid-flight.
     /// </summary>
     private async IAsyncEnumerable<TItem> CreateGatedInputItemsAsync(TaskCompletionSource<bool> gate)
     {
@@ -400,14 +406,15 @@ public abstract class LoaderBaseContractTests<TSut, TItem, TProgress>
     [Fact]
     public async Task LoadAsync_with_progress_invokes_callback_when_timer_fires_Async()
     {
-        using var timer = new ManualProgressTimer();
-        var sut = CreateSutWithTimer(timer);
+        var timer = new ManualProgressTimerCore();
+        var sut = CreateSut();
+        sut.WithManualProgressTimer(timer);
         TProgress? captured = default;
         var progress = new SynchronousProgress<TProgress>(r => captured = r);
         var gate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
         var task = sut.LoadAsync(CreateGatedInputItemsAsync(gate), progress);
-        timer.Fire();
+        timer.Tick();
         gate.SetResult(true);
         await task.ConfigureAwait(false);
 
@@ -554,14 +561,15 @@ public abstract class LoaderBaseContractTests<TSut, TItem, TProgress>
     [Fact]
     public async Task LoadAsync_with_progress_and_token_invokes_callback_when_timer_fires_Async()
     {
-        using var timer = new ManualProgressTimer();
-        var sut = CreateSutWithTimer(timer);
+        var timer = new ManualProgressTimerCore();
+        var sut = CreateSut();
+        sut.WithManualProgressTimer(timer);
         TProgress? captured = default;
         var progress = new SynchronousProgress<TProgress>(r => captured = r);
         var gate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
         var task = sut.LoadAsync(CreateGatedInputItemsAsync(gate), progress, CancellationToken.None);
-        timer.Fire();
+        timer.Tick();
         gate.SetResult(true);
         await task.ConfigureAwait(false);
 

--- a/src/Wolfgang.Etl.TestKit.Xunit/PublicAPI.Shipped.txt
+++ b/src/Wolfgang.Etl.TestKit.Xunit/PublicAPI.Shipped.txt
@@ -255,7 +255,7 @@ abstract Wolfgang.Etl.TestKit.Xunit.ExtractWithProgressAsyncContractTests<TSut, 
 abstract Wolfgang.Etl.TestKit.Xunit.ExtractWithProgressAsyncContractTests<TSut, TItem, TProgress>.CreateSut(int itemCount) -> TSut
 abstract Wolfgang.Etl.TestKit.Xunit.ExtractorBaseContractTests<TSut, TItem, TProgress>.CreateExpectedItems() -> System.Collections.Generic.IReadOnlyList<TItem>
 abstract Wolfgang.Etl.TestKit.Xunit.ExtractorBaseContractTests<TSut, TItem, TProgress>.CreateSut(int itemCount) -> TSut
-abstract Wolfgang.Etl.TestKit.Xunit.ExtractorBaseContractTests<TSut, TItem, TProgress>.CreateSutWithTimer(Wolfgang.Etl.Abstractions.IProgressTimer timer) -> TSut
+virtual Wolfgang.Etl.TestKit.Xunit.ExtractorBaseContractTests<TSut, TItem, TProgress>.CreateSutWithTimer(Wolfgang.Etl.Abstractions.IProgressTimer timer) -> TSut
 abstract Wolfgang.Etl.TestKit.Xunit.IdempotentExtractorContractTests<TSut, TItem, TProgress>.CreateExpectedItems() -> System.Collections.Generic.IReadOnlyList<TItem>!
 abstract Wolfgang.Etl.TestKit.Xunit.IdempotentExtractorContractTests<TSut, TItem, TProgress>.CreateSut(int itemCount) -> TSut
 abstract Wolfgang.Etl.TestKit.Xunit.IdempotentLoaderContractTests<TSut, TItem>.CreateSourceItems() -> System.Collections.Generic.IReadOnlyList<TItem>!
@@ -273,7 +273,7 @@ abstract Wolfgang.Etl.TestKit.Xunit.LoadWithProgressAsyncContractTests<TSut, TIt
 abstract Wolfgang.Etl.TestKit.Xunit.LoadWithProgressAsyncContractTests<TSut, TItem, TProgress>.CreateSut(int itemCount) -> TSut
 abstract Wolfgang.Etl.TestKit.Xunit.LoaderBaseContractTests<TSut, TItem, TProgress>.CreateSourceItems() -> System.Collections.Generic.IReadOnlyList<TItem>
 abstract Wolfgang.Etl.TestKit.Xunit.LoaderBaseContractTests<TSut, TItem, TProgress>.CreateSut(int itemCount) -> TSut
-abstract Wolfgang.Etl.TestKit.Xunit.LoaderBaseContractTests<TSut, TItem, TProgress>.CreateSutWithTimer(Wolfgang.Etl.Abstractions.IProgressTimer timer) -> TSut
+virtual Wolfgang.Etl.TestKit.Xunit.LoaderBaseContractTests<TSut, TItem, TProgress>.CreateSutWithTimer(Wolfgang.Etl.Abstractions.IProgressTimer timer) -> TSut
 abstract Wolfgang.Etl.TestKit.Xunit.TransformAsyncContractTests<TSut, TItem>.CreateExpectedItems() -> System.Collections.Generic.IReadOnlyList<TItem>
 abstract Wolfgang.Etl.TestKit.Xunit.TransformAsyncContractTests<TSut, TItem>.CreateSut(int itemCount) -> TSut
 abstract Wolfgang.Etl.TestKit.Xunit.TransformWithCancellationAsyncContractTests<TSut, TItem>.CreateExpectedItems() -> System.Collections.Generic.IReadOnlyList<TItem>
@@ -284,7 +284,7 @@ abstract Wolfgang.Etl.TestKit.Xunit.TransformWithProgressAsyncContractTests<TSut
 abstract Wolfgang.Etl.TestKit.Xunit.TransformWithProgressAsyncContractTests<TSut, TItem, TProgress>.CreateSut(int itemCount) -> TSut
 abstract Wolfgang.Etl.TestKit.Xunit.TransformerBaseContractTests<TSut, TItem, TProgress>.CreateExpectedItems() -> System.Collections.Generic.IReadOnlyList<TItem>
 abstract Wolfgang.Etl.TestKit.Xunit.TransformerBaseContractTests<TSut, TItem, TProgress>.CreateSut(int itemCount) -> TSut
-abstract Wolfgang.Etl.TestKit.Xunit.TransformerBaseContractTests<TSut, TItem, TProgress>.CreateSutWithTimer(Wolfgang.Etl.Abstractions.IProgressTimer timer) -> TSut
+virtual Wolfgang.Etl.TestKit.Xunit.TransformerBaseContractTests<TSut, TItem, TProgress>.CreateSutWithTimer(Wolfgang.Etl.Abstractions.IProgressTimer timer) -> TSut
 static Wolfgang.Etl.TestKit.Xunit.ProgressAssert.AllReportsSatisfy<T>(Wolfgang.Etl.TestKit.Xunit.ProgressCapture<T>! capture, System.Func<T, bool>! predicate) -> void
 static Wolfgang.Etl.TestKit.Xunit.ProgressAssert.FinalReportSatisfies<T>(Wolfgang.Etl.TestKit.Xunit.ProgressCapture<T>! capture, System.Func<T, bool>! predicate) -> void
 static Wolfgang.Etl.TestKit.Xunit.ProgressAssert.HasExactly<T>(Wolfgang.Etl.TestKit.Xunit.ProgressCapture<T>! capture, int count) -> void

--- a/src/Wolfgang.Etl.TestKit.Xunit/TransformerBaseContractTests.cs
+++ b/src/Wolfgang.Etl.TestKit.Xunit/TransformerBaseContractTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Wolfgang.Etl.Abstractions;
+using Wolfgang.Etl.TestKit;
 using Xunit;
 
 namespace Wolfgang.Etl.TestKit.Xunit;
@@ -52,9 +53,6 @@ namespace Wolfgang.Etl.TestKit.Xunit;
 ///
 ///     protected override IReadOnlyList&lt;MyRecord&gt; CreateExpectedItems() =>
 ///         new List&lt;MyRecord&gt; { new("a"), new("b"), new("c"), new("d"), new("e") };
-///
-///     protected override MyTransformer CreateSutWithTimer(IProgressTimer timer) =>
-///         new MyTransformer(timer);
 /// }
 /// </code>
 /// </example>
@@ -74,15 +72,23 @@ public abstract class TransformerBaseContractTests<TSut, TItem, TProgress>
     protected abstract TSut CreateSut(int itemCount);
 
     /// <summary>
-    /// Creates a <typeparamref name="TSut"/> with the supplied <see cref="IProgressTimer"/>
-    /// injected via the derived class's protected constructor.
+    /// <b>Deprecated.</b> The contract now drives progress timing via
+    /// <see cref="ManualProgressTimerCore"/> and <c>WithManualProgressTimer</c>, which need no
+    /// per-component timer plumbing — so overriding this is no longer required. Retained for source
+    /// compatibility with existing overrides; remove your override (and the component's
+    /// <c>IProgressTimer</c>-injection ctor) and it will be dropped in a future major version.
     /// </summary>
-    /// <param name="timer">
-    /// The <see cref="IProgressTimer"/> to inject. Typically a
-    /// <see cref="ManualProgressTimer"/> so that progress callbacks can be fired
-    /// on demand during tests.
-    /// </param>
-    protected abstract TSut CreateSutWithTimer(IProgressTimer timer);
+    /// <param name="timer">Unused by the contract.</param>
+    /// <returns>A new instance of <typeparamref name="TSut"/> (in existing overrides only).</returns>
+    /// <exception cref="NotSupportedException">
+    /// Always, if the base (non-overridden) implementation is invoked — the contract no longer calls it.
+    /// </exception>
+    protected virtual TSut CreateSutWithTimer(IProgressTimer timer) =>
+        throw new NotSupportedException
+        (
+            "CreateSutWithTimer is no longer used by the contract; progress timing is driven via " +
+            "ManualProgressTimerCore + WithManualProgressTimer. Remove this override."
+        );
 
 
     private const int DefaultItemCount = 5;
@@ -423,14 +429,15 @@ public abstract class TransformerBaseContractTests<TSut, TItem, TProgress>
     [Fact]
     public async Task TransformAsync_with_progress_invokes_callback_when_timer_fires_Async()
     {
-        using var timer = new ManualProgressTimer();
-        var sut = CreateSutWithTimer(timer);
+        var timer = new ManualProgressTimerCore();
+        var sut = CreateSut();
+        sut.WithManualProgressTimer(timer);
         TProgress? captured = default;
         var progress = new SynchronousProgress<TProgress>(r => captured = r);
 
         await using var enumerator = sut.TransformAsync(CreateInputItemsAsync(), progress).GetAsyncEnumerator();
         await enumerator.MoveNextAsync().ConfigureAwait(false);
-        timer.Fire();
+        timer.Tick();
 
         Assert.NotNull(captured);
     }
@@ -589,14 +596,15 @@ public abstract class TransformerBaseContractTests<TSut, TItem, TProgress>
     [Fact]
     public async Task TransformAsync_with_progress_and_token_invokes_callback_when_timer_fires_Async()
     {
-        using var timer = new ManualProgressTimer();
-        var sut = CreateSutWithTimer(timer);
+        var timer = new ManualProgressTimerCore();
+        var sut = CreateSut();
+        sut.WithManualProgressTimer(timer);
         TProgress? captured = default;
         var progress = new SynchronousProgress<TProgress>(r => captured = r);
 
         await using var enumerator = sut.TransformAsync(CreateInputItemsAsync(), progress, CancellationToken.None).GetAsyncEnumerator();
         await enumerator.MoveNextAsync().ConfigureAwait(false);
-        timer.Fire();
+        timer.Tick();
 
         Assert.NotNull(captured);
     }

--- a/src/Wolfgang.Etl.TestKit/ManualProgressTimerCore.cs
+++ b/src/Wolfgang.Etl.TestKit/ManualProgressTimerCore.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Threading;
+using Wolfgang.Etl.Abstractions;
+
+namespace Wolfgang.Etl.TestKit;
+
+/// <summary>
+/// A manually-driven progress timer for tests: instead of a real <see cref="System.Threading.Timer"/>
+/// firing on an interval, the stage's progress callback fires only when <see cref="Tick"/> is called,
+/// making progress-callback assertions deterministic. Attach it to a stage with
+/// <see cref="ProgressTimerExtensions.WithManualProgressTimer{TSource, TProgress}(ExtractorBase{TSource, TProgress}, ManualProgressTimerCore)"/>
+/// (and the loader / transformer overloads).
+/// </summary>
+/// <remarks>
+/// This drives the internal timer-core seam on the base classes (the same seam the base's own
+/// <c>CreateProgressTimer</c> uses), reachable here because <c>Wolfgang.Etl.TestKit</c> is an
+/// internals-visible friend of <c>Wolfgang.Etl.Abstractions</c> — so a component needs <b>no</b>
+/// per-type timer-injection plumbing to be timer-testable. Attach it before the run starts; the stage
+/// builds its progress timer when the run begins.
+/// <example><code>
+/// var timer = new ManualProgressTimerCore();
+/// var extractor = new TestExtractor&lt;int&gt;(new[] { 1, 2, 3 }).WithManualProgressTimer(timer);
+///
+/// await using var e = extractor.ExtractAsync(progress).GetAsyncEnumerator();
+/// await e.MoveNextAsync();
+/// timer.Tick();            // fires the progress callback exactly once
+/// </code></example>
+/// </remarks>
+public sealed class ManualProgressTimerCore
+{
+    private TimerCallback? _onTick;
+
+    // Consumed by ProgressTimerExtensions to set the base's internal TimerCoreFactory. The base calls
+    // this with the per-tick callback when it builds its progress timer; we capture the callback so
+    // Tick() can invoke it on demand and return a no-op core (interval timing is irrelevant here).
+    internal Func<TimerCallback, ITimerCore> CoreFactory =>
+        onTick =>
+        {
+            _onTick = onTick;
+            return new Core();
+        };
+
+
+
+    /// <summary>
+    /// Fires a single timer tick, synchronously invoking the stage's progress callback exactly once.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// The stage's progress timer has not been built yet — begin the run (start enumeration, or invoke
+    /// the loader) before calling <see cref="Tick"/>.
+    /// </exception>
+    public void Tick()
+    {
+        var onTick = _onTick
+            ?? throw new InvalidOperationException
+            (
+                "The progress timer has not started. Begin the run (start enumeration / invoke the " +
+                "loader) before calling Tick()."
+            );
+
+        onTick(state: null);
+    }
+
+
+
+    // A do-nothing ITimerCore: a manual timer never schedules real callbacks, so Change is a no-op.
+    private sealed class Core : ITimerCore
+    {
+        public void Change(int dueTime, int period)
+        {
+        }
+
+
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/src/Wolfgang.Etl.TestKit/ProgressTimerExtensions.cs
+++ b/src/Wolfgang.Etl.TestKit/ProgressTimerExtensions.cs
@@ -1,0 +1,98 @@
+using System;
+using Wolfgang.Etl.Abstractions;
+
+namespace Wolfgang.Etl.TestKit;
+
+/// <summary>
+/// Extension methods that attach a <see cref="ManualProgressTimerCore"/> to a stage so its progress
+/// callback fires deterministically (on <see cref="ManualProgressTimerCore.Tick"/>) instead of on a
+/// real timer interval.
+/// </summary>
+/// <remarks>
+/// These reach the internal timer-core seam on the base classes via the friend relationship between
+/// <c>Wolfgang.Etl.TestKit</c> and <c>Wolfgang.Etl.Abstractions</c>, so a component needs no
+/// per-type timer-injection plumbing. Attach the timer before the run starts; the stage builds its
+/// progress timer when the run begins.
+/// </remarks>
+public static class ProgressTimerExtensions
+{
+    /// <summary>Attaches <paramref name="timer"/> to <paramref name="extractor"/>.</summary>
+    /// <returns><paramref name="extractor"/>, for chaining.</returns>
+    /// <exception cref="ArgumentNullException">Either argument is <see langword="null"/>.</exception>
+    public static ExtractorBase<TSource, TProgress> WithManualProgressTimer<TSource, TProgress>
+    (
+        this ExtractorBase<TSource, TProgress> extractor,
+        ManualProgressTimerCore timer
+    )
+        where TSource : notnull
+        where TProgress : notnull
+    {
+        if (extractor is null)
+        {
+            throw new ArgumentNullException(nameof(extractor));
+        }
+
+        if (timer is null)
+        {
+            throw new ArgumentNullException(nameof(timer));
+        }
+
+        extractor.TimerCoreFactory = timer.CoreFactory;
+        return extractor;
+    }
+
+
+
+    /// <summary>Attaches <paramref name="timer"/> to <paramref name="loader"/>.</summary>
+    /// <returns><paramref name="loader"/>, for chaining.</returns>
+    /// <exception cref="ArgumentNullException">Either argument is <see langword="null"/>.</exception>
+    public static LoaderBase<TDestination, TProgress> WithManualProgressTimer<TDestination, TProgress>
+    (
+        this LoaderBase<TDestination, TProgress> loader,
+        ManualProgressTimerCore timer
+    )
+        where TDestination : notnull
+        where TProgress : notnull
+    {
+        if (loader is null)
+        {
+            throw new ArgumentNullException(nameof(loader));
+        }
+
+        if (timer is null)
+        {
+            throw new ArgumentNullException(nameof(timer));
+        }
+
+        loader.TimerCoreFactory = timer.CoreFactory;
+        return loader;
+    }
+
+
+
+    /// <summary>Attaches <paramref name="timer"/> to <paramref name="transformer"/>.</summary>
+    /// <returns><paramref name="transformer"/>, for chaining.</returns>
+    /// <exception cref="ArgumentNullException">Either argument is <see langword="null"/>.</exception>
+    public static TransformerBase<TSource, TDestination, TProgress> WithManualProgressTimer<TSource, TDestination, TProgress>
+    (
+        this TransformerBase<TSource, TDestination, TProgress> transformer,
+        ManualProgressTimerCore timer
+    )
+        where TSource : notnull
+        where TDestination : notnull
+        where TProgress : notnull
+    {
+        if (transformer is null)
+        {
+            throw new ArgumentNullException(nameof(transformer));
+        }
+
+        if (timer is null)
+        {
+            throw new ArgumentNullException(nameof(timer));
+        }
+
+        transformer.TimerCoreFactory = timer.CoreFactory;
+        return transformer;
+    }
+}

--- a/src/Wolfgang.Etl.TestKit/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.TestKit/PublicAPI.Unshipped.txt
@@ -1,1 +1,8 @@
 #nullable enable
+Wolfgang.Etl.TestKit.ManualProgressTimerCore
+Wolfgang.Etl.TestKit.ManualProgressTimerCore.ManualProgressTimerCore() -> void
+Wolfgang.Etl.TestKit.ManualProgressTimerCore.Tick() -> void
+Wolfgang.Etl.TestKit.ProgressTimerExtensions
+static Wolfgang.Etl.TestKit.ProgressTimerExtensions.WithManualProgressTimer<TDestination, TProgress>(this Wolfgang.Etl.Abstractions.LoaderBase<TDestination, TProgress>! loader, Wolfgang.Etl.TestKit.ManualProgressTimerCore! timer) -> Wolfgang.Etl.Abstractions.LoaderBase<TDestination, TProgress>!
+static Wolfgang.Etl.TestKit.ProgressTimerExtensions.WithManualProgressTimer<TSource, TDestination, TProgress>(this Wolfgang.Etl.Abstractions.TransformerBase<TSource, TDestination, TProgress>! transformer, Wolfgang.Etl.TestKit.ManualProgressTimerCore! timer) -> Wolfgang.Etl.Abstractions.TransformerBase<TSource, TDestination, TProgress>!
+static Wolfgang.Etl.TestKit.ProgressTimerExtensions.WithManualProgressTimer<TSource, TProgress>(this Wolfgang.Etl.Abstractions.ExtractorBase<TSource, TProgress>! extractor, Wolfgang.Etl.TestKit.ManualProgressTimerCore! timer) -> Wolfgang.Etl.Abstractions.ExtractorBase<TSource, TProgress>!

--- a/tests/Wolfgang.Etl.TestKit.Tests.Unit/ManualProgressTimerCoreTests.cs
+++ b/tests/Wolfgang.Etl.TestKit.Tests.Unit/ManualProgressTimerCoreTests.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+using Wolfgang.Etl.TestKit;
+using Xunit;
+
+namespace Wolfgang.Etl.TestKit.Tests.Unit;
+
+public class ManualProgressTimerCoreTests
+{
+    [Fact]
+    public void Tick_before_the_run_starts_throws_InvalidOperationException()
+    {
+        var timer = new ManualProgressTimerCore();
+
+        Assert.Throws<InvalidOperationException>
+        (
+            () => timer.Tick()
+        );
+    }
+
+
+
+    [Fact]
+    public async Task Tick_after_the_run_starts_invokes_the_progress_callback_Async()
+    {
+        var timer = new ManualProgressTimerCore();
+        var sut = new TestExtractor<int>(new[] { 1, 2, 3 });
+        sut.WithManualProgressTimer(timer);
+
+        Report? captured = null;
+        var progress = new SyncProgress<Report>(r => captured = r);
+
+        await using var enumerator = sut.ExtractAsync(progress).GetAsyncEnumerator();
+        await enumerator.MoveNextAsync().ConfigureAwait(false);   // starts the run; builds the progress timer
+        timer.Tick();                                            // fires the callback exactly once
+
+        Assert.NotNull(captured);
+    }
+
+
+
+    [Fact]
+    public void WithManualProgressTimer_when_extractor_is_null_throws_ArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>
+        (
+            () => ((ExtractorBase<int, Report>)null!).WithManualProgressTimer(new ManualProgressTimerCore())
+        );
+    }
+
+
+
+    [Fact]
+    public void WithManualProgressTimer_when_extractor_timer_is_null_throws_ArgumentNullException()
+    {
+        var sut = new TestExtractor<int>(new[] { 1 });
+
+        Assert.Throws<ArgumentNullException>
+        (
+            () => sut.WithManualProgressTimer(null!)
+        );
+    }
+
+
+
+    [Fact]
+    public void WithManualProgressTimer_when_loader_timer_is_null_throws_ArgumentNullException()
+    {
+        var sut = new TestLoader<int>(collectItems: false);
+
+        Assert.Throws<ArgumentNullException>
+        (
+            () => sut.WithManualProgressTimer(null!)
+        );
+    }
+
+
+
+    [Fact]
+    public void WithManualProgressTimer_when_transformer_timer_is_null_throws_ArgumentNullException()
+    {
+        var sut = new TestTransformer<int>();
+
+        Assert.Throws<ArgumentNullException>
+        (
+            () => sut.WithManualProgressTimer(null!)
+        );
+    }
+
+
+
+    // A synchronous IProgress<T> so a Tick's callback is observed inline (System.Progress<T> posts async).
+    private sealed class SyncProgress<T> : IProgress<T>
+    {
+        private readonly Action<T> _callback;
+
+        public SyncProgress(Action<T> callback) => _callback = callback;
+
+        public void Report(T value) => _callback(value);
+    }
+}


### PR DESCRIPTION
## Drive contract-base progress timing via `ManualProgressTimerCore`

Implements **Part B** of the timer-injection work (tracked in Chris-Wolfgang/ETL-Abstractions#352 / #344). Additive — no downstream change required to adopt.

### What
- **New public API (`Wolfgang.Etl.TestKit`):** `ManualProgressTimerCore` + `WithManualProgressTimer(...)` extensions for extractor / loader / transformer, mirroring the existing `ManualTimeSource` / `WithTimeSource` pattern. Attach the timer, then fire the stage's progress callback deterministically with `timer.Tick()`. It drives the base's internal timer-core seam via the `TestKit ⇆ Abstractions` friend relationship — so **a component needs no per-type `IProgressTimer`-injection plumbing** to be timer-testable.
- **Contract bases reworked:** `Extractor/Loader/TransformerBaseContractTests` timer tests now build the SUT with the standard `CreateSut(...)` and attach a `ManualProgressTimerCore`. They no longer require `CreateSutWithTimer`, which is demoted **`abstract` → `virtual`** (throws if the base impl runs). Existing downstream overrides still compile and run — nothing breaks on the TestKit bump.

### Why
This is the enabler that lets each downstream repo delete its per-component timer boilerplate (~80 `src/` files) at its own pace. Combined with Part A (convenience base classes, Abstractions 0.21.0), it **supersedes the #96 source generator** — the ceremony it targeted is now gone via base/TestKit defaults, no codegen.

### Deprecation path
`CreateSutWithTimer(IProgressTimer)` is documented as deprecated and no longer called by the contract. It is intentionally **not** `[Obsolete]`-attributed yet (that would turn existing overrides into warnings→errors downstream under warnings-as-errors). Downstream removes its override + `IProgressTimer` ctor per repo; the member is dropped in a future major.

### Verification
- Full solution build **0 warn / 0 err**.
- `TestKit.Xunit` self-tests **313** (exercise the reworked contract timer tests via `TestExtractor`/`TestLoader`/`TestTransformer`), `TestKit` unit **244** (incl. new `ManualProgressTimerCore` harness tests), DocExamples green.
- PublicAPI: new `.TestKit` entries; `.TestKit.Xunit` `CreateSutWithTimer` `abstract`→`virtual`.
