### PR TITLE
docs: repository moved notice (folded into ETL-Abstractions)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,20 @@
+> [!IMPORTANT]
+> ## This repository has moved
+>
+> The **`Wolfgang.Etl.TestKit`** and **`Wolfgang.Etl.TestKit.Xunit`** packages have been folded into
+> **[ETL-Abstractions](https://github.com/Chris-Wolfgang/ETL-Abstractions)** and now build, test, and
+> release from that repository alongside `Wolfgang.Etl.Abstractions`.
+>
+> - **Source & tests:** [ETL-Abstractions/src](https://github.com/Chris-Wolfgang/ETL-Abstractions/tree/main/src)
+> - **New issues & contributions:** the [ETL-Abstractions](https://github.com/Chris-Wolfgang/ETL-Abstractions) repo
+> - **NuGet packages are unchanged** — [Wolfgang.Etl.TestKit](https://www.nuget.org/packages/Wolfgang.Etl.TestKit/)
+>   and [Wolfgang.Etl.TestKit.Xunit](https://www.nuget.org/packages/Wolfgang.Etl.TestKit.Xunit/) keep their
+>   IDs and continue to publish (from the new repo). Nothing changes for consumers.
+>
+> This repository is retained (archived) for its release history. The original README follows.
+
+---
+
 # Wolfgang.Etl.TestKit
 
 An Extractor, Transformer and Loader designed to be used in testing libraries built with Wolfgang.Etl.Abstractions


### PR DESCRIPTION
Adds a prominent 'This repository has moved' notice to the top of the README ahead of archiving. Development of `Wolfgang.Etl.TestKit` / `.TestKit.Xunit` moved to [ETL-Abstractions](https://github.com/Chris-Wolfgang/ETL-Abstractions) in 0.22; package IDs are unchanged and continue to publish from there.

Refreshed onto current `main` (the older `docs/folded-into-abstractions` branch had diverged). After this merges I'll archive the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)